### PR TITLE
feat(#165,#166,#167): Admin Reporting Dashboard — sales, item rankings, payment breakdown

### DIFF
--- a/apps/web/app/admin/AdminNav.tsx
+++ b/apps/web/app/admin/AdminNav.tsx
@@ -15,6 +15,7 @@ const NAV_LINKS: NavLink[] = [
   { href: '/admin/tables', label: 'Tables' },
   { href: '/admin/pricing', label: 'Pricing' },
   { href: '/admin/users', label: 'Users' },
+  { href: '/admin/reports', label: '📊 Reports' },
   { href: '/admin/settings/printer', label: '🖨 Printer' },
 ]
 

--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -1,0 +1,307 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import type { JSX } from 'react'
+import { useUser } from '@/lib/user-context'
+import { callGetReports } from './reportsApi'
+import type { ReportData, ReportPeriod } from './reportsApi'
+import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
+
+const PERIOD_LABELS: { value: ReportPeriod; label: string }[] = [
+  { value: 'today', label: 'Today' },
+  { value: 'week', label: 'This Week' },
+  { value: 'month', label: 'This Month' },
+  { value: 'custom', label: 'Custom' },
+]
+
+function SummaryCard({ label, value }: { label: string; value: string | number }): JSX.Element {
+  return (
+    <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6 flex flex-col gap-2">
+      <span className="text-sm font-medium text-zinc-400 uppercase tracking-wide">{label}</span>
+      <span className="text-3xl font-bold text-white">{value}</span>
+    </div>
+  )
+}
+
+interface BarChartProps {
+  data: Array<{ date: string; revenue_cents: number }>
+}
+
+function BarChart({ data }: BarChartProps): JSX.Element {
+  if (data.length === 0) {
+    return <div className="text-zinc-500 text-sm py-4">No data for this period</div>
+  }
+
+  const maxRevenue = Math.max(...data.map(d => d.revenue_cents), 1)
+  const chartHeight = 160
+  const barWidth = Math.max(20, Math.min(48, Math.floor(600 / data.length) - 4))
+  const gap = 4
+  const totalWidth = data.length * (barWidth + gap)
+
+  return (
+    <div className="overflow-x-auto">
+      <svg
+        width={Math.max(totalWidth, 300)}
+        height={chartHeight + 40}
+        className="block"
+        aria-label="Revenue bar chart"
+      >
+        {data.map((d, i) => {
+          const barHeight = Math.max(2, Math.round((d.revenue_cents / maxRevenue) * chartHeight))
+          const x = i * (barWidth + gap)
+          const y = chartHeight - barHeight
+          const label = d.date.slice(5) // MM-DD
+          return (
+            <g key={d.date}>
+              <rect
+                x={x}
+                y={y}
+                width={barWidth}
+                height={barHeight}
+                rx={4}
+                className="fill-amber-500"
+              />
+              <title>{`${d.date}: ${formatPrice(d.revenue_cents, DEFAULT_CURRENCY_SYMBOL)}`}</title>
+              <text
+                x={x + barWidth / 2}
+                y={chartHeight + 16}
+                textAnchor="middle"
+                fontSize={10}
+                className="fill-zinc-400"
+                fill="#a1a1aa"
+              >
+                {label}
+              </text>
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+export default function ReportsDashboard(): JSX.Element {
+  const { accessToken } = useUser()
+  const [period, setPeriod] = useState<ReportPeriod>('today')
+  const [customFrom, setCustomFrom] = useState('')
+  const [customTo, setCustomTo] = useState('')
+  const [data, setData] = useState<ReportData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+
+  const fetchReports = useCallback(async (
+    p: ReportPeriod,
+    from?: string,
+    to?: string,
+  ): Promise<void> => {
+    if (!accessToken) return
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await callGetReports(supabaseUrl, accessToken, p, from, to)
+      setData(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load reports')
+    } finally {
+      setLoading(false)
+    }
+  }, [accessToken, supabaseUrl])
+
+  useEffect(() => {
+    if (period !== 'custom') {
+      void fetchReports(period)
+    }
+  }, [period, fetchReports])
+
+  function handleCustomFetch(): void {
+    if (!customFrom || !customTo) return
+    void fetchReports('custom', customFrom, customTo)
+  }
+
+  const totalRevenue = data ? formatPrice(data.summary.total_revenue_cents, DEFAULT_CURRENCY_SYMBOL) : '—'
+  const avgOrder = data ? formatPrice(data.summary.avg_order_cents, DEFAULT_CURRENCY_SYMBOL) : '—'
+  const totalPaymentRevenue = data
+    ? data.payment_breakdown.reduce((sum, p) => sum + p.revenue_cents, 0)
+    : 0
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <h1 className="text-2xl font-bold text-white">Reports</h1>
+        <div className="flex flex-wrap items-center gap-2">
+          {PERIOD_LABELS.map(({ value, label }) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setPeriod(value)}
+              className={[
+                'px-4 py-2 rounded-xl text-sm font-medium transition-colors min-h-[40px]',
+                period === value
+                  ? 'bg-amber-500 text-black'
+                  : 'bg-zinc-800 text-zinc-300 hover:bg-zinc-700 border border-zinc-700',
+              ].join(' ')}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Custom date range picker */}
+      {period === 'custom' && (
+        <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-4 flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-zinc-400 font-medium">From</label>
+            <input
+              type="date"
+              value={customFrom}
+              onChange={e => setCustomFrom(e.target.value)}
+              className="bg-zinc-700 text-white rounded-xl px-3 py-2 text-sm border border-zinc-600 focus:outline-none focus:border-amber-500"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs text-zinc-400 font-medium">To</label>
+            <input
+              type="date"
+              value={customTo}
+              onChange={e => setCustomTo(e.target.value)}
+              className="bg-zinc-700 text-white rounded-xl px-3 py-2 text-sm border border-zinc-600 focus:outline-none focus:border-amber-500"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={handleCustomFetch}
+            disabled={!customFrom || !customTo}
+            className="px-4 py-2 rounded-xl bg-amber-500 text-black font-medium text-sm hover:bg-amber-400 disabled:opacity-50 disabled:cursor-not-allowed min-h-[40px]"
+          >
+            Apply
+          </button>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="bg-red-900 border border-red-700 rounded-xl p-4 text-red-200 text-sm">
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="text-zinc-400 text-sm py-4 text-center animate-pulse">Loading reports…</div>
+      )}
+
+      {/* Row 1 — Summary cards */}
+      {data && (
+        <>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <SummaryCard label="Total Revenue" value={totalRevenue} />
+            <SummaryCard label="Orders" value={data.summary.order_count} />
+            <SummaryCard label="Avg Order" value={avgOrder} />
+            <SummaryCard label="Covers" value={data.summary.total_covers} />
+          </div>
+
+          {/* Row 2 — Revenue chart */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+            <h2 className="text-base font-semibold text-white mb-4">Revenue by Day</h2>
+            <BarChart data={data.revenue_by_day} />
+          </div>
+
+          {/* Row 3 — Top Items + Payment breakdown */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {/* Top Items */}
+            <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+              <h2 className="text-base font-semibold text-white mb-4">Top Items</h2>
+              {data.top_items.length === 0 ? (
+                <p className="text-zinc-500 text-sm">No item data for this period</p>
+              ) : (
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-zinc-400 border-b border-zinc-700">
+                      <th className="pb-2 pr-3 font-medium">#</th>
+                      <th className="pb-2 pr-3 font-medium">Item</th>
+                      <th className="pb-2 pr-3 font-medium text-right">Qty</th>
+                      <th className="pb-2 font-medium text-right">Revenue</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {data.top_items.map((item, idx) => (
+                      <tr key={item.name} className="border-b border-zinc-700/50">
+                        <td className="py-2 pr-3 text-zinc-400">{idx + 1}</td>
+                        <td className="py-2 pr-3 text-white font-medium">{item.name}</td>
+                        <td className="py-2 pr-3 text-zinc-300 text-right">{item.quantity_sold}</td>
+                        <td className="py-2 text-amber-400 text-right font-medium">
+                          {formatPrice(item.revenue_cents, DEFAULT_CURRENCY_SYMBOL)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+
+            {/* Payment Breakdown */}
+            <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+              <h2 className="text-base font-semibold text-white mb-4">Payment Methods</h2>
+              {data.payment_breakdown.length === 0 ? (
+                <p className="text-zinc-500 text-sm">No payment data for this period</p>
+              ) : (
+                <div className="space-y-3">
+                  {data.payment_breakdown.map(p => {
+                    const pct = totalPaymentRevenue > 0
+                      ? Math.round((p.revenue_cents / totalPaymentRevenue) * 100)
+                      : 0
+                    return (
+                      <div key={p.method}>
+                        <div className="flex justify-between text-sm mb-1">
+                          <span className="text-white font-medium capitalize">{p.method}</span>
+                          <span className="text-zinc-400">
+                            {p.count} orders · {formatPrice(p.revenue_cents, DEFAULT_CURRENCY_SYMBOL)} · {pct}%
+                          </span>
+                        </div>
+                        <div className="h-2 bg-zinc-700 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-amber-500 rounded-full transition-all"
+                            style={{ width: `${pct}%` }}
+                          />
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Row 4 — Discounts & Comps */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+            <h2 className="text-base font-semibold text-white mb-4">Discounts &amp; Comps</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="bg-zinc-900 rounded-xl p-4">
+                <div className="text-xs text-zinc-400 uppercase tracking-wide mb-1">Discounted Orders</div>
+                <div className="text-2xl font-bold text-white">{data.discount_summary.discount_order_count}</div>
+                <div className="text-sm text-zinc-400 mt-1">
+                  Total: {formatPrice(data.discount_summary.total_discount_cents, DEFAULT_CURRENCY_SYMBOL)}
+                </div>
+              </div>
+              <div className="bg-zinc-900 rounded-xl p-4">
+                <div className="text-xs text-zinc-400 uppercase tracking-wide mb-1">Comped Orders</div>
+                <div className="text-2xl font-bold text-white">{data.discount_summary.comp_order_count}</div>
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Empty state */}
+      {!loading && !data && !error && (
+        <div className="text-zinc-500 text-sm text-center py-12">
+          Select a period to load reports
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/app/admin/reports/page.tsx
+++ b/apps/web/app/admin/reports/page.tsx
@@ -1,0 +1,6 @@
+import type { JSX } from 'react'
+import ReportsDashboard from './ReportsDashboard'
+
+export default function ReportsPage(): JSX.Element {
+  return <ReportsDashboard />
+}

--- a/apps/web/app/admin/reports/reportsApi.ts
+++ b/apps/web/app/admin/reports/reportsApi.ts
@@ -1,0 +1,79 @@
+export interface ReportSummary {
+  total_revenue_cents: number
+  order_count: number
+  avg_order_cents: number
+  total_covers: number
+}
+
+export interface RevenueByDay {
+  date: string
+  revenue_cents: number
+}
+
+export interface TopItem {
+  name: string
+  quantity_sold: number
+  revenue_cents: number
+}
+
+export interface PaymentBreakdown {
+  method: string
+  count: number
+  revenue_cents: number
+}
+
+export interface DiscountSummary {
+  discount_order_count: number
+  total_discount_cents: number
+  comp_order_count: number
+}
+
+export interface ReportData {
+  summary: ReportSummary
+  revenue_by_day: RevenueByDay[]
+  top_items: TopItem[]
+  payment_breakdown: PaymentBreakdown[]
+  discount_summary: DiscountSummary
+}
+
+interface GetReportsResponse {
+  success: boolean
+  data?: ReportData
+  error?: string
+}
+
+export type ReportPeriod = 'today' | 'week' | 'month' | 'custom'
+
+export async function callGetReports(
+  supabaseUrl: string,
+  accessToken: string,
+  period: ReportPeriod,
+  from?: string,
+  to?: string,
+): Promise<ReportData> {
+  const body: { period: ReportPeriod; from?: string; to?: string } = { period }
+  if (period === 'custom' && from && to) {
+    body.from = from
+    body.to = to
+  }
+
+  const res = await fetch(`${supabaseUrl}/functions/v1/get_reports`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`get_reports failed: ${res.status} ${res.statusText} — ${text}`)
+  }
+
+  const json = (await res.json()) as GetReportsResponse
+  if (!json.success || !json.data) {
+    throw new Error(json.error ?? 'Failed to fetch reports')
+  }
+  return json.data
+}

--- a/supabase/functions/get_reports/index.ts
+++ b/supabase/functions/get_reports/index.ts
@@ -1,0 +1,269 @@
+import { verifyAndGetCaller } from '../_shared/auth.ts'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+type Period = 'today' | 'week' | 'month' | 'custom'
+
+interface RequestBody {
+  period: Period
+  from?: string
+  to?: string
+}
+
+function getDateRange(period: Period, from?: string, to?: string): { start: string; end: string } {
+  const now = new Date()
+  // Use UTC dates for consistent filtering
+  if (period === 'custom' && from && to) {
+    // Expect ISO date strings like "2026-03-01"; treat as UTC start/end of day
+    return {
+      start: `${from}T00:00:00.000Z`,
+      end: `${to}T23:59:59.999Z`,
+    }
+  }
+  if (period === 'today') {
+    const dateStr = now.toISOString().slice(0, 10)
+    return {
+      start: `${dateStr}T00:00:00.000Z`,
+      end: `${dateStr}T23:59:59.999Z`,
+    }
+  }
+  if (period === 'week') {
+    const day = now.getUTCDay() // 0=Sun
+    const diff = now.getUTCDate() - day + (day === 0 ? -6 : 1) // Monday
+    const monday = new Date(now)
+    monday.setUTCDate(diff)
+    const start = monday.toISOString().slice(0, 10)
+    const end = now.toISOString().slice(0, 10)
+    return {
+      start: `${start}T00:00:00.000Z`,
+      end: `${end}T23:59:59.999Z`,
+    }
+  }
+  // month
+  const year = now.getUTCFullYear()
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const start = `${year}-${month}-01`
+  const end = now.toISOString().slice(0, 10)
+  return {
+    start: `${start}T00:00:00.000Z`,
+    end: `${end}T23:59:59.999Z`,
+  }
+}
+
+interface OrderRow {
+  final_total_cents: number | null
+  covers: number | null
+  discount_amount_cents: number | null
+  order_comp: boolean | null
+  payment_method: string | null
+  created_at: string
+}
+
+interface OrderItemRow {
+  menu_item_id: string
+  quantity: number
+  unit_price_cents: number
+  menu_items: { name: string } | null
+}
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const caller = await verifyAndGetCaller(req, env.supabaseUrl, env.serviceKey, 'owner', fetchFn)
+  if ('error' in caller) {
+    return new Response(
+      JSON.stringify({ success: false, error: caller.error }),
+      { status: caller.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  const period = payload['period'] as Period | undefined
+  if (!period || !['today', 'week', 'month', 'custom'].includes(period)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'period must be one of: today, week, month, custom' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (period === 'custom') {
+    if (typeof payload['from'] !== 'string' || typeof payload['to'] !== 'string') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'from and to are required for custom period' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+  }
+
+  const { start, end } = getDateRange(period, payload['from'] as string | undefined, payload['to'] as string | undefined)
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    // Fetch all paid orders in range
+    const ordersRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=final_total_cents,covers,discount_amount_cents,order_comp,payment_method,created_at&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&limit=10000`,
+      { headers: dbHeaders },
+    )
+    if (!ordersRes.ok) {
+      const errText = await ordersRes.text()
+      return new Response(
+        JSON.stringify({ success: false, error: `Failed to fetch orders: ${errText}` }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const orders = (await ordersRes.json()) as OrderRow[]
+
+    // 1. Sales summary
+    let totalRevenueCents = 0
+    let totalCovers = 0
+    for (const o of orders) {
+      totalRevenueCents += o.final_total_cents ?? 0
+      totalCovers += o.covers ?? 0
+    }
+    const orderCount = orders.length
+    const avgOrderCents = orderCount > 0 ? Math.round(totalRevenueCents / orderCount) : 0
+
+    // 2. Revenue by day
+    const revenueByDayMap: Record<string, number> = {}
+    for (const o of orders) {
+      const date = o.created_at.slice(0, 10)
+      revenueByDayMap[date] = (revenueByDayMap[date] ?? 0) + (o.final_total_cents ?? 0)
+    }
+    const revenueByDay = Object.entries(revenueByDayMap)
+      .map(([date, revenue_cents]) => ({ date, revenue_cents }))
+      .sort((a, b) => a.date.localeCompare(b.date))
+
+    // 3. Payment method breakdown
+    const paymentMap: Record<string, { count: number; revenue_cents: number }> = {}
+    for (const o of orders) {
+      const method = o.payment_method ?? 'unknown'
+      if (!paymentMap[method]) paymentMap[method] = { count: 0, revenue_cents: 0 }
+      paymentMap[method].count += 1
+      paymentMap[method].revenue_cents += o.final_total_cents ?? 0
+    }
+    const paymentBreakdown = Object.entries(paymentMap).map(([method, v]) => ({
+      method,
+      count: v.count,
+      revenue_cents: v.revenue_cents,
+    }))
+
+    // 4. Discount/comp summary
+    let discountOrderCount = 0
+    let totalDiscountCents = 0
+    let compOrderCount = 0
+    for (const o of orders) {
+      if (o.order_comp === true) {
+        compOrderCount += 1
+      }
+      if ((o.discount_amount_cents ?? 0) > 0) {
+        discountOrderCount += 1
+        totalDiscountCents += o.discount_amount_cents ?? 0
+      }
+    }
+
+    // 5. Top items — fetch order_items for paid orders in range via join
+    // Use a separate query with date range on the orders table via join
+    const itemsRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/order_items?select=menu_item_id,quantity,unit_price_cents,menu_items(name),orders!inner(status,created_at)&orders.status=eq.paid&orders.created_at=gte.${encodeURIComponent(start)}&orders.created_at=lte.${encodeURIComponent(end)}&limit=50000`,
+      { headers: dbHeaders },
+    )
+
+    let topItems: Array<{ name: string; quantity_sold: number; revenue_cents: number }> = []
+    if (itemsRes.ok) {
+      const rawItems = (await itemsRes.json()) as Array<OrderItemRow & { orders?: unknown }>
+      const itemMap: Record<string, { name: string; quantity: number; revenue: number }> = {}
+      for (const item of rawItems) {
+        const id = item.menu_item_id
+        const name = (item.menu_items && 'name' in item.menu_items) ? (item.menu_items as { name: string }).name : id
+        if (!itemMap[id]) itemMap[id] = { name, quantity: 0, revenue: 0 }
+        itemMap[id].quantity += item.quantity
+        itemMap[id].revenue += item.quantity * item.unit_price_cents
+      }
+      topItems = Object.values(itemMap)
+        .sort((a, b) => b.quantity - a.quantity)
+        .slice(0, 10)
+        .map(i => ({ name: i.name, quantity_sold: i.quantity, revenue_cents: i.revenue }))
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          summary: {
+            total_revenue_cents: totalRevenueCents,
+            order_count: orderCount,
+            avg_order_cents: avgOrderCents,
+            total_covers: totalCovers,
+          },
+          revenue_by_day: revenueByDay,
+          top_items: topItems,
+          payment_breakdown: paymentBreakdown,
+          discount_summary: {
+            discount_order_count: discountOrderCount,
+            total_discount_cents: totalDiscountCents,
+            comp_order_count: compOrderCount,
+          },
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ success: false, error: err instanceof Error ? err.message : 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+}
+
+if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
+}


### PR DESCRIPTION
## Summary

Implements #165, #166, #167 — Admin Reporting Dashboard.

## Changes

### New edge function: `get_reports`
- **Auth:** requires `owner` role via JWT Bearer token
- **Queries:** sales summary, revenue by day, top 10 items, payment method breakdown, discount/comp summary
- Supports periods: `today`, `week`, `month`, `custom` (with `from`/`to` ISO date strings)

### New admin page: `/admin/reports`
- **Period selector**: Today / This Week / This Month / Custom date range picker
- **Row 1 — Summary cards**: Total Revenue, Orders, Avg Order, Covers
- **Row 2 — Revenue bar chart**: SVG inline chart, no external library
- **Row 3 — Two columns**: Top Items ranking table + Payment method breakdown with progress bars + % of total
- **Row 4 — Discounts & Comps**: discounted order count + total, comped order count
- Dark theme matching existing admin UI (`bg-zinc-900`, `bg-zinc-800`, amber accents)
- Uses `formatPrice` / `DEFAULT_CURRENCY_SYMBOL` from shared lib

### AdminNav update
- Added 📊 Reports link to sidebar navigation

## Auth pattern
Edge function calls use user JWT Bearer token from `useUser().accessToken` (already available in `user-context.tsx`).

Closes #165, #166, #167