### PR TITLE
fix: show table label in print views and fix Bengali currency symbol

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -46,5 +46,6 @@ body {
     top: 0;
     left: 0;
     width: 80mm;
+    font-family: var(--font-noto-sans), 'Noto Sans Bengali', Arial, sans-serif;
   }
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Noto_Sans_Bengali } from "next/font/google";
 import "./globals.css";
 import AppHeader from "@/components/AppHeader";
 import { UserProvider } from "@/lib/user-context";
@@ -12,6 +12,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const notoSansBengali = Noto_Sans_Bengali({
+  variable: "--font-noto-sans",
+  subsets: ["latin", "bengali"],
+  weight: ["400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -27,7 +33,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${notoSansBengali.variable} antialiased`}
       >
         <UserProvider>
           <AppHeader />

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -91,6 +91,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [billTimestamp, setBillTimestamp] = useState('')
   const [printingBill, setPrintingBill] = useState(false)
 
+  // Table label state
+  const [tableLabel, setTableLabel] = useState<string>('')
+
   // Covers / split bill state
   const [covers, setCovers] = useState(1)
   const [showSplitBill, setShowSplitBill] = useState(false)
@@ -231,12 +234,32 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       .catch(() => { /* non-fatal */ })
   }
 
+  function loadTableLabel(): void {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    if (!supabaseUrl || !supabaseKey) return
+    const url = new URL(`${supabaseUrl}/rest/v1/tables`)
+    url.searchParams.set('id', `eq.${tableId}`)
+    url.searchParams.set('select', 'label')
+    void fetch(url.toString(), {
+      headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` },
+    })
+      .then((r) => r.json())
+      .then((rows: Array<{ label: string }>) => {
+        if (rows.length > 0 && rows[0].label) {
+          setTableLabel(rows[0].label)
+        }
+      })
+      .catch(() => { /* non-fatal */ })
+  }
+
   useEffect(() => {
     loadItems()
     loadOrderStatus()
     loadVatConfig()
     loadPrinterConfig()
     loadCovers()
+    loadTableLabel()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orderId])
 
@@ -806,7 +829,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       {/* KOT print component — only marked as print-area when KOT is actively printing */}
       <div className={kotStatus !== null || reprintingKot ? 'print-area' : ''}>
         <KotPrintView
-          tableId={tableId}
+          tableLabel={tableLabel || tableId.slice(0, 8)}
           orderId={orderId}
           items={items}
           timestamp={kotTimestamp}
@@ -818,7 +841,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       {!splitBillPrinting && (
         <div className={printingBill ? 'print-area' : ''}>
           <BillPrintView
-            tableId={tableId}
+            tableLabel={tableLabel || tableId.slice(0, 8)}
             orderId={orderId}
             items={items}
             subtotalCents={billSubtotalCents}
@@ -840,7 +863,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       {splitBillPrinting && (
         <div className="print-area">
           <SplitBillPrintView
-            tableId={tableId}
+            tableLabel={tableLabel || tableId.slice(0, 8)}
             orderId={orderId}
             items={items}
             covers={covers}

--- a/apps/web/components/BillPrintView.test.tsx
+++ b/apps/web/components/BillPrintView.test.tsx
@@ -11,7 +11,7 @@ const mockItems: OrderItem[] = [
     price_cents: 1500,
     modifier_ids: [],
     modifier_names: [],
-    sent_to_kitchen: true, comp: false, comp_reason: null,
+    sent_to_kitchen: true, comp: false, comp_reason: null, seat: null,
   },
   {
     id: '2',
@@ -20,7 +20,7 @@ const mockItems: OrderItem[] = [
     price_cents: 200,
     modifier_ids: [],
     modifier_names: [],
-    sent_to_kitchen: true, comp: false, comp_reason: null,
+    sent_to_kitchen: true, comp: false, comp_reason: null, seat: null,
   },
 ]
 
@@ -35,7 +35,7 @@ describe('BillPrintView', () => {
   it('renders the restaurant name', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -52,7 +52,7 @@ describe('BillPrintView', () => {
   it('renders the table and short order ID', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -63,14 +63,14 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.getByText('Table: 3')).toBeInTheDocument()
+    expect(screen.getByText('Table: Table 3')).toBeInTheDocument()
     expect(screen.getByText('Order: order-ab')).toBeInTheDocument()
   })
 
   it('renders the timestamp', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -87,7 +87,7 @@ describe('BillPrintView', () => {
   it('renders item names with quantity and line total', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -110,7 +110,7 @@ describe('BillPrintView', () => {
   it('renders the subtotal', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -129,7 +129,7 @@ describe('BillPrintView', () => {
   it('renders the VAT line with percent label and amount', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -148,7 +148,7 @@ describe('BillPrintView', () => {
   it('renders the total', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -167,7 +167,7 @@ describe('BillPrintView', () => {
   it('renders the payment method for card', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -185,7 +185,7 @@ describe('BillPrintView', () => {
   it('renders payment method for cash', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -204,7 +204,7 @@ describe('BillPrintView', () => {
   it('renders tendered amount and change due for cash payment', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -229,7 +229,7 @@ describe('BillPrintView', () => {
   it('does not render tendered/change rows for card payment', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -247,7 +247,7 @@ describe('BillPrintView', () => {
   it('does not render tendered/change rows when not provided for cash payment', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -265,7 +265,7 @@ describe('BillPrintView', () => {
   it('renders the thank-you footer', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -282,7 +282,7 @@ describe('BillPrintView', () => {
   it('is hidden on screen via aria-hidden', () => {
     const { container } = render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={mockItems}
         subtotalCents={SUBTOTAL}
@@ -302,7 +302,7 @@ describe('BillPrintView', () => {
   it('renders an empty items list gracefully', () => {
     render(
       <BillPrintView
-        tableId="3"
+        tableLabel="Table 3"
         orderId="order-abc-12345678"
         items={[]}
         subtotalCents={0}

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -4,7 +4,7 @@ import type { OrderItem } from '@/app/tables/[id]/order/[order_id]/orderData'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 
 export interface BillPrintViewProps {
-  tableId: string
+  tableLabel: string
   orderId: string
   items: OrderItem[]
   subtotalCents: number
@@ -25,7 +25,7 @@ export interface BillPrintViewProps {
 }
 
 export default function BillPrintView({
-  tableId,
+  tableLabel,
   orderId,
   items,
   subtotalCents,
@@ -55,7 +55,7 @@ export default function BillPrintView({
 
       {/* Order info */}
       <div className="border-t border-b border-black py-1 mb-2 text-sm">
-        <p>Table: {tableId}</p>
+        <p>Table: {tableLabel}</p>
         <p>Order: {orderId.slice(0, 8)}</p>
       </div>
 

--- a/apps/web/components/KotPrintView.tsx
+++ b/apps/web/components/KotPrintView.tsx
@@ -3,7 +3,7 @@ import type { JSX } from 'react'
 import type { OrderItem } from '@/app/tables/[id]/order/[order_id]/orderData'
 
 interface KotPrintViewProps {
-  tableId: string
+  tableLabel: string
   orderId: string
   items: OrderItem[]
   timestamp: string
@@ -11,7 +11,7 @@ interface KotPrintViewProps {
   showAll?: boolean
 }
 
-export default function KotPrintView({ tableId, orderId, items, timestamp, showAll = false }: KotPrintViewProps): JSX.Element {
+export default function KotPrintView({ tableLabel, orderId, items, timestamp, showAll = false }: KotPrintViewProps): JSX.Element {
   const displayItems = showAll ? items : items.filter((item) => !item.sent_to_kitchen)
 
   return (
@@ -22,7 +22,7 @@ export default function KotPrintView({ tableId, orderId, items, timestamp, showA
         {showAll && <p className="text-xs">(REPRINT)</p>}
       </div>
       <div className="border-t border-b border-black py-1 mb-2 text-sm">
-        <p>Table: {tableId}</p>
+        <p>Table: {tableLabel}</p>
         <p>Order: {orderId.slice(0, 8)}</p>
         <p>Time: {timestamp}</p>
       </div>

--- a/apps/web/components/SplitBillPrintView.tsx
+++ b/apps/web/components/SplitBillPrintView.tsx
@@ -4,7 +4,7 @@ import type { OrderItem } from '@/app/tables/[id]/order/[order_id]/orderData'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 
 export interface SplitBillPrintViewProps {
-  tableId: string
+  tableLabel: string
   orderId: string
   items: OrderItem[]
   covers: number
@@ -20,7 +20,7 @@ export interface SplitBillPrintViewProps {
  * Renders one section per seat (or per cover for even split).
  */
 export default function SplitBillPrintView({
-  tableId,
+  tableLabel,
   orderId,
   items,
   covers,
@@ -113,7 +113,7 @@ export default function SplitBillPrintView({
 
             {/* Order info */}
             <div className="border-t border-b border-black py-1 mb-2 text-sm">
-              <p>Table: {tableId}</p>
+              <p>Table: {tableLabel}</p>
               <p>Order: {orderId.slice(0, 8)}</p>
               <p className="font-bold">{section.label}</p>
             </div>


### PR DESCRIPTION
Closes #219

## Changes

### Bug 1: Table label instead of UUID in print views
- Added `tableLabel` state to `OrderDetailClient` initialized to `''`
- Added `loadTableLabel()` that fetches `/rest/v1/tables?id=eq.{tableId}&select=label`
- Called `loadTableLabel()` in the existing `useEffect`
- Pass `tableLabel={tableLabel || tableId.slice(0, 8)}` to all three print components
- Renamed `tableId: string` prop to `tableLabel: string` in `KotPrintView`, `BillPrintView`, and `SplitBillPrintView`

### Bug 2: Bengali Taka symbol ৳ renders correctly when printing
- Added `Noto_Sans_Bengali` font (subsets: latin + bengali) to `layout.tsx`
- Applied via CSS variable `--font-noto-sans` to `.print-area` in `globals.css` `@media print` block

### Test fixes
- Updated `BillPrintView.test.tsx` to use `tableLabel` prop and add missing `seat: null` to mock items