### PR TITLE
fix: url-encode db password in migrate CI workflow

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -24,7 +24,6 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
 
       - name: Run migrations
-        run: supabase db push
+        run: supabase db push --db-url "${{ secrets.SUPABASE_DB_URL }}"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
The `+` character in the DB password was not being URL-encoded when Supabase CLI built the connection string, causing `SASL auth failure` on every push to main.

**Root cause:** `SUPABASE_DB_PASSWORD` env var gets interpolated into a postgres URL where `+` is treated as a space, breaking auth.

**Fix:** Switch to passing a full pre-encoded `--db-url` (via new `SUPABASE_DB_URL` secret) instead of relying on the CLI to build the URL from the raw password.

**Action required:** Add `SUPABASE_DB_URL` secret in GitHub repo settings:
```
postgresql://postgres.dmaogdwtgohrhbytxjqu:Sy_pbBraaZ%2BQ5Rr@aws-1-ap-northeast-2.pooler.supabase.com:5432/postgres
```
(note the `+` is encoded as `%2B`)