### PR TITLE
fix: bulk import auth — surface real errors, guard null token

### DIFF
--- a/apps/web/app/admin/menu/import/ImportMenuClient.tsx
+++ b/apps/web/app/admin/menu/import/ImportMenuClient.tsx
@@ -111,7 +111,7 @@ export default function ImportMenuClient(): JSX.Element {
           media_type: file.type,
         }))
       )
-      const items = await callExtractMenuBulk(supabaseUrl, accessToken ?? '', filePayloads)
+      const items = await callExtractMenuBulk(supabaseUrl, accessToken ?? null, filePayloads)
       const draftRows: DraftRow[] = items.map((item, i) => ({
         ...item,
         rowId: `row-${i}-${Date.now()}`,
@@ -190,7 +190,7 @@ export default function ImportMenuClient(): JSX.Element {
 
         await callCreateMenuItem(
           supabaseUrl,
-          accessToken ?? '',
+          accessToken ?? null,
           menuId,
           item.name,
           priceCents,

--- a/apps/web/app/admin/menu/import/extractMenuBulkApi.ts
+++ b/apps/web/app/admin/menu/import/extractMenuBulkApi.ts
@@ -7,11 +7,13 @@ export interface ExtractedMenuItemDraft {
 
 export async function callExtractMenuBulk(
   supabaseUrl: string,
-  accessToken: string,
+  accessToken: string | null,
   files: Array<{ data: string; media_type: string }>,
 ): Promise<ExtractedMenuItemDraft[]> {
   const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
   const url = `${supabaseUrl}/functions/v1/extract_menu_bulk`
+  if (!accessToken) throw new Error('Not authenticated — please log in and try again.')
+
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -21,6 +23,15 @@ export async function callExtractMenuBulk(
     },
     body: JSON.stringify({ files }),
   })
+
+  if (!res.ok) {
+    let msg = `HTTP ${res.status}`
+    try {
+      const errJson = (await res.json()) as { message?: string; error?: string }
+      msg = errJson.message ?? errJson.error ?? msg
+    } catch { /* ignore parse error */ }
+    throw new Error(msg)
+  }
 
   const json = (await res.json()) as { success: boolean; items?: ExtractedMenuItemDraft[]; error?: string }
   if (!json.success) {

--- a/apps/web/app/admin/menu/menuAdminApi.ts
+++ b/apps/web/app/admin/menu/menuAdminApi.ts
@@ -74,7 +74,7 @@ export async function callDeleteMenu(
 
 export async function callCreateMenuItem(
   supabaseUrl: string,
-  accessToken: string,
+  accessToken: string | null,
   menuId: string,
   name: string,
   priceCents: number,
@@ -83,6 +83,7 @@ export async function callCreateMenuItem(
   imageUrl?: string,
   available = true,
 ): Promise<string> {
+  if (!accessToken) throw new Error('Not authenticated')
   const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
   const res = await fetch(`${supabaseUrl}/functions/v1/create_menu_item`, {
     method: 'POST',


### PR DESCRIPTION
**Problem:** When `accessToken` is null (or the Supabase gateway returns a non-standard 401), the bulk import showed 'Bulk extraction failed' with no useful info. Root cause: `!json.success` evaluates to `true` for any response that isn't `{success: true}` (including gateway 401 JSON), and the fallback string hides the real error.\n\n**Fix:**\n- Check `res.ok` first; extract error from gateway response if not OK\n- Accept `string | null` in API wrappers and throw 'Not authenticated' early\n- Remove `?? ''` null-token fallback in `ImportMenuClient`