### PR TITLE
feat: wire close_order, open_shift, close_shift, record_payment to real DB

### DIFF
--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -32,7 +32,7 @@ export async function handler(
   env: HandlerEnv | null = readEnv(),
 ): Promise<Response> {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { status: 200, headers: corsHeaders })
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
 
   let body: unknown
@@ -61,6 +61,13 @@ export async function handler(
   }
 
   const orderId = payload['order_id'] as string
+  if (!isValidUuid(orderId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'order_id must be a valid UUID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
   const staffIdHeader = req.headers.get('x-demo-staff-id') ?? ''
   const userId = isValidUuid(staffIdHeader) ? staffIdHeader : SYSTEM_USER_ID
 
@@ -120,13 +127,13 @@ export async function handler(
     const items = (await itemsRes.json()) as Array<{ unit_price_cents: number; quantity: number }>
     const finalTotal = items.reduce((sum, item) => sum + item.unit_price_cents * item.quantity, 0)
 
-    // 3. Update order status to pending_payment
+    // 3. Update order status to pending_payment and persist final_total_cents
     const updateRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
       {
         method: 'PATCH',
         headers: { ...dbHeaders, Prefer: 'return=minimal' },
-        body: JSON.stringify({ status: 'pending_payment' }),
+        body: JSON.stringify({ status: 'pending_payment', final_total_cents: finalTotal }),
       },
     )
     if (!updateRes.ok) {
@@ -137,7 +144,7 @@ export async function handler(
     }
 
     // 4. Emit audit log entry
-    await fetchFn(
+    const auditRes = await fetchFn(
       `${supabaseUrl}/rest/v1/audit_log`,
       {
         method: 'POST',
@@ -148,13 +155,19 @@ export async function handler(
           action: 'close_order',
           entity_type: 'orders',
           entity_id: orderId,
-          payload: { final_total: finalTotal },
+          payload: { final_total_cents: finalTotal },
         }),
       },
     )
+    if (!auditRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to write audit log' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
 
     return new Response(
-      JSON.stringify({ success: true, data: { final_total: finalTotal } }),
+      JSON.stringify({ success: true, data: { final_total_cents: finalTotal } }),
       { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   } catch {

--- a/supabase/functions/close_shift/index.ts
+++ b/supabase/functions/close_shift/index.ts
@@ -32,7 +32,7 @@ export async function handler(
   env: HandlerEnv | null = readEnv(),
 ): Promise<Response> {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { status: 200, headers: corsHeaders })
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
 
   let body: unknown
@@ -67,6 +67,12 @@ export async function handler(
   }
 
   const shiftId = payload['shift_id'] as string
+  if (!isValidUuid(shiftId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'shift_id must be a valid UUID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
   const closingFloat = payload['closing_float'] as number
 
   const staffIdHeader = req.headers.get('x-demo-staff-id') ?? ''
@@ -114,13 +120,13 @@ export async function handler(
     }
     const restaurantId = shifts[0].restaurant_id
 
-    // 2. Close the shift by setting closed_at
+    // 2. Close the shift by setting closed_at and persisting closing_float_cents
     const updateRes = await fetchFn(
       `${supabaseUrl}/rest/v1/shifts?id=eq.${shiftId}`,
       {
         method: 'PATCH',
         headers: { ...dbHeaders, Prefer: 'return=minimal' },
-        body: JSON.stringify({ closed_at: new Date().toISOString() }),
+        body: JSON.stringify({ closed_at: new Date().toISOString(), closing_float_cents: closingFloat }),
       },
     )
     if (!updateRes.ok) {
@@ -131,7 +137,7 @@ export async function handler(
     }
 
     // 3. Emit audit log entry
-    await fetchFn(
+    const auditRes = await fetchFn(
       `${supabaseUrl}/rest/v1/audit_log`,
       {
         method: 'POST',
@@ -142,10 +148,16 @@ export async function handler(
           action: 'close_shift',
           entity_type: 'shifts',
           entity_id: shiftId,
-          payload: { closing_float: closingFloat },
+          payload: { closing_float_cents: closingFloat },
         }),
       },
     )
+    if (!auditRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to write audit log' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
 
     return new Response(
       JSON.stringify({ success: true, data: { shift_id: shiftId } }),

--- a/supabase/functions/open_shift/index.ts
+++ b/supabase/functions/open_shift/index.ts
@@ -20,13 +20,17 @@ function readEnv(): HandlerEnv | null {
   return { supabaseUrl, serviceKey }
 }
 
+function isValidUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
 export async function handler(
   req: Request,
   fetchFn: FetchFn = fetch,
   env: HandlerEnv | null = readEnv(),
 ): Promise<Response> {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { status: 200, headers: corsHeaders })
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
 
   let body: unknown
@@ -61,6 +65,12 @@ export async function handler(
   }
 
   const staffId = payload['staff_id'] as string
+  if (!isValidUuid(staffId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'staff_id must be a valid UUID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
   const openingFloat = payload['opening_float'] as number
 
   if (!env) {
@@ -99,7 +109,26 @@ export async function handler(
     }
     const restaurantId = users[0].restaurant_id
 
-    // 2. Insert row into shifts
+    // 2. Guard against duplicate open shifts
+    const openShiftRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/shifts?select=id&user_id=eq.${staffId}&closed_at=is.null`,
+      { headers: { ...dbHeaders, Prefer: 'count=none' } },
+    )
+    if (!openShiftRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to check existing shifts' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const openShifts = (await openShiftRes.json()) as Array<{ id: string }>
+    if (openShifts.length > 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'User already has an open shift' }),
+        { status: 409, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 3. Insert row into shifts, persisting opening_float_cents
     const insertRes = await fetchFn(
       `${supabaseUrl}/rest/v1/shifts`,
       {
@@ -108,6 +137,7 @@ export async function handler(
         body: JSON.stringify({
           restaurant_id: restaurantId,
           user_id: staffId,
+          opening_float_cents: openingFloat,
         }),
       },
     )
@@ -120,8 +150,8 @@ export async function handler(
     const inserted = (await insertRes.json()) as Array<{ id: string; opened_at: string }>
     const shift = inserted[0]
 
-    // 3. Emit audit log entry
-    await fetchFn(
+    // 4. Emit audit log entry
+    const auditRes = await fetchFn(
       `${supabaseUrl}/rest/v1/audit_log`,
       {
         method: 'POST',
@@ -132,10 +162,16 @@ export async function handler(
           action: 'open_shift',
           entity_type: 'shifts',
           entity_id: shift.id,
-          payload: { opening_float: openingFloat },
+          payload: { opening_float_cents: openingFloat },
         }),
       },
     )
+    if (!auditRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to write audit log' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
 
     return new Response(
       JSON.stringify({ success: true, data: { shift_id: shift.id, started_at: shift.opened_at } }),

--- a/supabase/functions/record_payment/index.ts
+++ b/supabase/functions/record_payment/index.ts
@@ -20,13 +20,17 @@ function readEnv(): HandlerEnv | null {
   return { supabaseUrl, serviceKey }
 }
 
+function isValidUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
 export async function handler(
   req: Request,
   fetchFn: FetchFn = fetch,
   env: HandlerEnv | null = readEnv(),
 ): Promise<Response> {
   if (req.method === 'OPTIONS') {
-    return new Response('ok', { status: 200, headers: corsHeaders })
+    return new Response(null, { status: 204, headers: corsHeaders })
   }
 
   let body: unknown
@@ -79,12 +83,14 @@ export async function handler(
   }
 
   const orderId = payload['order_id'] as string
+  if (!isValidUuid(orderId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'order_id must be a valid UUID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
   const amountCents = payload['amount'] as number
   const method = payload['method'] as string
-  const orderTotalCents = typeof payload['order_total_cents'] === 'number' ? payload['order_total_cents'] as number : null
-  const changeDue = orderTotalCents !== null && method === 'cash'
-    ? Math.max(0, amountCents - orderTotalCents)
-    : 0
 
   if (!env) {
     return new Response(
@@ -94,9 +100,7 @@ export async function handler(
   }
 
   const staffIdHeader = req.headers.get('x-demo-staff-id') ?? ''
-  const userId = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(staffIdHeader)
-    ? staffIdHeader
-    : '00000000-0000-0000-0000-000000000001'
+  const userId = isValidUuid(staffIdHeader) ? staffIdHeader : '00000000-0000-0000-0000-000000000001'
 
   const { supabaseUrl, serviceKey } = env
   const dbHeaders = {
@@ -107,9 +111,9 @@ export async function handler(
   }
 
   try {
-    // 1. Fetch the order to verify it exists and is pending_payment
+    // 1. Fetch the order to verify it exists, is pending_payment, and get final_total_cents
     const orderRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status&id=eq.${orderId}`,
+      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,final_total_cents&id=eq.${orderId}`,
       { headers: dbHeaders },
     )
     if (!orderRes.ok) {
@@ -118,7 +122,7 @@ export async function handler(
         { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
-    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string }>
+    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string; final_total_cents: number | null }>
     if (orders.length === 0) {
       return new Response(
         JSON.stringify({ success: false, error: 'Order not found' }),
@@ -132,8 +136,28 @@ export async function handler(
       )
     }
     const restaurantId = orders[0].restaurant_id
+    const finalTotalCents = orders[0].final_total_cents
+    const changeDue = finalTotalCents !== null && method === 'cash'
+      ? Math.max(0, amountCents - finalTotalCents)
+      : 0
 
-    // 2. Insert payment record
+    // 2. Mark the order as paid first (prevents duplicate payment processing)
+    const closeRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
+      {
+        method: 'PATCH',
+        headers: { ...dbHeaders, Prefer: 'return=minimal' },
+        body: JSON.stringify({ status: 'paid' }),
+      },
+    )
+    if (!closeRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to update order status' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 3. Insert payment record
     const paymentRes = await fetchFn(
       `${supabaseUrl}/rest/v1/payments`,
       {
@@ -155,24 +179,8 @@ export async function handler(
     const inserted = (await paymentRes.json()) as Array<{ id: string }>
     const paymentId = inserted[0].id
 
-    // 3. Mark the order as paid
-    const closeRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
-      {
-        method: 'PATCH',
-        headers: { ...dbHeaders, Prefer: 'return=minimal' },
-        body: JSON.stringify({ status: 'paid' }),
-      },
-    )
-    if (!closeRes.ok) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Failed to update order status' }),
-        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-      )
-    }
-
     // 4. Emit audit log entry
-    await fetchFn(
+    const auditRes = await fetchFn(
       `${supabaseUrl}/rest/v1/audit_log`,
       {
         method: 'POST',
@@ -187,6 +195,12 @@ export async function handler(
         }),
       },
     )
+    if (!auditRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to write audit log' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
 
     return new Response(
       JSON.stringify({ success: true, data: { payment_id: paymentId, change_due: changeDue } }),

--- a/supabase/migrations/20260305103000_extend_orders_status.sql
+++ b/supabase/migrations/20260305103000_extend_orders_status.sql
@@ -4,3 +4,8 @@
 ALTER TABLE orders DROP CONSTRAINT orders_status_check;
 ALTER TABLE orders ADD CONSTRAINT orders_status_check
   CHECK (status IN ('open', 'pending_payment', 'paid', 'closed', 'cancelled'));
+
+-- Rollback:
+-- ALTER TABLE orders DROP CONSTRAINT orders_status_check;
+-- ALTER TABLE orders ADD CONSTRAINT orders_status_check
+--   CHECK (status IN ('open', 'closed', 'cancelled'));

--- a/supabase/migrations/20260305104000_add_final_total_and_floats.sql
+++ b/supabase/migrations/20260305104000_add_final_total_and_floats.sql
@@ -1,0 +1,10 @@
+-- Add final_total_cents to orders so close_order can persist the calculated total
+-- Add opening_float_cents/closing_float_cents to shifts for float tracking
+ALTER TABLE orders ADD COLUMN final_total_cents integer;
+ALTER TABLE shifts ADD COLUMN opening_float_cents integer;
+ALTER TABLE shifts ADD COLUMN closing_float_cents integer;
+
+-- Rollback:
+-- ALTER TABLE orders DROP COLUMN final_total_cents;
+-- ALTER TABLE shifts DROP COLUMN opening_float_cents;
+-- ALTER TABLE shifts DROP COLUMN closing_float_cents;


### PR DESCRIPTION
Implements the remaining stub edge functions with real database reads and writes.

- `close_order`: validates open, calculates final_total from order_items, updates to pending_payment, inserts audit log
- `open_shift`: looks up user for restaurant_id, inserts into shifts table, returns real shift_id
- `close_shift`: validates not closed, sets closed_at, inserts audit log
- `record_payment`: accepts pending_payment, sets status to paid, adds audit log
- Migration to extend orders.status with pending_payment and paid

Closes #75

Generated with [Claude Code](https://claude.ai/code)