### PR TITLE
fix: add missing apikey header to get_reports call

### DIFF
--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -90,6 +90,7 @@ export default function ReportsDashboard(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
 
   const fetchReports = useCallback(async (
     p: ReportPeriod,
@@ -100,7 +101,7 @@ export default function ReportsDashboard(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const result = await callGetReports(supabaseUrl, accessToken, p, from, to)
+      const result = await callGetReports(supabaseUrl, accessToken, anonKey, p, from, to)
       setData(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load reports')

--- a/apps/web/app/admin/reports/reportsApi.ts
+++ b/apps/web/app/admin/reports/reportsApi.ts
@@ -47,6 +47,7 @@ export type ReportPeriod = 'today' | 'week' | 'month' | 'custom'
 export async function callGetReports(
   supabaseUrl: string,
   accessToken: string,
+  anonKey: string,
   period: ReportPeriod,
   from?: string,
   to?: string,
@@ -62,6 +63,7 @@ export async function callGetReports(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
+      apikey: anonKey,
     },
     body: JSON.stringify(body),
   })


### PR DESCRIPTION
Reports page showed '401 Unauthorized — Invalid JWT' because `reportsApi.ts` was missing the `apikey` header. Supabase gateway needs both `Authorization: Bearer <JWT>` and `apikey: <anon-key>` to route and authenticate the request.