### PR TITLE
feat: load live menu data from Supabase on the Add Items screen

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
@@ -96,9 +96,9 @@ describe('MenuPageClient', () => {
       expect(hrefs.filter((h) => h === expectedHref)).toHaveLength(2)
     })
 
-    it('"Order total" label uses at least base (16px) font size', () => {
+    it('"Added this session" label uses at least base (16px) font size', () => {
       render(<MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} />)
-      expect(screen.getByText('Order total').className).toContain('text-base')
+      expect(screen.getByText('Added this session').className).toContain('text-base')
     })
 
     it('renders category headings after data loads', async () => {
@@ -118,16 +118,16 @@ describe('MenuPageClient', () => {
   })
 
   describe('error state', () => {
-    it('shows an error message when fetching fails', async () => {
+    it('shows a generic error message when fetching fails', async () => {
       vi.mocked(fetchMenuCategories).mockRejectedValue(new Error('Failed to load menu'))
       render(<MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} />)
-      expect(await screen.findByText('Failed to load menu')).toBeInTheDocument()
+      expect(await screen.findByText('Unable to load menu. Please try again.')).toBeInTheDocument()
     })
 
-    it('shows "API not configured" when env vars are missing', async () => {
+    it('shows a generic error message when env vars are missing', async () => {
       process.env.NEXT_PUBLIC_SUPABASE_URL = ''
       render(<MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} />)
-      expect(await screen.findByText('API not configured')).toBeInTheDocument()
+      expect(await screen.findByText('Unable to load menu. Please try again.')).toBeInTheDocument()
     })
   })
 

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
@@ -50,7 +50,7 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
       return <p className="text-zinc-400 text-base">Loading menu…</p>
     }
     if (fetchError !== null) {
-      return <p className="text-red-400 text-base">{fetchError}</p>
+      return <p className="text-red-400 text-base">Unable to load menu. Please try again.</p>
     }
     if (categories.length === 0) {
       return <p className="text-zinc-500 text-base">No menu items available</p>
@@ -94,7 +94,7 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
 
       <footer className="mt-6 pt-4 border-t border-zinc-700 flex items-center justify-between gap-4">
         <div className="flex flex-col">
-          <span className="text-base text-zinc-400">Order total</span>
+          <span className="text-base text-zinc-400">Added this session</span>
           <span className="text-2xl font-bold text-white">{totalFormatted}</span>
         </div>
         <Link

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.test.ts
@@ -150,6 +150,39 @@ describe('fetchMenuCategories', () => {
     expect(result).toHaveLength(0)
   })
 
+  it('throws when orders response is not an array', async (): Promise<void> => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ error: 'unexpected' }),
+      }),
+    )
+
+    await expect(fetchMenuCategories(BASE_URL, API_KEY, ORDER_ID)).rejects.toThrow(
+      'Unexpected response format from orders endpoint',
+    )
+  })
+
+  it('throws when menus response is not an array', async (): Promise<void> => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve([{ restaurant_id: RESTAURANT_ID }]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ error: 'unexpected' }),
+        }),
+    )
+
+    await expect(fetchMenuCategories(BASE_URL, API_KEY, ORDER_ID)).rejects.toThrow(
+      'Unexpected response format from menus endpoint',
+    )
+  })
+
   it('propagates network errors', async (): Promise<void> => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
 

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.ts
@@ -47,6 +47,9 @@ export async function fetchMenuCategories(
   }
 
   const orders = (await orderRes.json()) as OrderRow[]
+  if (!Array.isArray(orders)) {
+    throw new Error('Unexpected response format from orders endpoint')
+  }
   if (orders.length === 0) {
     throw new Error('Unable to load menu')
   }
@@ -70,6 +73,9 @@ export async function fetchMenuCategories(
   }
 
   const menus = (await menusRes.json()) as MenuRow[]
+  if (!Array.isArray(menus)) {
+    throw new Error('Unexpected response format from menus endpoint')
+  }
   return menus.map((menu) => ({
     name: menu.name,
     items: menu.menu_items.map((item) => ({

--- a/supabase/migrations/20260305090300_add_anon_read_for_orders_and_menus.sql
+++ b/supabase/migrations/20260305090300_add_anon_read_for_orders_and_menus.sql
@@ -1,3 +1,6 @@
+-- Rollback: DROP POLICY "allow_anon_read" ON orders;
+--           DROP POLICY "allow_anon_read" ON menus;
+--
 -- Allow the anon role to read orders and menus so that the
 -- Add Items screen (which uses the publishable/anon key with no auth session)
 -- can look up the restaurant_id from an order and then fetch its menus.


### PR DESCRIPTION
Closes #82

## Changes

- `menuData.ts`: replaced static `MENU_CATEGORIES` stub with `fetchMenuCategories` that fetches the order to resolve `restaurant_id`, then queries `menus` joined with `menu_items` via the Supabase REST API
- `MenuPageClient.tsx`: added loading, error, and empty states; add_item_to_order flow unchanged
- `menuData.test.ts` (new): 8 unit tests for `fetchMenuCategories`
- `MenuPageClient.test.tsx`: updated to mock `fetchMenuCategories` and cover all new states

Generated with [Claude Code](https://claude.ai/code)