### PR TITLE
ci: add edge function deploy workflow + workflow_dispatch to migrate

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,24 @@
+name: Deploy Supabase Edge Functions
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'supabase/functions/**'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy all edge functions
+        run: supabase functions deploy --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'supabase/migrations/**'
+  workflow_dispatch:
 
 jobs:
   migrate:


### PR DESCRIPTION
## What

- Adds `.github/workflows/deploy-functions.yml` — deploys all Supabase edge functions on push to `main` (paths: `supabase/functions/**`) and via manual trigger (`workflow_dispatch`)
- Adds `workflow_dispatch` to `migrate.yml` so migrations can be manually re-triggered without needing a new migration file

## Why

Edge functions had no CI/CD — changes to `supabase/functions/` were never auto-deployed. The `extract_menu_item` function was manually deployed as a hotfix today. This workflow closes that gap permanently.

The `workflow_dispatch` addition to migrate allows manual re-runs (e.g. after fixing secrets, as happened today).

## Notes

Requires these 3 repo secrets to be set (already done):
- `SUPABASE_PROJECT_REF`
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_DB_PASSWORD`