### PR TITLE
fix: include modifier price deltas in session total on menu page

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.test.tsx
@@ -218,7 +218,26 @@ describe('MenuItemCard', () => {
       expect(body.modifier_ids).toEqual(['mod-001'])
     })
 
-    it('calls onItemAdded after confirming modifier selection', async () => {
+    it('calls onItemAdded with base price when no modifiers are selected', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: { order_item_id: 'new-item-uuid', order_total: 1200 },
+          }),
+      })
+
+      const onItemAdded = vi.fn()
+      render(<MenuItemCard item={mockItemWithModifiers} orderId={ORDER_ID} onItemAdded={onItemAdded} />)
+      await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Add to Order' }))
+
+      await waitFor(() => {
+        expect(onItemAdded).toHaveBeenCalledWith(1200)
+      })
+    })
+
+    it('calls onItemAdded with base price plus modifier price_delta_cents when modifier is selected', async () => {
       global.fetch = vi.fn().mockResolvedValue({
         json: () =>
           Promise.resolve({
@@ -230,10 +249,11 @@ describe('MenuItemCard', () => {
       const onItemAdded = vi.fn()
       render(<MenuItemCard item={mockItemWithModifiers} orderId={ORDER_ID} onItemAdded={onItemAdded} />)
       await userEvent.click(screen.getByRole('button', { name: 'Add' }))
+      await userEvent.click(screen.getByRole('button', { name: /Extra cheese/ }))
       await userEvent.click(screen.getByRole('button', { name: 'Add to Order' }))
 
       await waitFor(() => {
-        expect(onItemAdded).toHaveBeenCalledWith(1200)
+        expect(onItemAdded).toHaveBeenCalledWith(1250) // 1200 base + 50 delta
       })
     })
   })

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.tsx
@@ -33,7 +33,10 @@ export default function MenuItemCard({ item, orderId, onItemAdded }: MenuItemCar
       }
       await callAddItemToOrder(supabaseUrl, supabaseKey, orderId, item.id, modifierIds.length > 0 ? modifierIds : undefined)
       setSuccess(true)
-      onItemAdded(item.price_cents)
+      const modifierDeltaCents = item.modifiers
+        .filter((mod) => modifierIds.includes(mod.id))
+        .reduce((sum, mod) => sum + mod.price_delta_cents, 0)
+      onItemAdded(item.price_cents + modifierDeltaCents)
       setTimeout(() => setSuccess(false), 1500)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to add item')


### PR DESCRIPTION
When adding a menu item with modifiers, the "Added this session" total on the menu page now correctly includes the selected modifier price deltas.

Fixes #115

Generated with [Claude Code](https://claude.ai/code)