### PR TITLE
fix: sync missing split bill migration to unblock CI

### DIFF
--- a/supabase/migrations/20260326140000_add_split_bill.sql
+++ b/supabase/migrations/20260326140000_add_split_bill.sql
@@ -1,0 +1,6 @@
+-- Migration: Add split bill support (seat assignment + covers count)
+ALTER TABLE order_items
+  ADD COLUMN IF NOT EXISTS seat INTEGER;
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS covers INTEGER DEFAULT 1;


### PR DESCRIPTION
Migration `20260326140000` was applied to Supabase directly by the split-bill agent but the file only existed on the feature branch. CI was failing with 'Remote migration versions not found in local migrations directory'.