### PR TITLE
fix: allow anon read on restaurants & modifiers; remove broken /admin/tables nav link

### DIFF
--- a/apps/web/app/admin/AdminNav.test.tsx
+++ b/apps/web/app/admin/AdminNav.test.tsx
@@ -13,8 +13,13 @@ describe('AdminNav', () => {
     vi.mocked(usePathname).mockReturnValue('/admin')
     render(<AdminNav />)
     expect(screen.getByText('Dashboard')).toBeInTheDocument()
-    expect(screen.getByText('Tables')).toBeInTheDocument()
     expect(screen.getByText('Menu')).toBeInTheDocument()
+  })
+
+  it('does not render a Tables link', () => {
+    vi.mocked(usePathname).mockReturnValue('/admin')
+    render(<AdminNav />)
+    expect(screen.queryByText('Tables')).not.toBeInTheDocument()
   })
 
   it('highlights the active Dashboard link when on /admin', () => {
@@ -24,15 +29,15 @@ describe('AdminNav', () => {
     expect(dashboardLink?.className).toMatch(/bg-indigo-600/)
   })
 
-  it('highlights the active Tables link when on /admin/tables', () => {
-    vi.mocked(usePathname).mockReturnValue('/admin/tables')
+  it('highlights the active Menu link when on /admin/menu', () => {
+    vi.mocked(usePathname).mockReturnValue('/admin/menu')
     render(<AdminNav />)
-    const tablesLink = screen.getByText('Tables').closest('a')
-    expect(tablesLink?.className).toMatch(/bg-indigo-600/)
+    const menuLink = screen.getByText('Menu').closest('a')
+    expect(menuLink?.className).toMatch(/bg-indigo-600/)
   })
 
-  it('does not highlight Dashboard when on /admin/tables', () => {
-    vi.mocked(usePathname).mockReturnValue('/admin/tables')
+  it('does not highlight Dashboard when on /admin/menu', () => {
+    vi.mocked(usePathname).mockReturnValue('/admin/menu')
     render(<AdminNav />)
     const dashboardLink = screen.getByText('Dashboard').closest('a')
     expect(dashboardLink?.className).not.toMatch(/bg-indigo-600/)

--- a/apps/web/app/admin/AdminNav.tsx
+++ b/apps/web/app/admin/AdminNav.tsx
@@ -11,7 +11,6 @@ interface NavLink {
 
 const NAV_LINKS: NavLink[] = [
   { href: '/admin', label: 'Dashboard' },
-  { href: '/admin/tables', label: 'Tables' },
   { href: '/admin/menu', label: 'Menu' },
 ]
 

--- a/supabase/migrations/20260310090000_add_anon_read_for_restaurants_modifiers.sql
+++ b/supabase/migrations/20260310090000_add_anon_read_for_restaurants_modifiers.sql
@@ -1,0 +1,18 @@
+-- Allow the anon role to read restaurants and modifiers so that the
+-- admin menu management screen (which uses the publishable/anon key with
+-- no auth session) can:
+--   - resolve the restaurant_id needed to create new menus
+--   - load modifier data nested inside menu_items queries
+--
+-- HUMAN REVIEW REQUIRED: these policies grant unauthenticated read access.
+-- They are appropriate for the current demo / development stage where there
+-- is no login flow, but should be tightened before a production rollout.
+--
+-- Rollback: DROP POLICY "allow_anon_read" ON restaurants;
+--           DROP POLICY "allow_anon_read" ON modifiers;
+
+CREATE POLICY "allow_anon_read" ON restaurants
+  FOR SELECT TO anon USING (true);
+
+CREATE POLICY "allow_anon_read" ON modifiers
+  FOR SELECT TO anon USING (true);


### PR DESCRIPTION
Fixes the "Unable to load menu data" error on `/admin/menu` and the 404 on `/admin/tables`.

## Root causes
1. `/admin/tables` 404 — AdminNav linked to a non-existent route; Next.js was prefetching it on every admin page load
2. "Unable to load menu data" — `fetchMenuAdminData` queries `restaurants` with the anon key, but that table only had `allow_all_authenticated` RLS. Same gap for `modifiers` in the embedded join.

## Changes
- New migration adding `allow_anon_read` on `restaurants` and `modifiers` (matching existing demo-stage pattern)
- Remove `/admin/tables` from AdminNav
- Update AdminNav tests

Closes #91

Generated with [Claude Code](https://claude.ai/code)) • [`claude/issue-91-20260310-0846`](https://github.com/lidiapierre/ikitchen-pos/tree/claude/issue-91-20260310-0846