### PR TITLE
fix: fetch menu data server-side to bypass orders RLS gap

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
@@ -139,6 +139,36 @@ describe('MenuPageClient', () => {
     })
   })
 
+  describe('initialCategories prop', () => {
+    it('renders categories immediately without fetching when initialCategories is provided', () => {
+      render(
+        <MenuPageClient
+          tableId={TABLE_ID}
+          orderId={ORDER_ID}
+          initialCategories={MOCK_CATEGORIES}
+        />,
+      )
+      expect(screen.queryByText('Loading menu…')).not.toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Starters' })).toBeInTheDocument()
+      expect(vi.mocked(fetchMenuCategories)).not.toHaveBeenCalled()
+    })
+
+    it('shows empty state when initialCategories is an empty array', () => {
+      render(
+        <MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} initialCategories={[]} />,
+      )
+      expect(screen.getByText('No menu items available')).toBeInTheDocument()
+    })
+
+    it('falls back to client fetch when initialCategories is null', async () => {
+      render(
+        <MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} initialCategories={null} />,
+      )
+      expect(await screen.findByRole('heading', { name: 'Starters' })).toBeInTheDocument()
+      expect(vi.mocked(fetchMenuCategories)).toHaveBeenCalledOnce()
+    })
+  })
+
   describe('handleItemAdded', () => {
     it('updates the order total when a single item is added', async () => {
       render(<MenuPageClient tableId={TABLE_ID} orderId={ORDER_ID} />)

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
@@ -10,15 +10,26 @@ import MenuItemCard from './MenuItemCard'
 interface MenuPageClientProps {
   tableId: string
   orderId: string
+  /** Menu data pre-fetched server-side. When provided the client skips its own fetch. */
+  initialCategories?: MenuCategory[] | null
 }
 
-export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps): JSX.Element {
+export default function MenuPageClient({
+  tableId,
+  orderId,
+  initialCategories,
+}: MenuPageClientProps): JSX.Element {
   const [orderTotalCents, setOrderTotalCents] = useState(0)
-  const [categories, setCategories] = useState<MenuCategory[]>([])
-  const [loading, setLoading] = useState(true)
+  const [categories, setCategories] = useState<MenuCategory[]>(initialCategories ?? [])
+  const [loading, setLoading] = useState(initialCategories === null || initialCategories === undefined)
   const [fetchError, setFetchError] = useState<string | null>(null)
 
   useEffect(() => {
+    // Server component already resolved the data — skip client fetch.
+    if (initialCategories !== null && initialCategories !== undefined) {
+      return
+    }
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
     if (!supabaseUrl || !supabaseKey) {
@@ -37,7 +48,7 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
       .finally(() => {
         setLoading(false)
       })
-  }, [orderId])
+  }, [orderId, initialCategories])
 
   function handleItemAdded(priceCents: number): void {
     setOrderTotalCents((prev) => prev + priceCents)

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/page.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/page.test.tsx
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import type { ReactNode, JSX } from 'react'
 import MenuPage from './page'
+import type { MenuCategory } from './menuData'
+import { fetchMenuCategories } from './menuData'
+
+vi.mock('./menuData', () => ({
+  fetchMenuCategories: vi.fn(),
+}))
 
 vi.mock('next/link', () => ({
   default: ({ children, href }: { children: ReactNode; href: string }): JSX.Element => (
@@ -12,6 +18,39 @@ vi.mock('next/link', () => ({
 vi.mock('next/navigation', () => ({
   useRouter: (): { push: () => void } => ({ push: vi.fn() }),
 }))
+
+const MOCK_CATEGORIES: MenuCategory[] = [
+  {
+    name: 'Starters',
+    items: [
+      { id: '00000000-0000-0000-0000-000000000301', name: 'Bruschetta', price_cents: 850 },
+      { id: '00000000-0000-0000-0000-000000000302', name: 'Caesar Salad', price_cents: 1050 },
+      { id: '00000000-0000-0000-0000-000000000303', name: 'Soup of the Day', price_cents: 750 },
+    ],
+  },
+  {
+    name: 'Mains',
+    items: [
+      { id: '00000000-0000-0000-0000-000000000304', name: 'Grilled Salmon', price_cents: 1850 },
+      { id: '00000000-0000-0000-0000-000000000305', name: 'Ribeye Steak', price_cents: 2650 },
+      { id: '00000000-0000-0000-0000-000000000306', name: 'Mushroom Risotto', price_cents: 1450 },
+    ],
+  },
+  {
+    name: 'Drinks',
+    items: [
+      { id: '00000000-0000-0000-0000-000000000307', name: 'House Wine', price_cents: 950 },
+      { id: '00000000-0000-0000-0000-000000000308', name: 'Craft Beer', price_cents: 750 },
+      { id: '00000000-0000-0000-0000-000000000309', name: 'Fresh Lemonade', price_cents: 450 },
+    ],
+  },
+]
+
+beforeEach(() => {
+  vi.mocked(fetchMenuCategories).mockResolvedValue(MOCK_CATEGORIES)
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+  process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'test-anon-key'
+})
 
 describe('MenuPage', () => {
   it('renders the Menu heading', async (): Promise<void> => {
@@ -94,5 +133,22 @@ describe('MenuPage', () => {
     render(await MenuPage({ params }))
 
     expect(screen.getByText('$0.00')).toBeInTheDocument()
+  })
+
+  it('passes server-fetched categories so menu renders without loading state', async (): Promise<void> => {
+    const params = Promise.resolve({ id: '1', order_id: 'order-xyz' })
+    render(await MenuPage({ params }))
+
+    expect(screen.queryByText('Loading menu…')).not.toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Starters' })).toBeInTheDocument()
+  })
+
+  it('falls back gracefully when server fetch fails', async (): Promise<void> => {
+    vi.mocked(fetchMenuCategories).mockRejectedValue(new Error('network error'))
+    const params = Promise.resolve({ id: '1', order_id: 'order-xyz' })
+    render(await MenuPage({ params }))
+
+    // Server fetch failed so initialCategories is null; client retries and shows loading
+    expect(screen.getByText('Loading menu…')).toBeInTheDocument()
   })
 })

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/page.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/page.tsx
@@ -1,5 +1,7 @@
 import type { JSX } from 'react'
 import MenuPageClient from './MenuPageClient'
+import { fetchMenuCategories } from './menuData'
+import type { MenuCategory } from './menuData'
 
 interface PageProps {
   params: Promise<{ id: string; order_id: string }>
@@ -7,5 +9,26 @@ interface PageProps {
 
 export default async function MenuPage({ params }: PageProps): Promise<JSX.Element> {
   const { id, order_id } = await params
-  return <MenuPageClient tableId={id} orderId={order_id} />
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  // Prefer the service-role key (server-only, bypasses RLS) so that the
+  // orders + menus fetch succeeds regardless of anon-read RLS policies.
+  // Falls back to the publishable key so local dev without a service key
+  // still works (provided the anon policies are in place).
+  const fetchKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+
+  let initialCategories: MenuCategory[] | null = null
+  if (supabaseUrl && fetchKey) {
+    try {
+      initialCategories = await fetchMenuCategories(supabaseUrl, fetchKey, order_id)
+    } catch {
+      // Server-side fetch failed; MenuPageClient will retry client-side.
+    }
+  }
+
+  return (
+    <MenuPageClient tableId={id} orderId={order_id} initialCategories={initialCategories} />
+  )
 }


### PR DESCRIPTION
Fixes #82

## Problem
The Add Items screen showed "Unable to load menu" in production because `fetchMenuCategories` first queries the `orders` table with the anon key to resolve `restaurant_id`. If the `allow_anon_read` RLS policy on `orders` was not applied, the query silently returns `[]` and the screen errored.

## Fix
- `page.tsx`: server component now fetches menu data using `SUPABASE_SERVICE_ROLE_KEY` (bypasses RLS), falling back to the publishable key
- `MenuPageClient.tsx`: accepts `initialCategories` prop; renders immediately from server data, falls back to client fetch if server returns null
- `page.test.tsx`: fixed broken tests that lacked `fetchMenuCategories` mock
- `MenuPageClient.test.tsx`: added tests for `initialCategories` prop

After merging, add `SUPABASE_SERVICE_ROLE_KEY` as a server-side env var in Vercel.

Generated with [Claude Code](https://claude.ai/code)