### PR TITLE
fix: ci.yml — pin supabase CLI version + use SUPABASE_DB_URL for migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: supabase/setup-cli@v1
+        with:
+          version: latest
       - name: Deploy edge functions
         run: |
           supabase functions deploy --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
@@ -134,6 +136,6 @@ jobs:
           version: latest
 
       - name: Deploy migrations
-        run: supabase db push --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: supabase db push --db-url "${{ secrets.SUPABASE_DB_URL }}"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
Two failures in the CI `deploy-*` jobs after merging #153:

**1. Deploy Edge Functions — `failed to parse config`**
`supabase/setup-cli@v1` without `version: latest` installs an older CLI that doesn't understand some keys in `config.toml`. Fix: pin to `version: latest`.

**2. Deploy Migrations — missing DB password**
The `deploy-migrations` job was using `--project-ref` without passing a DB password, so it would always fail. Fix: switch to `--db-url "${{ secrets.SUPABASE_DB_URL }}"` (same approach as PR #153 for `migrate.yml`).