### PR TITLE
fix: Back to Tables always goes to /tables, not placeholder stub

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -336,7 +336,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       }
     }
 
-    router.push(`/tables/${tableId}`)
+    router.push('/tables')
   }
 
   // Reprint KOT: show all items (no side effects — does NOT call markItemsSentToKitchen)
@@ -467,7 +467,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         throw new Error('Not authenticated')
       }
       await callCancelOrder(supabaseUrl, accessToken, orderId, cancelReason)
-      router.push(`/tables/${tableId}`)
+      router.push('/tables')
     } catch (err) {
       setCancelError(err instanceof Error ? err.message : 'Failed to cancel order')
     } finally {
@@ -1646,7 +1646,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
             <button
               type="button"
-              onClick={() => { router.push(`/tables/${tableId}`) }}
+              onClick={() => { router.push('/tables') }}
               className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-white transition-colors"
             >
               Cancel

--- a/apps/web/app/tables/[id]/page.tsx
+++ b/apps/web/app/tables/[id]/page.tsx
@@ -1,23 +1,12 @@
-import type { JSX } from 'react'
-import Link from 'next/link'
+import { redirect } from 'next/navigation'
 
 interface PageProps {
   params: Promise<{ id: string }>
 }
 
-export default async function TableDetailPage({ params }: PageProps): Promise<JSX.Element> {
-  const { id } = await params
-
-  return (
-    <main className="min-h-screen bg-zinc-900 p-6">
-      <Link
-        href="/tables"
-        className="inline-block text-zinc-400 hover:text-white text-base mb-8 min-h-[48px] min-w-[48px] flex items-center gap-2"
-      >
-        ← Back to Tables
-      </Link>
-      <h1 className="text-2xl font-bold text-white">Table {id}</h1>
-      <p className="text-zinc-400 mt-4 text-base">Table detail — coming soon.</p>
-    </main>
-  )
+// There is no standalone table detail page — tables only exist in the context of an order.
+// Redirect to the tables list so users never land on a dead-end.
+export default async function TableDetailPage({ params }: PageProps): Promise<never> {
+  await params
+  redirect('/tables')
 }


### PR DESCRIPTION
After payment, cancel, or clicking Cancel in the payment modal, the app was routing to `/tables/${tableId}` which shows the 'Table detail — coming soon' placeholder. Fixed all three `router.push` calls to go to `/tables` directly. Also added a redirect on `/tables/[id]` so that page is never a dead-end.