### PR TITLE
fix: add anon read RLS policies for order_items and menu_items

### DIFF
--- a/supabase/migrations/20260305084600_add_anon_read_for_order_items.sql
+++ b/supabase/migrations/20260305084600_add_anon_read_for_order_items.sql
@@ -1,0 +1,17 @@
+-- Allow the anon role to read order_items and menu_items so that the
+-- frontend (which uses the publishable/anon key with no auth session) can
+-- display order contents on the "View Order" screen.
+--
+-- The existing "allow_all_authenticated" policies cover writes from
+-- authenticated sessions.  Writes from the Action API use the service-role
+-- key and bypass RLS entirely, so no additional write policy is needed here.
+--
+-- HUMAN REVIEW REQUIRED: these policies grant unauthenticated read access.
+-- They are appropriate for the current demo / development stage where there
+-- is no login flow, but should be tightened before a production rollout.
+
+CREATE POLICY "allow_anon_read" ON order_items
+  FOR SELECT TO anon USING (true);
+
+CREATE POLICY "allow_anon_read" ON menu_items
+  FOR SELECT TO anon USING (true);


### PR DESCRIPTION
Fixes #78

The "View Order" page always showed an empty order because the frontend reads order_items using the anon key (no login session), but the existing RLS policy only grants access to the authenticated role. Supabase silently returns an empty array when the caller's role is not covered.

Adds SELECT policies for the anon role on order_items and menu_items (the join target). Flagged HUMAN REVIEW REQUIRED as this grants unauthenticated read access that should be tightened before production.

Generated with [Claude Code](https://claude.ai/code)