### PR TITLE
fix: ensure open shift for E2E tests (fix CI failures)

### DIFF
--- a/apps/web/global-setup.ts
+++ b/apps/web/global-setup.ts
@@ -124,6 +124,54 @@ async function globalSetup(_config: FullConfig): Promise<void> {
   await staffContext.close()
 
   await browser.close()
+
+  // Ensure a shift is open so E2E tests that create orders can proceed.
+  // The E2E tests hit the real Vercel deployment; without an open shift,
+  // clicking a table redirects to /shifts and all order-flow tests fail.
+  await ensureShiftOpen(supabaseUrl, anonKey, adminEmail, adminPassword)
+}
+
+async function ensureShiftOpen(
+  supabaseUrl: string,
+  anonKey: string,
+  adminEmail: string,
+  adminPassword: string,
+): Promise<void> {
+  // Get admin JWT
+  const authRes = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: anonKey },
+    body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+  })
+  if (!authRes.ok) return
+  const session = (await authRes.json()) as { access_token: string }
+  const jwt = session.access_token
+
+  // Check if a shift is already open via REST
+  const shiftRes = await fetch(
+    `${supabaseUrl}/rest/v1/shifts?select=id,status&status=eq.open&limit=1`,
+    { headers: { apikey: anonKey, Authorization: `Bearer ${jwt}` } },
+  )
+  if (!shiftRes.ok) return
+  const openShifts = (await shiftRes.json()) as Array<{ id: string }>
+  if (openShifts.length > 0) return // shift already open
+
+  // Open a shift
+  const openRes = await fetch(`${supabaseUrl}/functions/v1/open_shift`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ opening_float: 0 }),
+  })
+  if (!openRes.ok) {
+    const t = await openRes.text()
+    console.warn('[global-setup] Could not open shift:', openRes.status, t)
+  } else {
+    console.log('[global-setup] Opened a shift for E2E tests')
+  }
 }
 
 export default globalSetup

--- a/apps/web/global-teardown.ts
+++ b/apps/web/global-teardown.ts
@@ -1,0 +1,54 @@
+/**
+ * Global teardown: close the shift that was opened in global-setup.ts so the
+ * production database is left in a clean state after E2E tests finish.
+ */
+
+async function globalTeardown(): Promise<void> {
+  const supabaseUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? 'https://dmaogdwtgohrhbytxjqu.supabase.co'
+  const anonKey =
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ??
+    'sb_publishable_IzsBL3KELStvo6bioFKWhA_dMj81UxH'
+  const adminEmail = process.env.E2E_ADMIN_EMAIL
+  const adminPassword = process.env.E2E_ADMIN_PASSWORD
+
+  if (!adminEmail || !adminPassword) return
+
+  // Get admin JWT
+  const authRes = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', apikey: anonKey },
+    body: JSON.stringify({ email: adminEmail, password: adminPassword }),
+  })
+  if (!authRes.ok) return
+  const session = (await authRes.json()) as { access_token: string }
+  const jwt = session.access_token
+
+  // Find the open shift
+  const shiftRes = await fetch(
+    `${supabaseUrl}/rest/v1/shifts?select=id&status=eq.open&limit=1`,
+    { headers: { apikey: anonKey, Authorization: `Bearer ${jwt}` } },
+  )
+  if (!shiftRes.ok) return
+  const openShifts = (await shiftRes.json()) as Array<{ id: string }>
+  if (openShifts.length === 0) return
+
+  // Close the shift
+  const closeRes = await fetch(`${supabaseUrl}/functions/v1/close_shift`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ shift_id: openShifts[0].id, closing_float: 0 }),
+  })
+  if (!closeRes.ok) {
+    const t = await closeRes.text()
+    console.warn('[global-teardown] Could not close shift:', closeRes.status, t)
+  } else {
+    console.log('[global-teardown] Closed E2E test shift')
+  }
+}
+
+export default globalTeardown

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -6,6 +6,7 @@ export const STORAGE_STATE = path.join(__dirname, 'e2e/.auth/admin.json');
 export default defineConfig({
   testDir: './e2e',
   globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000',


### PR DESCRIPTION
All order-flow E2E tests were failing because clicking a table redirects to `/shifts` when there's no open shift.

**Fix:** `global-setup.ts` now checks for an open shift and opens one if needed. `global-teardown.ts` closes it afterward to leave production clean.