### PR TITLE
fix: add anon write RLS policies for menu admin CRUD

### DIFF
--- a/supabase/migrations/20260310092000_add_anon_write_for_menu_admin.sql
+++ b/supabase/migrations/20260310092000_add_anon_write_for_menu_admin.sql
@@ -1,0 +1,22 @@
+-- Allow the anon role to perform write operations (INSERT, UPDATE, DELETE) on
+-- menus, menu_items, and modifiers so that the admin menu management screen
+-- (which uses the publishable/anon key with no auth session) can perform CRUD.
+--
+-- HUMAN REVIEW REQUIRED: these policies grant unauthenticated write access.
+-- They are appropriate for the current demo / development stage where there
+-- is no login flow, but must be replaced with authenticated admin-only policies
+-- before production rollout.
+--
+-- Rollback:
+--   DROP POLICY "allow_anon_write" ON menus;
+--   DROP POLICY "allow_anon_write" ON menu_items;
+--   DROP POLICY "allow_anon_write" ON modifiers;
+
+CREATE POLICY "allow_anon_write" ON menus
+  FOR ALL TO anon USING (true) WITH CHECK (true);
+
+CREATE POLICY "allow_anon_write" ON menu_items
+  FOR ALL TO anon USING (true) WITH CHECK (true);
+
+CREATE POLICY "allow_anon_write" ON modifiers
+  FOR ALL TO anon USING (true) WITH CHECK (true);


### PR DESCRIPTION
Fixes the error when editing menu items on `/admin/menu`.

Root cause: all existing RLS policies on `menus`, `menu_items`, and `modifiers` only granted SELECT to the anon role. The edit flow sends PATCH/DELETE/POST which were all blocked by PostgREST with a 403 because no write policies existed for anon on those tables.

Adds migration `20260310092000_add_anon_write_for_menu_admin.sql` granting anon ALL on menus, menu_items, and modifiers. Marked HUMAN REVIEW REQUIRED for tightening before production.

Closes #91

Generated with [Claude Code](https://claude.ai/code)