### PR TITLE
fix: implement add_item_to_order edge function with real DB persistence

### DIFF
--- a/supabase/functions/add_item_to_order/index.test.ts
+++ b/supabase/functions/add_item_to_order/index.test.ts
@@ -1,10 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { handler, corsHeaders } from './index'
+import type { HandlerEnv, FetchFn } from './index'
 
-const FIXED_UUID = '22222222-2222-2222-2222-222222222222'
+const TEST_ENV: HandlerEnv = {
+  supabaseUrl: 'https://example.supabase.co',
+  serviceKey: 'test-service-key',
+}
+
+function mockOkJson(data: unknown): Response {
+  return {
+    ok: true,
+    json: () => Promise.resolve(data),
+  } as unknown as Response
+}
+
+function mockOkEmpty(): Response {
+  return { ok: true, json: () => Promise.resolve(undefined) } as unknown as Response
+}
+
+function buildHappyPathFetch(newItemId: string): FetchFn {
+  return vi.fn()
+    .mockResolvedValueOnce(mockOkJson([{ price_cents: 1200 }]))           // menu_items
+    .mockResolvedValueOnce(mockOkJson([{ status: 'open' }]))              // orders
+    .mockResolvedValueOnce(mockOkJson([]))                                  // existing order_items (none)
+    .mockResolvedValueOnce(mockOkJson([{ id: newItemId }]))               // insert order_item
+    .mockResolvedValueOnce(mockOkJson([{ unit_price_cents: 1200, quantity: 1 }])) // total
+}
 
 beforeEach(() => {
-  vi.stubGlobal('crypto', { randomUUID: () => FIXED_UUID })
+  vi.restoreAllMocks()
 })
 
 describe('add_item_to_order handler', () => {
@@ -20,29 +44,103 @@ describe('add_item_to_order handler', () => {
     })
   })
 
-  describe('POST — happy path', () => {
+  describe('POST — happy path (new item)', () => {
     it('returns 200 with order_item_id and order_total on success', async (): Promise<void> => {
+      const mockFetch = buildHappyPathFetch('new-item-uuid-001')
       const req = new Request('http://localhost/functions/v1/add_item_to_order', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ order_id: 'order-abc-123', menu_item_id: 'item-uuid-001' }),
       })
-      const res = await handler(req)
+      const res = await handler(req, mockFetch, TEST_ENV)
       expect(res.status).toBe(200)
       const json = await res.json() as { success: boolean; data: { order_item_id: string; order_total: number } }
       expect(json.success).toBe(true)
-      expect(json.data.order_item_id).toBe(FIXED_UUID)
-      expect(typeof json.data.order_total).toBe('number')
+      expect(json.data.order_item_id).toBe('new-item-uuid-001')
+      expect(json.data.order_total).toBe(1200)
     })
 
     it('includes CORS headers in success response', async (): Promise<void> => {
+      const mockFetch = buildHappyPathFetch('new-item-uuid-002')
       const req = new Request('http://localhost/functions/v1/add_item_to_order', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ order_id: 'order-abc-123', menu_item_id: 'item-uuid-001' }),
       })
-      const res = await handler(req)
+      const res = await handler(req, mockFetch, TEST_ENV)
       expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+  })
+
+  describe('POST — happy path (increment existing item)', () => {
+    it('increments quantity and returns correct total when item already in order', async (): Promise<void> => {
+      const existingItemId = 'existing-item-uuid-001'
+      const mockFetch: FetchFn = vi.fn()
+        .mockResolvedValueOnce(mockOkJson([{ price_cents: 1200 }]))
+        .mockResolvedValueOnce(mockOkJson([{ status: 'open' }]))
+        .mockResolvedValueOnce(mockOkJson([{ id: existingItemId, quantity: 1 }]))
+        .mockResolvedValueOnce(mockOkEmpty())
+        .mockResolvedValueOnce(mockOkJson([{ unit_price_cents: 1200, quantity: 2 }]))
+      const req = new Request('http://localhost/functions/v1/add_item_to_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: 'order-abc-123', menu_item_id: 'item-uuid-001' }),
+      })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: { order_item_id: string; order_total: number } }
+      expect(json.success).toBe(true)
+      expect(json.data.order_item_id).toBe(existingItemId)
+      expect(json.data.order_total).toBe(2400)
+    })
+  })
+
+  describe('POST — state validation', () => {
+    it('returns 404 when menu item does not exist', async (): Promise<void> => {
+      const mockFetch: FetchFn = vi.fn()
+        .mockResolvedValueOnce(mockOkJson([]))
+      const req = new Request('http://localhost/functions/v1/add_item_to_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: 'order-abc-123', menu_item_id: 'nonexistent-item' }),
+      })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(404)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Menu item not found')
+    })
+
+    it('returns 404 when order does not exist', async (): Promise<void> => {
+      const mockFetch: FetchFn = vi.fn()
+        .mockResolvedValueOnce(mockOkJson([{ price_cents: 1200 }]))
+        .mockResolvedValueOnce(mockOkJson([]))
+      const req = new Request('http://localhost/functions/v1/add_item_to_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: 'nonexistent-order', menu_item_id: 'item-uuid-001' }),
+      })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(404)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Order not found')
+    })
+
+    it('returns 409 when order is not open', async (): Promise<void> => {
+      const mockFetch: FetchFn = vi.fn()
+        .mockResolvedValueOnce(mockOkJson([{ price_cents: 1200 }]))
+        .mockResolvedValueOnce(mockOkJson([{ status: 'closed' }]))
+      const req = new Request('http://localhost/functions/v1/add_item_to_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: 'order-abc-123', menu_item_id: 'item-uuid-001' }),
+      })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(409)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Order is not open')
     })
   })
 

--- a/supabase/functions/add_item_to_order/index.ts
+++ b/supabase/functions/add_item_to_order/index.ts
@@ -1,10 +1,30 @@
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-demo-staff-id',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
-export async function handler(req: Request): Promise<Response> {
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { status: 200, headers: corsHeaders })
   }
@@ -40,12 +60,154 @@ export async function handler(req: Request): Promise<Response> {
     )
   }
 
-  return new Response(
-    JSON.stringify({ success: true, data: { order_item_id: crypto.randomUUID(), order_total: 0 } }),
-    { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-  )
+  const orderId = payload['order_id'] as string
+  const menuItemId = payload['menu_item_id'] as string
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=representation',
+  }
+
+  try {
+    // 1. Fetch menu item to get price
+    const menuItemRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/menu_items?select=price_cents&id=eq.${menuItemId}`,
+      { headers: dbHeaders },
+    )
+    if (!menuItemRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch menu item' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const menuItems = (await menuItemRes.json()) as Array<{ price_cents: number }>
+    if (menuItems.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Menu item not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const priceCents = menuItems[0].price_cents
+
+    // 2. Verify order exists and is open
+    const orderRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=status&id=eq.${orderId}`,
+      { headers: dbHeaders },
+    )
+    if (!orderRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch order' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const orders = (await orderRes.json()) as Array<{ status: string }>
+    if (orders.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    if (orders[0].status !== 'open') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order is not open' }),
+        { status: 409, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 3. Check for an existing non-voided order item for this menu item
+    const existingRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/order_items?select=id,quantity&order_id=eq.${orderId}&menu_item_id=eq.${menuItemId}&voided=eq.false`,
+      { headers: dbHeaders },
+    )
+    if (!existingRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch order items' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const existingItems = (await existingRes.json()) as Array<{ id: string; quantity: number }>
+
+    let orderItemId: string
+    if (existingItems.length > 0) {
+      // Increment quantity on the existing item
+      const existing = existingItems[0]
+      const patchRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/order_items?id=eq.${existing.id}`,
+        {
+          method: 'PATCH',
+          headers: { ...dbHeaders, Prefer: 'return=minimal' },
+          body: JSON.stringify({ quantity: existing.quantity + 1 }),
+        },
+      )
+      if (!patchRes.ok) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Failed to update order item' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      orderItemId = existing.id
+    } else {
+      // Insert a new order item
+      const insertRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/order_items`,
+        {
+          method: 'POST',
+          headers: dbHeaders,
+          body: JSON.stringify({
+            order_id: orderId,
+            menu_item_id: menuItemId,
+            unit_price_cents: priceCents,
+            quantity: 1,
+          }),
+        },
+      )
+      if (!insertRes.ok) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Failed to insert order item' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      const inserted = (await insertRes.json()) as Array<{ id: string }>
+      orderItemId = inserted[0].id
+    }
+
+    // 4. Calculate the updated order total
+    const totalRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/order_items?select=unit_price_cents,quantity&order_id=eq.${orderId}&voided=eq.false`,
+      { headers: { ...dbHeaders, Prefer: 'count=none' } },
+    )
+    if (!totalRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to calculate order total' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const allItems = (await totalRes.json()) as Array<{ unit_price_cents: number; quantity: number }>
+    const orderTotal = allItems.reduce((sum, item) => sum + item.unit_price_cents * item.quantity, 0)
+
+    return new Response(
+      JSON.stringify({ success: true, data: { order_item_id: orderItemId, order_total: orderTotal } }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
 }
 
 if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
-  Deno.serve(handler)
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
 }


### PR DESCRIPTION
Fixes #78

The `add_item_to_order` edge function was a stub that returned `success: true` without writing to the database. Items appeared "Added" due to local state updates, but the order_items table remained empty, so "View Order" showed nothing.

The function now fetches the menu item price, validates the order is open, upserts the order item (inserting or incrementing quantity), and returns the real order total.

Generated with [Claude Code](https://claude.ai/code)