### PR TITLE
feat: apply VAT rates in payment total and bill — closes #146

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -43,6 +43,11 @@ vi.mock('@/components/KotPrintView', () => ({
   default: (): JSX.Element => <div data-testid="kot-print-view" />,
 }))
 
+vi.mock('@/lib/fetchVatConfig', () => ({
+  fetchOrderVatContext: vi.fn().mockResolvedValue({ restaurantId: 'rest-1', menuId: null }),
+  fetchVatConfig: vi.fn().mockResolvedValue({ vatPercent: 15, taxInclusive: false }),
+}))
+
 const mockItems = [
   { id: '1', name: 'Bruschetta', quantity: 2, price_cents: 850, modifier_ids: [], modifier_names: [], sent_to_kitchen: false },
   { id: '2', name: 'Grilled Salmon', quantity: 1, price_cents: 1850, modifier_ids: [], modifier_names: [], sent_to_kitchen: false },

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -12,6 +12,8 @@ import { callVoidItem } from './voidItemApi'
 import { callCancelOrder } from './cancelOrderApi'
 import { markItemsSentToKitchen } from './kotApi'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
+import { calcVat } from '@/lib/vatCalc'
+import { fetchVatConfig, fetchOrderVatContext } from '@/lib/fetchVatConfig'
 import KotPrintView from '@/components/KotPrintView'
 import BillPrintView from '@/components/BillPrintView'
 
@@ -63,6 +65,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [billTimestamp, setBillTimestamp] = useState('')
   const [printingBill, setPrintingBill] = useState(false)
 
+  // VAT config state (fetched once on load)
+  const [vatPercent, setVatPercent] = useState(0)
+  const [taxInclusive, setTaxInclusive] = useState(false)
+  const [vatConfigLoading, setVatConfigLoading] = useState(true)
+
   function loadItems(): void {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
@@ -109,9 +116,37 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       })
   }
 
+  function loadVatConfig(): void {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    if (!supabaseUrl || !supabaseKey) {
+      setVatConfigLoading(false)
+      return
+    }
+
+    setVatConfigLoading(true)
+    fetchOrderVatContext(supabaseUrl, supabaseKey, orderId)
+      .then(({ restaurantId, menuId }) =>
+        fetchVatConfig(supabaseUrl, supabaseKey, restaurantId, menuId),
+      )
+      .then((config) => {
+        setVatPercent(config.vatPercent)
+        setTaxInclusive(config.taxInclusive)
+      })
+      .catch(() => {
+        // Non-fatal: fall back to 0% VAT (safe — no overcharging)
+        setVatPercent(0)
+        setTaxInclusive(false)
+      })
+      .finally(() => {
+        setVatConfigLoading(false)
+      })
+  }
+
   useEffect(() => {
     loadItems()
     loadOrderStatus()
+    loadVatConfig()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orderId])
 
@@ -126,14 +161,16 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     return () => { clearTimeout(timer) }
   }, [step, router, printingBill])
 
-  const totalCents = items.reduce((sum, item) => sum + item.quantity * item.price_cents, 0)
+  const rawItemsTotalCents = items.reduce((sum, item) => sum + item.quantity * item.price_cents, 0)
+
+  // VAT breakdown (uses fetched config; calcVat is a pure function)
+  const vatBreakdown = calcVat(rawItemsTotalCents, vatPercent, taxInclusive)
+  const { subtotalCents: billSubtotalCents, vatCents: billVatCents, totalCents: billTotalCents } = vatBreakdown
+
+  // Displayed "total" in the order footer is the VAT-inclusive grand total
+  const totalCents = billTotalCents
   const totalFormatted = formatPrice(totalCents, currencySymbol)
 
-  // Bill totals (subtotal = items sum; VAT hardcoded at 15% pending issue #146)
-  const VAT_PERCENT = 15
-  const billSubtotalCents = totalCents
-  const billVatCents = Math.round(billSubtotalCents * VAT_PERCENT / 100)
-  const billTotalCents = billSubtotalCents + billVatCents
   const billPaymentMethod = (confirmedPaymentMethod ?? paymentMethod) as 'cash' | 'card'
   const billAmountTenderedCents = paymentMethod === 'cash'
     ? Math.round(parseFloat(amountTenderedDollars || '0') * 100)
@@ -211,10 +248,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   async function handleRecordPayment(): Promise<void> {
     setPaymentError(null)
 
+    // For cash: amount tendered must cover the VAT-inclusive total
     const amountCentsToTender = paymentMethod === 'cash'
       ? Math.round(parseFloat(amountTenderedDollars || '0') * 100)
-      : totalCents
-    if (paymentMethod === 'cash' && amountCentsToTender < totalCents) {
+      : billTotalCents
+    if (paymentMethod === 'cash' && amountCentsToTender < billTotalCents) {
       setPaymentError('Amount tendered must be at least the order total')
       return
     }
@@ -226,7 +264,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       if (!supabaseUrl || !supabaseKey) {
         throw new Error('API not configured')
       }
-      const result = await callRecordPayment(supabaseUrl, supabaseKey, orderId, amountCentsToTender, paymentMethod, totalCents)
+      // Pass the VAT-inclusive total as the final amount to record_payment
+      const result = await callRecordPayment(supabaseUrl, supabaseKey, orderId, amountCentsToTender, paymentMethod, billTotalCents)
       setConfirmedPaymentMethod(paymentMethod)
       if (paymentMethod === 'cash') {
         setChangeDueCents(result.change_due)
@@ -448,7 +487,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         orderId={orderId}
         items={items}
         subtotalCents={billSubtotalCents}
-        vatPercent={VAT_PERCENT}
+        vatPercent={vatPercent}
+        taxInclusive={taxInclusive}
         totalCents={billTotalCents}
         paymentMethod={billPaymentMethod}
         amountTenderedCents={billAmountTenderedCents}
@@ -657,13 +697,22 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         ) : step === 'payment' ? (
           <div className="space-y-5">
             <h2 className="text-xl font-semibold text-white">Record Payment</h2>
-            <div className="bg-zinc-800 rounded-xl px-4 py-3 flex justify-between items-center text-sm">
-              <div className="text-zinc-400">
-                <span>Subtotal {totalFormatted}</span>
-                <span className="mx-2 text-zinc-600">·</span>
-                <span>VAT {VAT_PERCENT}% {formatPrice(billVatCents, currencySymbol)}</span>
+            {/* Order total breakdown */}
+            <div className="bg-zinc-800 rounded-xl px-4 py-3 text-sm space-y-1.5">
+              <div className="flex justify-between text-zinc-400">
+                <span>Subtotal</span>
+                <span>{formatPrice(billSubtotalCents, currencySymbol)}</span>
               </div>
-              <span className="text-white font-bold text-base">{formatPrice(billTotalCents, currencySymbol)}</span>
+              {billVatCents > 0 && (
+                <div className="flex justify-between text-zinc-400">
+                  <span>VAT {vatPercent}%{taxInclusive ? ' (incl.)' : ''}</span>
+                  <span>{formatPrice(billVatCents, currencySymbol)}</span>
+                </div>
+              )}
+              <div className="flex justify-between font-bold text-white border-t border-zinc-700 pt-1.5 mt-1">
+                <span>Total</span>
+                <span>{formatPrice(billTotalCents, currencySymbol)}</span>
+              </div>
             </div>
 
             <div>
@@ -701,9 +750,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 <p className="text-zinc-400 text-base mb-2">Amount tendered</p>
                 <input
                   type="number"
-                  min={(totalCents / 100).toFixed(2)}
+                  min={(billTotalCents / 100).toFixed(2)}
                   step="0.01"
-                  placeholder={(totalCents / 100).toFixed(2)}
+                  placeholder={(billTotalCents / 100).toFixed(2)}
                   value={amountTenderedDollars}
                   onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setAmountTenderedDollars(e.target.value) }}
                   className="w-full min-h-[48px] px-4 rounded-xl text-base bg-zinc-800 text-white border-2 border-zinc-600 focus:border-amber-400 focus:outline-none"

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClientEmptyState.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClientEmptyState.test.tsx
@@ -19,6 +19,12 @@ vi.mock('./closeOrderApi', () => ({
 
 vi.mock('./orderData', () => ({
   fetchOrderItems: vi.fn(),
+  fetchOrderSummary: vi.fn().mockResolvedValue({ status: 'open', payment_method: null }),
+}))
+
+vi.mock('@/lib/fetchVatConfig', () => ({
+  fetchOrderVatContext: vi.fn().mockResolvedValue({ restaurantId: 'rest-1', menuId: null }),
+  fetchVatConfig: vi.fn().mockResolvedValue({ vatPercent: 15, taxInclusive: false }),
 }))
 
 describe('OrderDetailClient — empty state', () => {
@@ -40,9 +46,9 @@ describe('OrderDetailClient — empty state', () => {
     expect(await screen.findByText('No items yet — tap Add Items to start')).toBeInTheDocument()
   })
 
-  it('still renders the Add Items link in the empty state', (): void => {
+  it('still renders the Add Items link in the empty state', async (): Promise<void> => {
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 
-    expect(screen.getByRole('link', { name: 'Add Items' })).toBeInTheDocument()
+    expect(await screen.findByRole('link', { name: 'Add Items' })).toBeInTheDocument()
   })
 })

--- a/apps/web/components/BillPrintView.test.tsx
+++ b/apps/web/components/BillPrintView.test.tsx
@@ -140,8 +140,8 @@ describe('BillPrintView', () => {
       />,
     )
 
-    // VAT (15%): 570 cents = ৳ 5.70
-    expect(screen.getByText('VAT (15%)')).toBeInTheDocument()
+    // VAT 15%: 570 cents = ৳ 5.70
+    expect(screen.getByText('VAT 15%')).toBeInTheDocument()
     expect(screen.getByText('৳ 5.70')).toBeInTheDocument()
   })
 

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -9,6 +9,8 @@ export interface BillPrintViewProps {
   items: OrderItem[]
   subtotalCents: number
   vatPercent: number
+  /** Whether prices already include VAT (affects label on receipt) */
+  taxInclusive?: boolean
   totalCents: number
   paymentMethod: 'cash' | 'card'
   amountTenderedCents?: number
@@ -22,13 +24,16 @@ export default function BillPrintView({
   items,
   subtotalCents,
   vatPercent,
+  taxInclusive = false,
   totalCents,
   paymentMethod,
   amountTenderedCents,
   changeDueCents,
   timestamp,
 }: BillPrintViewProps): JSX.Element {
-  const vatCents = Math.round(subtotalCents * vatPercent / 100)
+  // vatCents is already pre-calculated by the caller (calcVat utility).
+  // Derive it here for display only; totalCents is the authoritative value.
+  const vatCents = totalCents - subtotalCents
 
   return (
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
@@ -66,10 +71,12 @@ export default function BillPrintView({
           <span>Subtotal</span>
           <span>{formatPrice(subtotalCents, DEFAULT_CURRENCY_SYMBOL)}</span>
         </div>
-        <div className="flex justify-between">
-          <span>VAT ({vatPercent}%)</span>
-          <span>{formatPrice(vatCents, DEFAULT_CURRENCY_SYMBOL)}</span>
-        </div>
+        {vatPercent > 0 && (
+          <div className="flex justify-between">
+            <span>VAT {vatPercent}%{taxInclusive ? ' (incl.)' : ''}</span>
+            <span>{formatPrice(vatCents, DEFAULT_CURRENCY_SYMBOL)}</span>
+          </div>
+        )}
         <div className="flex justify-between font-bold">
           <span>Total</span>
           <span>{formatPrice(totalCents, DEFAULT_CURRENCY_SYMBOL)}</span>

--- a/apps/web/lib/fetchVatConfig.ts
+++ b/apps/web/lib/fetchVatConfig.ts
@@ -1,0 +1,140 @@
+/**
+ * Fetch VAT configuration from Supabase for a given restaurant.
+ *
+ * Looks up:
+ * - config.tax_inclusive (key/value table)
+ * - vat_rates (menu-specific first, then restaurant default)
+ */
+
+export interface VatConfig {
+  /** VAT rate in percent (e.g. 15 for 15%). 0 means no VAT. */
+  vatPercent: number
+  /** Whether item prices already include VAT */
+  taxInclusive: boolean
+}
+
+/**
+ * Fetch the VAT config for a restaurant.
+ * Menu-specific rate takes precedence over restaurant-level default.
+ * All errors are swallowed (returns 0% exclusive as safe fallback).
+ */
+export async function fetchVatConfig(
+  supabaseUrl: string,
+  apiKey: string,
+  restaurantId: string,
+  menuId?: string | null,
+): Promise<VatConfig> {
+  const headers = {
+    apikey: apiKey,
+    Authorization: `Bearer ${apiKey}`,
+  }
+
+  // ── 1. Fetch tax_inclusive from config table ──────────────────────────────
+  let taxInclusive = false
+  try {
+    const configUrl = new URL(`${supabaseUrl}/rest/v1/config`)
+    configUrl.searchParams.set('restaurant_id', `eq.${restaurantId}`)
+    configUrl.searchParams.set('key', 'eq.tax_inclusive')
+    configUrl.searchParams.set('select', 'value')
+    configUrl.searchParams.set('limit', '1')
+
+    const configRes = await fetch(configUrl.toString(), { headers })
+    if (configRes.ok) {
+      const rows = (await configRes.json()) as Array<{ value: string }>
+      if (rows.length > 0) {
+        taxInclusive = rows[0].value === 'true'
+      }
+    }
+  } catch {
+    // Non-fatal: default to exclusive
+  }
+
+  // ── 2. Fetch VAT rates for this restaurant ────────────────────────────────
+  let vatPercent = 0
+  try {
+    const vatUrl = new URL(`${supabaseUrl}/rest/v1/vat_rates`)
+    vatUrl.searchParams.set('restaurant_id', `eq.${restaurantId}`)
+    vatUrl.searchParams.set('select', 'percentage,menu_id')
+
+    const vatRes = await fetch(vatUrl.toString(), { headers })
+    if (vatRes.ok) {
+      const rates = (await vatRes.json()) as Array<{
+        percentage: string | number
+        menu_id: string | null
+      }>
+
+      if (rates.length > 0) {
+        // Prefer menu-specific rate if we have a menuId
+        if (menuId) {
+          const menuRate = rates.find((r) => r.menu_id === menuId)
+          if (menuRate) {
+            return { vatPercent: Number(menuRate.percentage), taxInclusive }
+          }
+        }
+
+        // Fall back to restaurant-level default (menu_id IS NULL)
+        const defaultRate = rates.find((r) => r.menu_id === null)
+        vatPercent = defaultRate
+          ? Number(defaultRate.percentage)
+          : Number(rates[0].percentage)
+      }
+    }
+  } catch {
+    // Non-fatal: return 0% VAT so payment can proceed
+  }
+
+  return { vatPercent, taxInclusive }
+}
+
+/**
+ * Fetch the restaurant_id and (optionally) the menu_id of the first item
+ * in the order — used to look up per-menu VAT rates.
+ */
+export async function fetchOrderVatContext(
+  supabaseUrl: string,
+  apiKey: string,
+  orderId: string,
+): Promise<{ restaurantId: string; menuId: string | null }> {
+  const headers = {
+    apikey: apiKey,
+    Authorization: `Bearer ${apiKey}`,
+  }
+
+  // Fetch restaurant_id from orders
+  const orderUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
+  orderUrl.searchParams.set('id', `eq.${orderId}`)
+  orderUrl.searchParams.set('select', 'restaurant_id')
+  orderUrl.searchParams.set('limit', '1')
+
+  const orderRes = await fetch(orderUrl.toString(), { headers })
+  if (!orderRes.ok) {
+    throw new Error(`Failed to fetch order: ${orderRes.status} ${orderRes.statusText}`)
+  }
+  const orders = (await orderRes.json()) as Array<{ restaurant_id: string }>
+  if (orders.length === 0) throw new Error('Order not found')
+
+  const restaurantId = orders[0].restaurant_id
+
+  // Fetch menu_id from first order item (via menu_items relation)
+  let menuId: string | null = null
+  try {
+    const itemUrl = new URL(`${supabaseUrl}/rest/v1/order_items`)
+    itemUrl.searchParams.set('order_id', `eq.${orderId}`)
+    itemUrl.searchParams.set('select', 'menu_items(menu_id)')
+    itemUrl.searchParams.set('limit', '1')
+
+    const itemRes = await fetch(itemUrl.toString(), { headers })
+    if (itemRes.ok) {
+      const rows = (await itemRes.json()) as Array<{
+        menu_items: { menu_id: string } | null
+      }>
+      if (rows.length > 0 && rows[0].menu_items) {
+        menuId = rows[0].menu_items.menu_id
+      }
+    }
+  } catch {
+    // Non-fatal
+  }
+
+  return { restaurantId, menuId }
+}

--- a/apps/web/lib/vatCalc.test.ts
+++ b/apps/web/lib/vatCalc.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { calcVat } from './vatCalc'
+
+describe('calcVat — exclusive mode (tax_inclusive = false)', () => {
+  it('adds VAT on top of subtotal', () => {
+    // ৳1,000 net + 15% = ৳150 VAT = ৳1,150 total
+    const result = calcVat(100000, 15, false)
+    expect(result.subtotalCents).toBe(100000)
+    expect(result.vatCents).toBe(15000)
+    expect(result.totalCents).toBe(115000)
+    expect(result.vatPercent).toBe(15)
+    expect(result.taxInclusive).toBe(false)
+  })
+
+  it('rounds VAT to nearest cent', () => {
+    // ৳10.01 net + 15% = ৳1.5015 → rounds to ৳1.50 (150 cents)
+    const result = calcVat(1001, 15, false)
+    expect(result.vatCents).toBe(150)
+    expect(result.totalCents).toBe(1151)
+  })
+
+  it('handles a typical restaurant order', () => {
+    // 2 × ৳150 + 4 × ৳20 = ৳300 + ৳80 = ৳380 subtotal (3800 cents)
+    // VAT 15% = 570 cents → total 4370 cents
+    const result = calcVat(3800, 15, false)
+    expect(result.subtotalCents).toBe(3800)
+    expect(result.vatCents).toBe(570)
+    expect(result.totalCents).toBe(4370)
+  })
+})
+
+describe('calcVat — inclusive mode (tax_inclusive = true)', () => {
+  it('extracts VAT from gross price', () => {
+    // ৳1,150 gross includes 15% VAT
+    // vat = 115000 × 15 / 115 = 15000 cents
+    // net = 115000 − 15000 = 100000 cents
+    const result = calcVat(115000, 15, true)
+    expect(result.subtotalCents).toBe(100000)
+    expect(result.vatCents).toBe(15000)
+    expect(result.totalCents).toBe(115000)
+    expect(result.taxInclusive).toBe(true)
+  })
+
+  it('total equals the raw input (price not changed)', () => {
+    const gross = 46000
+    const result = calcVat(gross, 10, true)
+    expect(result.totalCents).toBe(gross)
+  })
+
+  it('extracted vat + net = gross', () => {
+    const gross = 23800
+    const result = calcVat(gross, 5, true)
+    expect(result.subtotalCents + result.vatCents).toBe(gross)
+  })
+})
+
+describe('calcVat — zero VAT (0% rate)', () => {
+  it('returns no VAT line and total equals subtotal (exclusive)', () => {
+    const result = calcVat(50000, 0, false)
+    expect(result.vatCents).toBe(0)
+    expect(result.subtotalCents).toBe(50000)
+    expect(result.totalCents).toBe(50000)
+  })
+
+  it('returns no VAT line and total equals gross (inclusive)', () => {
+    const result = calcVat(50000, 0, true)
+    expect(result.vatCents).toBe(0)
+    expect(result.subtotalCents).toBe(50000)
+    expect(result.totalCents).toBe(50000)
+  })
+
+  it('negative rate treated same as zero', () => {
+    const result = calcVat(50000, -5, false)
+    expect(result.vatCents).toBe(0)
+    expect(result.totalCents).toBe(50000)
+  })
+})

--- a/apps/web/lib/vatCalc.ts
+++ b/apps/web/lib/vatCalc.ts
@@ -1,0 +1,75 @@
+/**
+ * VAT calculation utility — pure functions, no side effects.
+ *
+ * tax_inclusive = false (exclusive):
+ *   VAT is added ON TOP of item subtotal.
+ *   vatCents  = round(subtotal × rate / 100)
+ *   total     = subtotal + vatCents
+ *
+ * tax_inclusive = true (inclusive):
+ *   VAT is already BAKED INTO item prices.
+ *   vatCents  = round(gross × rate / (100 + rate))
+ *   net       = gross − vatCents   (displayed as subtotal)
+ *   total     = gross              (unchanged)
+ */
+
+export interface VatBreakdown {
+  /** Net amount before VAT (or extracted net if inclusive) */
+  subtotalCents: number
+  /** VAT amount in cents */
+  vatCents: number
+  /** Grand total to charge the customer */
+  totalCents: number
+  /** VAT rate used (%) */
+  vatPercent: number
+  /** Whether prices were tax-inclusive */
+  taxInclusive: boolean
+}
+
+/**
+ * Calculate VAT breakdown from a raw items-sum in cents.
+ *
+ * @param rawSubtotalCents  Sum of (quantity × price_cents) for all items
+ * @param vatPercent        VAT rate in percent (e.g. 15 for 15%)
+ * @param taxInclusive      Whether prices already include VAT
+ */
+export function calcVat(
+  rawSubtotalCents: number,
+  vatPercent: number,
+  taxInclusive: boolean,
+): VatBreakdown {
+  // Zero or negative rate → no VAT line
+  if (vatPercent <= 0) {
+    return {
+      subtotalCents: rawSubtotalCents,
+      vatCents: 0,
+      totalCents: rawSubtotalCents,
+      vatPercent,
+      taxInclusive,
+    }
+  }
+
+  if (taxInclusive) {
+    // Reverse-calculate: extract VAT from gross
+    // vat = gross × rate / (100 + rate)
+    const vatCents = Math.round((rawSubtotalCents * vatPercent) / (100 + vatPercent))
+    return {
+      subtotalCents: rawSubtotalCents - vatCents,
+      vatCents,
+      totalCents: rawSubtotalCents,
+      vatPercent,
+      taxInclusive,
+    }
+  } else {
+    // Add VAT on top of net
+    // vat = net × rate / 100
+    const vatCents = Math.round((rawSubtotalCents * vatPercent) / 100)
+    return {
+      subtotalCents: rawSubtotalCents,
+      vatCents,
+      totalCents: rawSubtotalCents + vatCents,
+      vatPercent,
+      taxInclusive,
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #146 — VAT calculation in payment flow and bill/receipt.

## What changed

### New: `apps/web/lib/vatCalc.ts`
Pure `calcVat(rawSubtotalCents, vatPercent, taxInclusive)` utility:
- **Exclusive mode** (`tax_inclusive = false`): VAT added on top → `total = subtotal + vat`
- **Inclusive mode** (`tax_inclusive = true`): VAT extracted from gross → `vat = gross × rate / (100 + rate)`
- Zero/negative rate → no VAT, total = subtotal

### New: `apps/web/lib/fetchVatConfig.ts`
- `fetchOrderVatContext`: gets `restaurant_id` and `menu_id` from the order
- `fetchVatConfig`: looks up `vat_rates` (menu-specific first, then restaurant default) and `config.tax_inclusive`
- All errors are non-fatal — falls back to 0% VAT so payment can always proceed

### Updated: `OrderDetailClient.tsx`
- Fetches VAT config on mount (replaces hardcoded `VAT_PERCENT = 15`)
- Payment step shows proper 3-line breakdown: **Subtotal / VAT X% / Total**
- Cash tendering validation uses the VAT-inclusive total
- `record_payment` called with the VAT-inclusive final total
- `BillPrintView` receives `vatPercent` + `taxInclusive` from fetched config

### Updated: `BillPrintView.tsx`
- `vatCents` derived from `totalCents - subtotalCents` (single source of truth from caller)
- VAT line hidden when `vatPercent = 0`
- Label shows `(incl.)` suffix for tax-inclusive mode
- New optional prop: `taxInclusive?: boolean`

## Tests
- 9 new unit tests for `calcVat` (exclusive, inclusive, zero-rate modes, rounding)
- Fixed pre-existing broken test mocks in `OrderDetailClientEmptyState.test.tsx`
- Updated `BillPrintView.test.tsx` label assertion to match new format (`VAT 15%` → `VAT 15%`)

## Notes
- VAT calculation is client-side for display; `record_payment` receives the final total
- Safe fallback: if config fetch fails, 0% VAT is used — no risk of overcharging