### PR TITLE
feat: implement functional table detail page (#125)

### DIFF
--- a/apps/web/app/tables/[id]/TableDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/TableDetailClient.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import type { ReactNode, JSX } from 'react'
+import TableDetailClient from './TableDetailClient'
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }): JSX.Element => (
+    <a href={href}>{children as ReactNode}</a>
+  ),
+}))
+
+const mockPush = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: (): { push: ReturnType<typeof vi.fn> } => ({ push: mockPush }),
+}))
+
+vi.mock('./tableDetailData', () => ({
+  fetchTableById: vi.fn(),
+}))
+
+vi.mock('../components/createOrderApi', () => ({
+  callCreateOrder: vi.fn(),
+}))
+
+describe('TableDetailClient', () => {
+  beforeEach((): void => {
+    vi.clearAllMocks()
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'test-key')
+  })
+
+  afterEach((): void => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('occupied table', () => {
+    beforeEach(async (): Promise<void> => {
+      const { fetchTableById } = await import('./tableDetailData')
+      vi.mocked(fetchTableById).mockResolvedValue({
+        id: 'table-001',
+        label: '3',
+        open_order_id: 'order-abc-123',
+      })
+    })
+
+    it('shows loading state initially', (): void => {
+      render(<TableDetailClient tableId="table-001" />)
+      expect(screen.getByText('Loading…')).toBeInTheDocument()
+    })
+
+    it('renders the table label', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-001" />)
+      expect(await screen.findByText('Table 3')).toBeInTheDocument()
+    })
+
+    it('renders "Occupied" status badge', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-001" />)
+      expect(await screen.findByText('Occupied')).toBeInTheDocument()
+    })
+
+    it('renders a "Go to Order" link pointing to the active order', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-001" />)
+      const link = await screen.findByRole('link', { name: 'Go to Order' })
+      expect(link).toHaveAttribute('href', '/tables/table-001/order/order-abc-123')
+    })
+
+    it('"Go to Order" link meets 48px minimum touch target', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-001" />)
+      const link = await screen.findByRole('link', { name: 'Go to Order' })
+      expect(link.className).toContain('min-h-[')
+    })
+
+    it('does not render "Start Order" button for occupied table', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-001" />)
+      await screen.findByText('Occupied')
+      expect(screen.queryByRole('button', { name: 'Start Order' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('empty table', () => {
+    beforeEach(async (): Promise<void> => {
+      const { fetchTableById } = await import('./tableDetailData')
+      vi.mocked(fetchTableById).mockResolvedValue({
+        id: 'table-002',
+        label: '5',
+        open_order_id: null,
+      })
+    })
+
+    it('renders the table label', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-002" />)
+      expect(await screen.findByText('Table 5')).toBeInTheDocument()
+    })
+
+    it('renders "Empty" status badge', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-002" />)
+      expect(await screen.findByText('Empty')).toBeInTheDocument()
+    })
+
+    it('renders "Start Order" button', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-002" />)
+      expect(await screen.findByRole('button', { name: 'Start Order' })).toBeInTheDocument()
+    })
+
+    it('"Start Order" button meets 48px minimum touch target', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-002" />)
+      const btn = await screen.findByRole('button', { name: 'Start Order' })
+      expect(btn.className).toContain('min-h-[')
+    })
+
+    it('calls create_order and navigates to the new order on success', async (): Promise<void> => {
+      const { callCreateOrder } = await import('../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'new-order-xyz' })
+
+      render(<TableDetailClient tableId="table-002" />)
+      const btn = await screen.findByRole('button', { name: 'Start Order' })
+      fireEvent.click(btn)
+
+      await waitFor((): void => {
+        expect(mockPush).toHaveBeenCalledWith('/tables/table-002/order/new-order-xyz')
+      })
+    })
+
+    it('shows "Creating…" and disables button while create_order is in progress', async (): Promise<void> => {
+      const { callCreateOrder } = await import('../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockImplementation(
+        (): Promise<{ order_id: string }> => new Promise(() => {}),
+      )
+
+      render(<TableDetailClient tableId="table-002" />)
+      const btn = await screen.findByRole('button', { name: 'Start Order' })
+      fireEvent.click(btn)
+
+      await waitFor((): void => {
+        expect(screen.getByRole('button', { name: 'Creating…' })).toBeDisabled()
+      })
+    })
+
+    it('shows error message when create_order fails', async (): Promise<void> => {
+      const { callCreateOrder } = await import('../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockRejectedValue(new Error('Table has an open order'))
+
+      render(<TableDetailClient tableId="table-002" />)
+      const btn = await screen.findByRole('button', { name: 'Start Order' })
+      fireEvent.click(btn)
+
+      await waitFor((): void => {
+        expect(screen.getByText('Table has an open order')).toBeInTheDocument()
+      })
+    })
+
+    it('shows "API not configured" error when env vars are absent', async (): Promise<void> => {
+      vi.unstubAllEnvs()
+
+      render(<TableDetailClient tableId="table-002" />)
+      const btn = await screen.findByRole('button', { name: 'Start Order' })
+      fireEvent.click(btn)
+
+      await waitFor((): void => {
+        expect(screen.getByText('API not configured')).toBeInTheDocument()
+      })
+    })
+
+    it('does not render "Go to Order" link for empty table', async (): Promise<void> => {
+      render(<TableDetailClient tableId="table-002" />)
+      await screen.findByText('Empty')
+      expect(screen.queryByRole('link', { name: 'Go to Order' })).not.toBeInTheDocument()
+    })
+  })
+
+  describe('error and loading states', () => {
+    it('shows error message when fetch fails', async (): Promise<void> => {
+      const { fetchTableById } = await import('./tableDetailData')
+      vi.mocked(fetchTableById).mockRejectedValue(new Error('Table not found'))
+
+      render(<TableDetailClient tableId="table-999" />)
+      expect(await screen.findByText('Table not found')).toBeInTheDocument()
+    })
+
+    it('shows "Supabase is not configured" when env vars are absent', (): void => {
+      vi.unstubAllEnvs()
+
+      render(<TableDetailClient tableId="table-001" />)
+      expect(screen.getByText('Supabase is not configured')).toBeInTheDocument()
+    })
+  })
+
+  describe('navigation', () => {
+    it('renders "Back to Tables" link pointing to /tables', (): void => {
+      render(<TableDetailClient tableId="table-001" />)
+      const backLink = screen.getByRole('link', { name: /Back to Tables/ })
+      expect(backLink).toHaveAttribute('href', '/tables')
+    })
+
+    it('"Back to Tables" link meets 48px minimum touch target', (): void => {
+      render(<TableDetailClient tableId="table-001" />)
+      const backLink = screen.getByRole('link', { name: /Back to Tables/ })
+      expect(backLink.className).toContain('min-h-[48px]')
+    })
+  })
+})

--- a/apps/web/app/tables/[id]/TableDetailClient.tsx
+++ b/apps/web/app/tables/[id]/TableDetailClient.tsx
@@ -1,0 +1,127 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { fetchTableById } from './tableDetailData'
+import { callCreateOrder } from '../components/createOrderApi'
+import type { TableRow } from '../tablesData'
+
+interface TableDetailClientProps {
+  tableId: string
+}
+
+export default function TableDetailClient({ tableId }: TableDetailClientProps): JSX.Element {
+  const router = useRouter()
+  const [table, setTable] = useState<TableRow | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionLoading, setActionLoading] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const loadTable = useCallback((): void => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+
+    if (!supabaseUrl || !supabaseKey) {
+      setError('Supabase is not configured')
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    fetchTableById(supabaseUrl, supabaseKey, tableId)
+      .then((data) => { setTable(data) })
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : 'Failed to load table')
+      })
+      .finally(() => { setLoading(false) })
+  }, [tableId])
+
+  useEffect(() => {
+    loadTable()
+  }, [loadTable])
+
+  async function handleStartOrder(): Promise<void> {
+    setActionError(null)
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+
+    if (!supabaseUrl || !supabaseKey) {
+      setActionError('API not configured')
+      return
+    }
+
+    setActionLoading(true)
+    try {
+      const result = await callCreateOrder(supabaseUrl, supabaseKey, tableId)
+      router.push(`/tables/${tableId}/order/${result.order_id}`)
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : 'Failed to create order')
+    } finally {
+      setActionLoading(false)
+    }
+  }
+
+  const isOccupied = table !== null && table.open_order_id !== null
+
+  return (
+    <main className="min-h-screen bg-zinc-900 p-6">
+      <Link
+        href="/tables"
+        className="inline-flex items-center gap-2 text-zinc-400 hover:text-white text-base mb-8 min-h-[48px] min-w-[48px]"
+      >
+        ← Back to Tables
+      </Link>
+
+      {loading ? (
+        <p className="text-zinc-400 text-lg">Loading…</p>
+      ) : error !== null ? (
+        <p className="text-red-400 text-lg">{error}</p>
+      ) : table === null ? (
+        <p className="text-zinc-400 text-lg">Table not found.</p>
+      ) : (
+        <div className="flex flex-col gap-8">
+          <div className="flex items-center gap-4">
+            <h1 className="text-3xl font-bold text-white">Table {table.label}</h1>
+            <span
+              className={[
+                'text-base font-semibold px-3 py-1 rounded-full',
+                isOccupied
+                  ? 'bg-amber-500 text-white'
+                  : 'bg-zinc-700 text-zinc-300',
+              ].join(' ')}
+            >
+              {isOccupied ? 'Occupied' : 'Empty'}
+            </span>
+          </div>
+
+          {isOccupied && table.open_order_id !== null ? (
+            <Link
+              href={`/tables/${tableId}/order/${table.open_order_id}`}
+              className="inline-flex items-center justify-center text-xl font-semibold bg-amber-600 hover:bg-amber-500 text-white rounded-2xl px-8 min-h-[64px] min-w-[48px] transition-colors"
+            >
+              Go to Order
+            </Link>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <button
+                type="button"
+                onClick={() => { void handleStartOrder() }}
+                disabled={actionLoading}
+                className="inline-flex items-center justify-center text-xl font-semibold bg-emerald-700 hover:bg-emerald-600 text-white rounded-2xl px-8 min-h-[64px] min-w-[48px] transition-colors disabled:opacity-60 disabled:cursor-wait"
+              >
+                {actionLoading ? 'Creating…' : 'Start Order'}
+              </button>
+              {actionError !== null && (
+                <p className="text-red-400 text-base">{actionError}</p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/apps/web/app/tables/[id]/page.tsx
+++ b/apps/web/app/tables/[id]/page.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react'
-import Link from 'next/link'
+import TableDetailClient from './TableDetailClient'
 
 interface PageProps {
   params: Promise<{ id: string }>
@@ -7,17 +7,5 @@ interface PageProps {
 
 export default async function TableDetailPage({ params }: PageProps): Promise<JSX.Element> {
   const { id } = await params
-
-  return (
-    <main className="min-h-screen bg-zinc-900 p-6">
-      <Link
-        href="/tables"
-        className="inline-block text-zinc-400 hover:text-white text-base mb-8 min-h-[48px] min-w-[48px] flex items-center gap-2"
-      >
-        ← Back to Tables
-      </Link>
-      <h1 className="text-2xl font-bold text-white">Table {id}</h1>
-      <p className="text-zinc-400 mt-4 text-base">Table detail — coming soon.</p>
-    </main>
-  )
+  return <TableDetailClient tableId={id} />
 }

--- a/apps/web/app/tables/[id]/tableDetailData.ts
+++ b/apps/web/app/tables/[id]/tableDetailData.ts
@@ -1,0 +1,60 @@
+import type { TableRow } from '../tablesData'
+
+interface TableApiRow {
+  id: string
+  label: string
+}
+
+interface OrderApiRow {
+  id: string
+}
+
+export async function fetchTableById(
+  supabaseUrl: string,
+  apiKey: string,
+  tableId: string,
+): Promise<TableRow> {
+  const headers = {
+    apikey: apiKey,
+    Authorization: `Bearer ${apiKey}`,
+  }
+
+  const tableUrl = new URL(`${supabaseUrl}/rest/v1/tables`)
+  tableUrl.searchParams.set('select', 'id,label')
+  tableUrl.searchParams.set('id', `eq.${tableId}`)
+
+  const tableRes = await fetch(tableUrl.toString(), { headers })
+
+  if (!tableRes.ok) {
+    const body = await tableRes.text()
+    throw new Error(`Failed to fetch table: ${tableRes.status} ${tableRes.statusText} — ${body}`)
+  }
+
+  const tables = (await tableRes.json()) as TableApiRow[]
+  const tableRow = tables[0]
+
+  if (!tableRow) {
+    throw new Error('Table not found')
+  }
+
+  const orderUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
+  orderUrl.searchParams.set('select', 'id')
+  orderUrl.searchParams.set('table_id', `eq.${tableId}`)
+  orderUrl.searchParams.set('status', 'eq.open')
+
+  const orderRes = await fetch(orderUrl.toString(), { headers })
+
+  if (!orderRes.ok) {
+    const body = await orderRes.text()
+    throw new Error(`Failed to fetch order: ${orderRes.status} ${orderRes.statusText} — ${body}`)
+  }
+
+  const orders = (await orderRes.json()) as OrderApiRow[]
+  const openOrder = orders[0]
+
+  return {
+    id: tableRow.id,
+    label: tableRow.label,
+    open_order_id: openOrder ? openOrder.id : null,
+  }
+}


### PR DESCRIPTION
Replace the stub at `/tables/[id]` with a full table detail view.

## Changes
- `tableDetailData.ts` — fetches single table by ID with open-order lookup
- `TableDetailClient.tsx` — occupied/empty render paths, loading/error states, 48px touch targets
- `page.tsx` — replaces stub with `<TableDetailClient />`
- `TableDetailClient.test.tsx` — unit tests for occupied and empty paths

Closes #125

Generated with [Claude Code](https://claude.ai/code)