### PR TITLE
fix: null-guard embedded relations in fetchMenus; surface fetch errors

### DIFF
--- a/apps/web/app/admin/menu/MenuManager.tsx
+++ b/apps/web/app/admin/menu/MenuManager.tsx
@@ -426,6 +426,7 @@ export default function MenuManager(): JSX.Element {
       <div className="flex flex-col gap-6">
         <h1 className="text-2xl font-bold text-white">Menu</h1>
         <p className="text-red-400 text-base">Unable to load menu data. Please try again.</p>
+        <p className="text-red-300 text-sm font-mono">{fetchError}</p>
       </div>
     )
   }

--- a/apps/web/app/admin/menu/menuAdminData.ts
+++ b/apps/web/app/admin/menu/menuAdminData.ts
@@ -80,11 +80,11 @@ async function fetchMenus(supabaseUrl: string, apiKey: string): Promise<AdminMen
     id: menu.id,
     name: menu.name,
     restaurant_id: menu.restaurant_id,
-    items: menu.menu_items.map((item) => ({
+    items: (menu.menu_items ?? []).map((item) => ({
       id: item.id,
       name: item.name,
       price_cents: item.price_cents,
-      modifiers: item.modifiers.map((mod) => ({
+      modifiers: (item.modifiers ?? []).map((mod) => ({
         id: mod.id,
         name: mod.name,
         price_delta_cents: mod.price_delta_cents,


### PR DESCRIPTION
Fixes the "Unable to load menu data" crash on `/admin/menu`.

## Root cause

PostgREST returns `null` (not `[]`) for an embedded relation when the caller's role lacks SELECT permission. `fetchMenus` called `.map()` directly on `menu.menu_items` and `item.modifiers`, throwing a TypeError that was caught and silently replaced with the generic banner.

The underlying permission gap (`allow_anon_read` on `modifiers` from migration `20260310090000`) is already in the repo - it just needs `supabase db push` to reach production.

## Changes
- `menuAdminData.ts`: use `?? []` guards on both `menu_items` and `modifiers`
- `MenuManager.tsx`: render actual `fetchError` message below the banner

Closes #91

Generated with [Claude Code](https://claude.ai/code)