### PR TITLE
fix: register all missing edge functions in supabase/config.toml

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -354,13 +354,28 @@ authorization_url_path = "/oauth/consent"
 # Allow dynamic client registration
 allow_dynamic_registration = false
 
-[functions.create_order]
+[functions.add_item_to_order]
+verify_jwt = false
+
+[functions.cancel_order]
 verify_jwt = false
 
 [functions.close_order]
 verify_jwt = false
 
+[functions.close_shift]
+verify_jwt = false
+
+[functions.create_order]
+verify_jwt = false
+
+[functions.open_shift]
+verify_jwt = false
+
 [functions.record_payment]
+verify_jwt = false
+
+[functions.void_item]
 verify_jwt = false
 
 [edge_runtime]


### PR DESCRIPTION
Five edge functions (`add_item_to_order`, `cancel_order`, `close_shift`, `open_shift`, `void_item`) existed in `supabase/functions/` but were not registered in `supabase/config.toml`, so Supabase never deployed them.

All functions are now registered with `verify_jwt = false`, matching the pattern of the existing registered functions.

Fixes #74

Generated with [Claude Code](https://claude.ai/code)