### PR TITLE
fix: void item 'Load failed' — wrong auth token + x-demo-staff-id

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/voidItemApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/voidItemApi.ts
@@ -6,21 +6,26 @@ export interface VoidItemResponse {
 
 export async function callVoidItem(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   orderItemId: string,
   reason: string,
 ): Promise<void> {
+  if (!accessToken) throw new Error('Not authenticated — please log in and try again.')
   const res = await fetch(`${supabaseUrl}/functions/v1/void_item`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-      'x-demo-staff-id': '00000000-0000-0000-0000-000000000010',
+      Authorization: `Bearer ${accessToken}`,
     },
     body: JSON.stringify({ order_item_id: orderItemId, reason }),
   })
   if (!res.ok) {
-    throw new Error(`HTTP ${res.status}`)
+    let errMsg = `HTTP ${res.status}`
+    try {
+      const body = (await res.json()) as { error?: string; message?: string }
+      errMsg = body.error ?? body.message ?? errMsg
+    } catch { /* ignore */ }
+    throw new Error(errMsg)
   }
   const json = (await res.json()) as VoidItemResponse
   if (!json.success) {


### PR DESCRIPTION
voidItemApi.ts was using the publishable key as Bearer JWT and still had x-demo-staff-id. Fixed: proper accessToken, no x-demo-staff-id, better error message extraction. Also redeployed void_item with --no-verify-jwt.