### PR TITLE
fix: remove apikey header from edge function calls (fixes 401 Invalid JWT)

### DIFF
--- a/apps/web/app/admin/menu/extractMenuItemApi.ts
+++ b/apps/web/app/admin/menu/extractMenuItemApi.ts
@@ -18,7 +18,6 @@ export async function callExtractMenuItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: apiKey,
     },
     body: JSON.stringify({ file_data: fileData, media_type: mediaType }),
   })
@@ -43,7 +42,6 @@ export async function uploadMenuFile(
     method: 'POST',
     headers: {
       Authorization: `Bearer ${apiKey}`,
-      apikey: apiKey,
       'Content-Type': file.type,
     },
     body: file,

--- a/apps/web/app/admin/menu/import/extractMenuBulkApi.ts
+++ b/apps/web/app/admin/menu/import/extractMenuBulkApi.ts
@@ -19,7 +19,6 @@ export async function callExtractMenuBulk(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: apiKey,
     },
     body: JSON.stringify({ files }),
   })

--- a/apps/web/app/admin/menu/menuAdminApi.ts
+++ b/apps/web/app/admin/menu/menuAdminApi.ts
@@ -6,7 +6,6 @@ export interface ModifierInput {
 function buildHeaders(apiKey: string, withPreferRepresentation = false): Record<string, string> {
   const h: Record<string, string> = {
     'Content-Type': 'application/json',
-    apikey: apiKey,
     Authorization: `Bearer ${apiKey}`,
   }
   if (withPreferRepresentation) h['Prefer'] = 'return=representation'
@@ -90,7 +89,6 @@ export async function callCreateMenuItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: apiKey,
     },
     body: JSON.stringify({
       menu_id: menuId,
@@ -125,7 +123,6 @@ export async function callUpdateMenuItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: apiKey,
     },
     body: JSON.stringify({
       menu_item_id: menuItemId,
@@ -152,7 +149,6 @@ export async function callDeleteMenuItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: apiKey,
     },
     body: JSON.stringify({ menu_item_id: menuItemId }),
   })

--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -90,7 +90,6 @@ export default function ReportsDashboard(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
 
   const fetchReports = useCallback(async (
     p: ReportPeriod,
@@ -101,7 +100,7 @@ export default function ReportsDashboard(): JSX.Element {
     setLoading(true)
     setError(null)
     try {
-      const result = await callGetReports(supabaseUrl, accessToken, anonKey, p, from, to)
+      const result = await callGetReports(supabaseUrl, accessToken, p, from, to)
       setData(result)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load reports')

--- a/apps/web/app/admin/reports/reportsApi.ts
+++ b/apps/web/app/admin/reports/reportsApi.ts
@@ -47,7 +47,6 @@ export type ReportPeriod = 'today' | 'week' | 'month' | 'custom'
 export async function callGetReports(
   supabaseUrl: string,
   accessToken: string,
-  anonKey: string,
   period: ReportPeriod,
   from?: string,
   to?: string,
@@ -63,7 +62,6 @@ export async function callGetReports(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: anonKey,
     },
     body: JSON.stringify(body),
   })

--- a/apps/web/app/admin/tables/tableAdminApi.ts
+++ b/apps/web/app/admin/tables/tableAdminApi.ts
@@ -7,7 +7,6 @@ interface ActionResponse {
 function buildHeaders(apiKey: string): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    apikey: apiKey,
     Authorization: `Bearer ${apiKey}`,
   }
 }

--- a/apps/web/app/admin/users/userAdminApi.ts
+++ b/apps/web/app/admin/users/userAdminApi.ts
@@ -7,7 +7,6 @@ interface ActionResponse {
 function buildHeaders(apiKey: string): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    apikey: apiKey,
     Authorization: `Bearer ${apiKey}`,
   }
 }

--- a/apps/web/app/tables/[id]/order/[order_id]/applyDiscountApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/applyDiscountApi.ts
@@ -17,7 +17,6 @@ export async function callApplyDiscount(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: anonKey,
     },
     body: JSON.stringify({
       order_id: orderId,

--- a/apps/web/app/tables/[id]/order/[order_id]/compApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/compApi.ts
@@ -22,7 +22,6 @@ export async function callCompItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: anonKey,
     },
     body: JSON.stringify(body),
   })

--- a/apps/web/app/tables/[id]/order/[order_id]/recordPaymentApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/recordPaymentApi.ts
@@ -16,7 +16,6 @@ export async function callRecordPayment(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      apikey: apiKey,
       'x-demo-staff-id': '00000000-0000-0000-0000-000000000010',
     },
     body: JSON.stringify({ order_id: orderId, amount: amountCents, method, order_total_cents: orderTotalCents }),

--- a/apps/web/app/tables/[id]/order/[order_id]/splitBillApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/splitBillApi.ts
@@ -9,7 +9,6 @@ export async function callSetCovers(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? '',
     },
     body: JSON.stringify({ order_id: orderId, covers }),
   })
@@ -30,7 +29,6 @@ export async function callSetItemSeat(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? '',
     },
     body: JSON.stringify({ order_item_id: orderItemId, seat }),
   })

--- a/apps/web/app/tables/[id]/order/[order_id]/transferOrderApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/transferOrderApi.ts
@@ -10,7 +10,6 @@ export async function callTransferOrder(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
-      apikey: anonKey,
     },
     body: JSON.stringify({ order_id: orderId, target_table_id: targetTableId }),
   })

--- a/apps/web/app/tables/[id]/order/[order_id]/voidItemApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/voidItemApi.ts
@@ -15,7 +15,6 @@ export async function callVoidItem(
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${apiKey}`,
-      apikey: apiKey,
       'x-demo-staff-id': '00000000-0000-0000-0000-000000000010',
     },
     body: JSON.stringify({ order_item_id: orderItemId, reason }),


### PR DESCRIPTION
**Root cause:** `sb_publishable_*` is not a JWT. Sending it as `apikey` header to Supabase edge functions causes the gateway to reject with `401 Invalid JWT` — even when the Bearer JWT is valid.

**Rule:** Edge function calls need only `Authorization: Bearer <user_jwt>`. The `apikey` header is only for REST `/rest/v1/` calls.

**Affected:** get_reports, comp_item, apply_discount, transfer_order, set_covers, set_item_seat, extract_menu_bulk, void_item, record_payment, menu admin APIs, user admin APIs.