### PR TITLE
feat(#163): table transfer — move active order to another table

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -12,6 +12,7 @@ import { callVoidItem } from './voidItemApi'
 import { callCancelOrder } from './cancelOrderApi'
 import { callApplyDiscount } from './applyDiscountApi'
 import { callCompItem } from './compApi'
+import { callTransferOrder } from './transferOrderApi'
 import { markItemsSentToKitchen } from './kotApi'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 import { calcVat } from '@/lib/vatCalc'
@@ -65,6 +66,16 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [cancelReason, setCancelReason] = useState('')
   const [cancelling, setCancelling] = useState(false)
   const [cancelError, setCancelError] = useState<string | null>(null)
+
+  // Transfer table state
+  interface AvailableTable { id: string; label: string }
+  const [showTransferModal, setShowTransferModal] = useState(false)
+  const [availableTables, setAvailableTables] = useState<AvailableTable[]>([])
+  const [transferTablesLoading, setTransferTablesLoading] = useState(false)
+  const [transferTablesError, setTransferTablesError] = useState<string | null>(null)
+  const [transferTarget, setTransferTarget] = useState<AvailableTable | null>(null)
+  const [transferring, setTransferring] = useState(false)
+  const [transferError, setTransferError] = useState<string | null>(null)
 
   // Printer config state
   const [printerConfig, setPrinterConfig] = useState<PrinterConfig | null>(null)
@@ -528,6 +539,68 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     }
   }
 
+  async function openTransferModal(): Promise<void> {
+    setTransferTarget(null)
+    setTransferError(null)
+    setTransferTablesError(null)
+    setShowTransferModal(true)
+    setTransferTablesLoading(true)
+
+    try {
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+      const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+      if (!supabaseUrl || !supabaseKey) throw new Error('API not configured')
+
+      // Fetch all tables
+      const tablesUrl = new URL(`${supabaseUrl}/rest/v1/tables`)
+      tablesUrl.searchParams.set('select', 'id,label')
+      tablesUrl.searchParams.set('order', 'label')
+      const tablesRes = await fetch(tablesUrl.toString(), {
+        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+      })
+      if (!tablesRes.ok) throw new Error('Failed to fetch tables')
+      const allTables = (await tablesRes.json()) as AvailableTable[]
+
+      // Fetch open orders to determine occupied tables
+      const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
+      ordersUrl.searchParams.set('select', 'table_id')
+      ordersUrl.searchParams.set('status', 'eq.open')
+      const ordersRes = await fetch(ordersUrl.toString(), {
+        headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+      })
+      if (!ordersRes.ok) throw new Error('Failed to fetch orders')
+      const openOrders = (await ordersRes.json()) as Array<{ table_id: string | null }>
+      const occupiedTableIds = new Set(openOrders.map((o) => o.table_id).filter(Boolean))
+
+      // Filter: exclude current table and occupied tables
+      const available = allTables.filter(
+        (t) => t.id !== tableId && !occupiedTableIds.has(t.id),
+      )
+      setAvailableTables(available)
+    } catch (err) {
+      setTransferTablesError(err instanceof Error ? err.message : 'Failed to load tables')
+    } finally {
+      setTransferTablesLoading(false)
+    }
+  }
+
+  async function handleTransfer(): Promise<void> {
+    if (!transferTarget) return
+    setTransferError(null)
+    setTransferring(true)
+    try {
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+      if (!supabaseUrl || !accessToken) throw new Error('Not authenticated')
+      await callTransferOrder(supabaseUrl, accessToken, orderId, transferTarget.id)
+      setShowTransferModal(false)
+      router.push(`/tables/${transferTarget.id}/order/${orderId}`)
+    } catch (err) {
+      setTransferError(err instanceof Error ? err.message : 'Failed to transfer order')
+    } finally {
+      setTransferring(false)
+    }
+  }
+
   function renderItems(): JSX.Element {
     if (loading) {
       return <p className="text-zinc-400 text-base">Loading items…</p>
@@ -791,6 +864,87 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 {voidingInProgress ? 'Voiding…' : 'Confirm Void'}
               </button>
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Transfer table modal */}
+      {showTransferModal && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/70">
+          <div className="w-full max-w-lg bg-zinc-800 rounded-t-2xl p-6 space-y-4 max-h-[80vh] overflow-y-auto">
+            {transferTarget === null ? (
+              <>
+                <div className="flex items-center justify-between">
+                  <h2 className="text-xl font-semibold text-white">Move Table</h2>
+                  <button
+                    type="button"
+                    onClick={() => { setShowTransferModal(false) }}
+                    className="text-zinc-400 hover:text-white text-base px-3 py-2 min-h-[48px] min-w-[48px]"
+                  >
+                    ✕
+                  </button>
+                </div>
+                <p className="text-zinc-400 text-base">Select a table to move this order to:</p>
+                {transferTablesLoading && (
+                  <p className="text-zinc-400 text-base">Loading tables…</p>
+                )}
+                {transferTablesError !== null && (
+                  <p className="text-red-400 text-base">{transferTablesError}</p>
+                )}
+                {!transferTablesLoading && transferTablesError === null && availableTables.length === 0 && (
+                  <p className="text-zinc-500 text-base">No available tables to move to.</p>
+                )}
+                {!transferTablesLoading && availableTables.length > 0 && (
+                  <div className="grid grid-cols-2 gap-3">
+                    {availableTables.map((t) => (
+                      <button
+                        key={t.id}
+                        type="button"
+                        onClick={() => { setTransferTarget(t); setTransferError(null) }}
+                        className="min-h-[80px] rounded-xl bg-zinc-700 hover:bg-zinc-600 border-2 border-zinc-600 hover:border-amber-400 flex flex-col items-center justify-center gap-1 transition-colors"
+                      >
+                        <span className="text-white font-bold text-lg">{t.label}</span>
+                        <span className="text-xs font-semibold text-green-400 bg-green-900/40 px-2 py-0.5 rounded-full">Empty</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <h2 className="text-xl font-semibold text-white">Confirm Move</h2>
+                <p className="text-zinc-300 text-base">
+                  Move order to{' '}
+                  <span className="font-semibold text-white">{transferTarget.label}</span>?
+                </p>
+                {transferError !== null && (
+                  <p className="text-red-400 text-base">{transferError}</p>
+                )}
+                <div className="flex gap-3">
+                  <button
+                    type="button"
+                    onClick={() => { setTransferTarget(null); setTransferError(null) }}
+                    disabled={transferring}
+                    className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold border-2 border-zinc-600 text-zinc-300 hover:border-zinc-400 transition-colors disabled:opacity-50"
+                  >
+                    Back
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { void handleTransfer() }}
+                    disabled={transferring}
+                    className={[
+                      'flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors',
+                      transferring
+                        ? 'bg-zinc-700 text-zinc-400 cursor-wait'
+                        : 'bg-amber-500 hover:bg-amber-400 text-zinc-900',
+                    ].join(' ')}
+                  >
+                    {transferring ? 'Moving…' : 'Confirm'}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       )}
@@ -1079,6 +1233,14 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 {reprintingKot ? 'Reprinting…' : '🖨 Reprint KOT'}
               </button>
             )}
+
+            <button
+              type="button"
+              onClick={() => { void openTransferModal() }}
+              className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-amber-400 border-2 border-zinc-700 hover:border-amber-600 transition-colors mb-3"
+            >
+              ↔ Move Table
+            </button>
 
             <button
               type="button"

--- a/apps/web/app/tables/[id]/order/[order_id]/transferOrderApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/transferOrderApi.ts
@@ -1,0 +1,28 @@
+export async function callTransferOrder(
+  supabaseUrl: string,
+  accessToken: string,
+  orderId: string,
+  targetTableId: string,
+): Promise<void> {
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
+  const res = await fetch(`${supabaseUrl}/functions/v1/transfer_order`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ order_id: orderId, target_table_id: targetTableId }),
+  })
+
+  if (!res.ok) {
+    let message = 'Failed to transfer order'
+    try {
+      const data = (await res.json()) as { error?: string }
+      if (data.error) message = data.error
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(message)
+  }
+}

--- a/supabase/functions/transfer_order/index.ts
+++ b/supabase/functions/transfer_order/index.ts
@@ -1,0 +1,180 @@
+import { verifyAndGetCaller } from '../_shared/auth.ts'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { status: 200, headers: corsHeaders })
+  }
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  // Verify JWT and check minimum role
+  const caller = await verifyAndGetCaller(req, env.supabaseUrl, env.serviceKey, 'server', fetchFn)
+  if ('error' in caller) {
+    return new Response(
+      JSON.stringify({ success: false, error: caller.error }),
+      { status: caller.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid or missing request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  if (typeof payload['order_id'] !== 'string' || payload['order_id'] === '') {
+    return new Response(
+      JSON.stringify({ success: false, error: 'order_id is required and must be a non-empty string' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (typeof payload['target_table_id'] !== 'string' || payload['target_table_id'] === '') {
+    return new Response(
+      JSON.stringify({ success: false, error: 'target_table_id is required and must be a non-empty string' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const orderId = payload['order_id'] as string
+  const targetTableId = payload['target_table_id'] as string
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    // 1. Fetch the order — must be open
+    const orderRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=id,status,table_id&id=eq.${orderId}`,
+      { headers: dbHeaders },
+    )
+    if (!orderRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch order' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const orders = (await orderRes.json()) as Array<{ id: string; status: string; table_id: string }>
+    if (orders.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order not found' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const order = orders[0]
+    if (order.status !== 'open') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order is not open' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 2. Fetch the target table — must exist
+    const tableRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/tables?select=id,label&id=eq.${targetTableId}`,
+      { headers: dbHeaders },
+    )
+    if (!tableRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch target table' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const tables = (await tableRes.json()) as Array<{ id: string; label: string }>
+    if (tables.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Target table not found' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 3. Check target table has no other open order
+    const occupiedRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=id&table_id=eq.${targetTableId}&status=eq.open`,
+      { headers: dbHeaders },
+    )
+    if (!occupiedRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to check target table occupancy' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const occupiedOrders = (await occupiedRes.json()) as Array<{ id: string }>
+    if (occupiedOrders.length > 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Target table already has an open order' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 4. Update the order's table_id
+    const updateRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
+      {
+        method: 'PATCH',
+        headers: { ...dbHeaders, Prefer: 'return=minimal' },
+        body: JSON.stringify({ table_id: targetTableId }),
+      },
+    )
+    if (!updateRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to transfer order' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data: { order_id: orderId, new_table_id: targetTableId } }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+}
+
+if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
+}


### PR DESCRIPTION
## Summary

Closes #163

Implements table transfer: move an active (open) order from one table to another.

## Changes

### Edge function: `transfer_order`
- Verifies caller has `server` role minimum
- Validates the order exists and is `open`
- Validates the target table exists
- Checks the target table has no existing open order
- Updates `orders.table_id` and returns `{ order_id, new_table_id }`
- Returns 400 on validation errors (not open, occupied, not found)

### Client helper: `transferOrderApi.ts`
- POST to `/functions/v1/transfer_order` with user JWT Bearer token

### UI: `OrderDetailClient.tsx`
- Added **↔ Move Table** button in the order step, below Reprint KOT, above Cancel order
- Bottom-sheet modal lists all empty (unoccupied) tables fetched from the REST API
- Tables shown as a card grid with label + green "Empty" badge
- Click a table → confirmation step: "Move order to [Table]?"
- On confirm: calls `callTransferOrder`, then navigates to the new URL
- Loading and error states throughout

### `user-context.tsx`
- Added `accessToken` to `UserContextValue` — captures the Supabase JWT from `getSession()` and `onAuthStateChange`, making it available throughout the app for authenticated edge function calls