### PR TITLE
fix: allow anon uploads to menu-uploads storage bucket

### DIFF
--- a/supabase/migrations/20260324000000_add_anon_upload_for_menu_storage.sql
+++ b/supabase/migrations/20260324000000_add_anon_upload_for_menu_storage.sql
@@ -1,0 +1,11 @@
+-- Allow anon role to upload to menu-uploads bucket
+-- Required until Supabase Auth is implemented (issue #92)
+-- Once auth is live, this policy should be replaced with an authenticated-only policy
+-- HUMAN REVIEW REQUIRED when auth is added
+
+CREATE POLICY "menu_uploads_insert_anon"
+  ON storage.objects FOR INSERT TO anon
+  WITH CHECK (bucket_id = 'menu-uploads');
+
+-- Rollback:
+-- DROP POLICY "menu_uploads_insert_anon" ON storage.objects;


### PR DESCRIPTION
## Problem

Saving a new menu item with an image fails with:
`Upload failed: 400 — {"statusCode":"403","error":"Unauthorized","message":"new row violates row-level security policy"}`

The `menu_uploads_insert_authenticated` storage policy (added in #134) requires the `authenticated` role, but the app currently uses the anon key for all requests — Supabase Auth hasn't been implemented yet (see issue #92).

## Fix

Add a storage RLS policy allowing `anon` to insert into `menu-uploads`.

## Note

This is a temporary policy consistent with the rest of the app's current anon-access pattern. It must be reviewed and tightened when issue #92 (Supabase Auth) is implemented. The policy includes a `HUMAN REVIEW REQUIRED` comment as a marker.