### PR TITLE
test(e2e): E2E coverage for void item, payment, and bill print flows (#180)

### DIFF
--- a/apps/web/e2e/void-payment-bill.spec.ts
+++ b/apps/web/e2e/void-payment-bill.spec.ts
@@ -288,8 +288,8 @@ test.describe('void item, payment, and bill print flows', () => {
 
     // Change due screen
     await expect(page.getByRole('heading', { name: 'Change Due' })).toBeVisible()
-    // change_due is 2000 cents = ৳20
-    await expect(page.getByText(/20/)).toBeVisible()
+    // change_due is 2000 cents = ৳20.00 — use paragraph role to avoid strict mode violation
+    await expect(page.getByRole('paragraph').filter({ hasText: /20\.00/ })).toBeVisible()
 
     // Click Done
     await page.getByRole('button', { name: 'Done' }).click()


### PR DESCRIPTION
## Summary

Implements issue #180 — adds Playwright E2E spec covering:

1. **Void item flow**: open order → click Void on item → enter reason in dialog → confirm → item removed from list
2. **Payment full flow (cash)**: Close Order → enter cash amount → Confirm Payment → Change Due screen → Done → success state
3. **Print bill**: success state → Print Bill button visible → click → no JS console errors

## Test file
`apps/web/e2e/void-payment-bill.spec.ts`

## Notes
- All network calls mocked (no real Supabase calls)
- Follows the same auth + mock pattern as `payment-completion.spec.ts` and `bill-print.spec.ts`
- Uses `test.use({ storageState: 'e2e/.auth/admin.json' })`
- State tracking: order_items mock returns 1 item after void (simulating server response)
- TypeScript passes for the new file (pre-existing errors in other files are unrelated)