### PR TITLE
fix: print only receipt — hide page content during print (#215)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -30,4 +30,21 @@ body {
     margin: 0;
     size: 80mm auto;
   }
+
+  /* Hide everything on the page — only the .print-area element and its children show */
+  body * {
+    visibility: hidden;
+  }
+
+  .print-area,
+  .print-area * {
+    visibility: visible;
+  }
+
+  .print-area {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 80mm;
+  }
 }

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -45,7 +45,7 @@ export default function BillPrintView({
   const vatCents = totalCents - subtotalCents
 
   return (
-    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="print-area hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       {/* Header */}
       <div className="text-center mb-2">
         <p className="text-base font-bold">Lahore by iKitchen</p>

--- a/apps/web/components/KotPrintView.tsx
+++ b/apps/web/components/KotPrintView.tsx
@@ -15,7 +15,7 @@ export default function KotPrintView({ tableId, orderId, items, timestamp, showA
   const displayItems = showAll ? items : items.filter((item) => !item.sent_to_kitchen)
 
   return (
-    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="print-area hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       <div className="text-center mb-2">
         <p className="text-base font-bold">Lahore by iKitchen</p>
         <p className="text-sm">KITCHEN ORDER TICKET</p>

--- a/apps/web/components/SplitBillPrintView.tsx
+++ b/apps/web/components/SplitBillPrintView.tsx
@@ -96,7 +96,7 @@ export default function SplitBillPrintView({
       <div
         id="split-bill-print-root"
         aria-hidden="true"
-        className="hidden print:block font-mono text-black bg-white w-full"
+        className="print-area hidden print:block font-mono text-black bg-white w-full"
       >
         {sections.map((section, idx) => (
           <div


### PR DESCRIPTION
Fixes #215. Add `body * { visibility: hidden }` + `.print-area` visibility pattern to `@media print` block, and add `print-area` class to all three print view wrappers (BillPrintView, SplitBillPrintView, KotPrintView).