### PR TITLE
fix: rename app from 'iKitchen' to 'IKitchen POS'

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'react'
 export default function Home(): JSX.Element {
   return (
     <main className="flex min-h-screen items-center justify-center bg-zinc-900">
-      <h1 className="text-4xl font-bold text-white">iKitchen POS</h1>
+      <h1 className="text-4xl font-bold text-white">IKitchen POS</h1>
     </main>
   )
 }

--- a/supabase/migrations/20260226000000_initial_schema.sql
+++ b/supabase/migrations/20260226000000_initial_schema.sql
@@ -1,4 +1,4 @@
--- Initial schema for iKitchen POS
+-- Initial schema for IKitchen POS
 -- HUMAN REVIEW REQUIRED: RLS policies are permissive stubs for early development
 
 -- Enable UUID extension


### PR DESCRIPTION
Replace all occurrences of 'iKitchen' with 'IKitchen POS' across the codebase.

Closes #26

Generated with [Claude Code](https://claude.ai/code)