### PR TITLE
fix: KOT prints on 2 pages — conditional print-area

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -803,47 +803,53 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
   return (
     <main className="min-h-screen bg-zinc-900 p-6 flex flex-col">
-      {/* KOT print component — hidden on screen, visible only when printing */}
-      <KotPrintView
-        tableId={tableId}
-        orderId={orderId}
-        items={items}
-        timestamp={kotTimestamp}
-        showAll={kotShowAll}
-      />
-
-      {/* Bill print component — hidden on screen, visible only when printing */}
-      {!splitBillPrinting && (
-        <BillPrintView
+      {/* KOT print component — only marked as print-area when KOT is actively printing */}
+      <div className={kotStatus !== null || reprintingKot ? 'print-area' : ''}>
+        <KotPrintView
           tableId={tableId}
           orderId={orderId}
           items={items}
-          subtotalCents={billSubtotalCents}
-          vatPercent={vatPercent}
-          taxInclusive={taxInclusive}
-          totalCents={billTotalCents}
-          paymentMethod={billPaymentMethod}
-          amountTenderedCents={billAmountTenderedCents}
-          changeDueCents={billPaymentMethod === 'cash' ? changeDueCents : undefined}
-          timestamp={billTimestamp}
-          discountAmountCents={appliedDiscountCents}
-          discountLabel={appliedDiscountLabel}
-          orderComp={orderIsComp}
+          timestamp={kotTimestamp}
+          showAll={kotShowAll}
         />
+      </div>
+
+      {/* Bill print component — only marked as print-area when bill is actively printing */}
+      {!splitBillPrinting && (
+        <div className={printingBill ? 'print-area' : ''}>
+          <BillPrintView
+            tableId={tableId}
+            orderId={orderId}
+            items={items}
+            subtotalCents={billSubtotalCents}
+            vatPercent={vatPercent}
+            taxInclusive={taxInclusive}
+            totalCents={billTotalCents}
+            paymentMethod={billPaymentMethod}
+            amountTenderedCents={billAmountTenderedCents}
+            changeDueCents={billPaymentMethod === 'cash' ? changeDueCents : undefined}
+            timestamp={billTimestamp}
+            discountAmountCents={appliedDiscountCents}
+            discountLabel={appliedDiscountLabel}
+            orderComp={orderIsComp}
+          />
+        </div>
       )}
 
-      {/* Split bill print component — hidden on screen, visible only when split bill printing */}
+      {/* Split bill print component — only marked as print-area when split bill is printing */}
       {splitBillPrinting && (
-        <SplitBillPrintView
-          tableId={tableId}
-          orderId={orderId}
-          items={items}
-          covers={covers}
-          vatPercent={vatPercent}
-          taxInclusive={taxInclusive}
-          timestamp={splitBillTimestamp}
-          evenSplit={splitBillPrintMode === 'even'}
-        />
+        <div className="print-area">
+          <SplitBillPrintView
+            tableId={tableId}
+            orderId={orderId}
+            items={items}
+            covers={covers}
+            vatPercent={vatPercent}
+            taxInclusive={taxInclusive}
+            timestamp={splitBillTimestamp}
+            evenSplit={splitBillPrintMode === 'even'}
+          />
+        </div>
       )}
 
       {/* Split bill modal */}

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -45,7 +45,7 @@ export default function BillPrintView({
   const vatCents = totalCents - subtotalCents
 
   return (
-    <div aria-hidden="true" className="print-area hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       {/* Header */}
       <div className="text-center mb-2">
         <p className="text-base font-bold">Lahore by iKitchen</p>

--- a/apps/web/components/KotPrintView.tsx
+++ b/apps/web/components/KotPrintView.tsx
@@ -15,7 +15,7 @@ export default function KotPrintView({ tableId, orderId, items, timestamp, showA
   const displayItems = showAll ? items : items.filter((item) => !item.sent_to_kitchen)
 
   return (
-    <div aria-hidden="true" className="print-area hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       <div className="text-center mb-2">
         <p className="text-base font-bold">Lahore by iKitchen</p>
         <p className="text-sm">KITCHEN ORDER TICKET</p>

--- a/apps/web/components/SplitBillPrintView.tsx
+++ b/apps/web/components/SplitBillPrintView.tsx
@@ -96,7 +96,7 @@ export default function SplitBillPrintView({
       <div
         id="split-bill-print-root"
         aria-hidden="true"
-        className="print-area hidden print:block font-mono text-black bg-white w-full"
+        className="hidden print:block font-mono text-black bg-white w-full"
       >
         {sections.map((section, idx) => (
           <div


### PR DESCRIPTION
All three print views (KOT, Bill, SplitBill) had `print-area` class permanently. When KOT printed, Bill was also in the DOM with `print-area` → both printed → 2 pages.

**Fix:** move `print-area` to wrapper divs in `OrderDetailClient`, conditional on which view is actively printing (`kotStatus`/`reprintingKot`, `printingBill`, `splitBillPrinting`). Remove `print-area` from component-level classes.