### PR TITLE
fix(e2e): correct base64url cookie encoding for @supabase/ssr v0.9

### DIFF
--- a/apps/web/e2e/bill-print.spec.ts
+++ b/apps/web/e2e/bill-print.spec.ts
@@ -16,21 +16,22 @@ test.describe('Print Bill button', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test.beforeEach(async ({ page }) => {
-    // Mock Supabase auth session so UserContext.accessToken is always populated.
-    // Without this, getSession() returns null in CI and edge function calls throw
-    // 'Not authenticated' before reaching the mocked routes below.
-    await page.route('**/auth/v1/token**', async (route) => {
+    // Mock Supabase auth so UserContext.accessToken + role are populated.
+    // getUser() is called by getUserRole(); getSession() reads from cookies (set via storageState).
+    await page.route('**/auth/v1/user**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          access_token: 'e2e-test-token',
-          token_type: 'bearer',
-          expires_in: 3600,
-          refresh_token: 'e2e-refresh-token',
-          user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' },
-        }),
+        body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001', email: 'admin@lahore.ikitchen.com.bd', role: 'authenticated' }),
       });
+    });
+    await page.route('**/rest/v1/users?**', async (route) => {
+      const url = route.request().url();
+      if (url.includes('select=role')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ role: 'owner' }]) });
+      } else {
+        await route.continue();
+      }
     });
 
     // Mock tables list

--- a/apps/web/e2e/modifier-selection.spec.ts
+++ b/apps/web/e2e/modifier-selection.spec.ts
@@ -44,9 +44,14 @@ test.describe('modifier selection — direct add (no modifiers)', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test('clicking Add on an item without modifiers does not show a modal', async ({ page }) => {
-    // Mock auth session so UserContext.accessToken is populated
-    await page.route('**/auth/v1/token**', async (route) => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ access_token: 'e2e-test-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'e2e-refresh', user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' } }) })
+    // Mock Supabase auth so UserContext.accessToken + role are populated.
+    await page.route('**/auth/v1/user**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001', email: 'admin@lahore.ikitchen.com.bd', role: 'authenticated' }) })
+    })
+    await page.route('**/rest/v1/users?**', async (route) => {
+      if (route.request().url().includes('select=role')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ role: 'owner' }]) })
+      } else { await route.continue() }
     })
     // Intercept the Supabase REST calls to inject a menu item without modifiers
     await page.route('**/rest/v1/orders**', async (route) => {
@@ -98,8 +103,13 @@ test.describe('modifier selection — modal flow (item with modifiers)', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test('clicking Add on an item with modifiers shows the selection modal', async ({ page }) => {
-    await page.route('**/auth/v1/token**', async (route) => {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ access_token: 'e2e-test-token', token_type: 'bearer', expires_in: 3600, refresh_token: 'e2e-refresh', user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' } }) })
+    await page.route('**/auth/v1/user**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001', email: 'admin@lahore.ikitchen.com.bd', role: 'authenticated' }) })
+    })
+    await page.route('**/rest/v1/users?**', async (route) => {
+      if (route.request().url().includes('select=role')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ role: 'owner' }]) })
+      } else { await route.continue() }
     })
     await page.route('**/rest/v1/orders**', async (route) => {
       await route.fulfill({

--- a/apps/web/e2e/payment-completion.spec.ts
+++ b/apps/web/e2e/payment-completion.spec.ts
@@ -18,19 +18,21 @@ test.describe('post-payment completion flow', () => {
   test.use({ storageState: 'e2e/.auth/admin.json' })
 
   test.beforeEach(async ({ page }) => {
-    // Mock Supabase auth session so UserContext.accessToken is always populated.
-    await page.route('**/auth/v1/token**', async (route) => {
+    // Mock Supabase auth so UserContext.accessToken + role are populated.
+    await page.route('**/auth/v1/user**', async (route) => {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          access_token: 'e2e-test-token',
-          token_type: 'bearer',
-          expires_in: 3600,
-          refresh_token: 'e2e-refresh-token',
-          user: { id: '00000000-0000-0000-0000-000000000001', role: 'authenticated' },
-        }),
+        body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001', email: 'admin@lahore.ikitchen.com.bd', role: 'authenticated' }),
       });
+    });
+    await page.route('**/rest/v1/users?**', async (route) => {
+      const url = route.request().url();
+      if (url.includes('select=role')) {
+        await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([{ role: 'owner' }]) });
+      } else {
+        await route.continue();
+      }
     });
 
     // Mock tables list — table starts as occupied (has an open order)

--- a/apps/web/global-setup.ts
+++ b/apps/web/global-setup.ts
@@ -13,8 +13,11 @@ import { chromium, type FullConfig } from '@playwright/test'
 
 interface AuthSession {
   access_token: string
-  refresh_token: string
+  token_type: string
+  expires_in: number
   expires_at?: number
+  refresh_token: string
+  user: Record<string, unknown>
 }
 
 interface CookieEntry {
@@ -49,14 +52,26 @@ async function buildStorageState(
 
   const session = (await res.json()) as AuthSession
 
-  // Build the Supabase SSR session cookie value (matches @supabase/ssr format)
+  // Build the Supabase SSR session cookie value.
+  // @supabase/ssr v0.9+ encodes session cookies as "base64-" + base64url(sessionJSON).
+  // Storing raw JSON (as was done before) causes getSession() to silently return null.
   const projectRef = new URL(supabaseUrl).hostname.split('.')[0]
   const cookieName = `sb-${projectRef}-auth-token`
-  const cookieValue = JSON.stringify({
+  const sessionJson = JSON.stringify({
     access_token: session.access_token,
-    refresh_token: session.refresh_token,
+    token_type: session.token_type ?? 'bearer',
+    expires_in: session.expires_in ?? 3600,
     expires_at: session.expires_at ?? Math.floor(Date.now() / 1000) + 3600,
+    refresh_token: session.refresh_token,
+    user: session.user ?? {},
   })
+  // base64url encode (no padding, URL-safe chars) and prefix with "base64-"
+  const base64url = Buffer.from(sessionJson, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  const cookieValue = `base64-${base64url}`
 
   // Supabase SSR chunks cookies >3180 chars across .0, .1 etc.
   const chunkSize = 3180


### PR DESCRIPTION
**Root cause found:** `@supabase/ssr` v0.9 stores session cookies as `base64-` + base64url(JSON). `global-setup.ts` was storing raw JSON → `getSession()` silently returned null → `accessToken = null` → every edge function call threw 'Not authenticated'.\n\n**Fixes:**\n- Encode cookie correctly as `base64-` + base64url\n- Include all required session fields (token_type, expires_in, user)\n- Mock `/auth/v1/user` + `/rest/v1/users` in affected specs so `getUserRole()` also works