### PR TITLE
fix(e2e): fix httpOnly cookie bug + mock auth in affected E2E specs

### DIFF
--- a/apps/web/e2e/bill-print.spec.ts
+++ b/apps/web/e2e/bill-print.spec.ts
@@ -16,6 +16,23 @@ test.describe('Print Bill button', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test.beforeEach(async ({ page }) => {
+    // Mock Supabase auth session so UserContext.accessToken is always populated.
+    // Without this, getSession() returns null in CI and edge function calls throw
+    // 'Not authenticated' before reaching the mocked routes below.
+    await page.route('**/auth/v1/token**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-test-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'e2e-refresh-token',
+          user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' },
+        }),
+      });
+    });
+
     // Mock tables list
     await page.route('**/rest/v1/tables**', async (route) => {
       await route.fulfill({

--- a/apps/web/e2e/modifier-selection.spec.ts
+++ b/apps/web/e2e/modifier-selection.spec.ts
@@ -44,6 +44,10 @@ test.describe('modifier selection — direct add (no modifiers)', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test('clicking Add on an item without modifiers does not show a modal', async ({ page }) => {
+    // Mock auth session so UserContext.accessToken is populated
+    await page.route('**/auth/v1/token**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ access_token: 'e2e-test-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'e2e-refresh', user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' } }) })
+    })
     // Intercept the Supabase REST calls to inject a menu item without modifiers
     await page.route('**/rest/v1/orders**', async (route) => {
       await route.fulfill({
@@ -94,6 +98,9 @@ test.describe('modifier selection — modal flow (item with modifiers)', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test('clicking Add on an item with modifiers shows the selection modal', async ({ page }) => {
+    await page.route('**/auth/v1/token**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ access_token: 'e2e-test-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'e2e-refresh', user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' } }) })
+    })
     await page.route('**/rest/v1/orders**', async (route) => {
       await route.fulfill({
         status: 200,

--- a/apps/web/e2e/payment-completion.spec.ts
+++ b/apps/web/e2e/payment-completion.spec.ts
@@ -18,6 +18,21 @@ test.describe('post-payment completion flow', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test.beforeEach(async ({ page }) => {
+    // Mock Supabase auth session so UserContext.accessToken is always populated.
+    await page.route('**/auth/v1/token**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-test-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'e2e-refresh-token',
+          user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' },
+        }),
+      });
+    });
+
     // Mock tables list — table starts as occupied (has an open order)
     await page.route('**/rest/v1/tables**', async (route) => {
       await route.fulfill({

--- a/apps/web/global-setup.ts
+++ b/apps/web/global-setup.ts
@@ -70,7 +70,10 @@ async function buildStorageState(
     value: chunk,
     domain: 'localhost',
     path: '/',
-    httpOnly: true,
+    // Must be false: Supabase createBrowserClient reads session via document.cookie.
+    // httpOnly cookies are invisible to JavaScript and would prevent getSession()
+    // from finding the token in E2E tests.
+    httpOnly: false,
     secure: false,
     sameSite: 'Lax',
   }))


### PR DESCRIPTION
Still-failing E2E tests after PR #204. Two root causes:

1. **httpOnly cookies**: `global-setup.ts` was creating cookies with `httpOnly: true`. Supabase `createBrowserClient` reads session via `document.cookie`, which cannot access httpOnly cookies → `getSession()` always returned null → `accessToken = null` → handlers threw 'Not authenticated'.

2. **Belt-and-suspenders auth mock**: Added `**/auth/v1/token**` route mock to the three affected spec `beforeEach` blocks so `UserContext` always gets a token regardless of cookie parsing.