### PR TITLE
feat: set up Playwright for E2E testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright
+playwright-report/
+apps/web/test-results/

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test('tables page loads without error', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+
+  await page.goto('/tables');
+
+  expect(errors).toHaveLength(0);
+  await expect(page).not.toHaveURL(/error/);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "next": "16.1.6",
@@ -30,6 +31,7 @@
     "jsdom": "^25.0.0",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "vitest": "^2.1.0"
+    "vitest": "^2.1.0",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  use: {
+    baseURL: 'http://localhost:3000',
+    viewport: { width: 1280, height: 800 },
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
Sets up Playwright as the E2E testing framework for the web app.

## Changes
- Add `@playwright/test` to `apps/web` devDependencies
- Create `apps/web/playwright.config.ts` (Chromium only, 1280×800, base URL localhost:3000)
- Create `apps/web/e2e/smoke.spec.ts` with smoke test for `/tables`
- Add `test:e2e` script to `apps/web/package.json`
- Update `.gitignore` to exclude Playwright output artifacts

Closes #66

Generated with [Claude Code](https://claude.ai/code)