### PR TITLE
fix: move edge function handler to _shared to fix cross-directory import

### DIFF
--- a/supabase/functions/_shared/createOrderHandler.ts
+++ b/supabase/functions/_shared/createOrderHandler.ts
@@ -1,0 +1,47 @@
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+export async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { status: 200, headers: corsHeaders })
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid or missing request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  if (!body) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Missing request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  if (typeof payload['table_id'] !== 'number') {
+    return new Response(
+      JSON.stringify({ success: false, error: 'table_id is required and must be a number' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (typeof payload['staff_id'] !== 'string' || payload['staff_id'] === '') {
+    return new Response(
+      JSON.stringify({ success: false, error: 'staff_id is required and must be a non-empty string' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  return new Response(
+    JSON.stringify({ success: true, data: { order_id: crypto.randomUUID(), status: 'open' } }),
+    { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+  )
+}

--- a/supabase/functions/create_order/index.ts
+++ b/supabase/functions/create_order/index.ts
@@ -1,3 +1,3 @@
-import { handler } from '../../../apps/api/create_order/index.ts'
+import { handler } from '../_shared/createOrderHandler.ts'
 
 Deno.serve(handler)


### PR DESCRIPTION
Closes #45

The previous `supabase/functions/create_order/index.ts` imported the handler from `../../../apps/api/create_order/index.ts`, escaping the `supabase/functions/` boundary. The Supabase CLI does not reliably bundle cross-directory imports, so the deployed function crashed silently on startup — causing the browser fetch to hang forever (the "Creating…" bug).

Moves the handler to `supabase/functions/_shared/createOrderHandler.ts` (the canonical Supabase convention for shared code, always bundled correctly) and updates the entry point to import from there. `apps/api/create_order/index.ts` is unchanged and continues to serve unit tests.

Generated with [Claude Code](https://claude.ai/code)