### PR TITLE
fix: admin table/user management edge calls use user JWT not publishable key

### DIFF
--- a/apps/web/app/admin/tables/TableManager.tsx
+++ b/apps/web/app/admin/tables/TableManager.tsx
@@ -5,6 +5,7 @@ import type { JSX } from 'react'
 import { fetchAdminTables, fetchRestaurantId } from './tableAdminData'
 import type { AdminTable } from './tableAdminData'
 import { callCreateTable, callUpdateTable, callDeleteTable } from './tableAdminApi'
+import { useUser } from '@/lib/user-context'
 
 interface TableFormValues {
   label: string
@@ -40,12 +41,13 @@ function validateForm(form: TableFormValues): TableFormErrors {
 }
 
 export default function TableManager(): JSX.Element {
+  const { accessToken } = useUser()
   const [tables, setTables] = useState<AdminTable[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
-  const supabaseConfig = useRef<{ url: string; key: string } | null>(null)
+  const supabaseConfig = useRef<{ url: string } | null>(null)
   const restaurantIdRef = useRef<string>('')
 
   const [showAddForm, setShowAddForm] = useState(false)
@@ -69,7 +71,7 @@ export default function TableManager(): JSX.Element {
       setLoading(false)
       return
     }
-    supabaseConfig.current = { url: supabaseUrl, key: supabaseKey }
+    supabaseConfig.current = { url: supabaseUrl }
 
     Promise.all([
       fetchRestaurantId(supabaseUrl, supabaseKey),
@@ -112,7 +114,7 @@ export default function TableManager(): JSX.Element {
       const seatCount = parseInt(addForm.seatCount, 10)
       const tableId = await callCreateTable(
         config.url,
-        config.key,
+        accessToken ?? '',
         restaurantIdRef.current,
         addForm.label.trim(),
         seatCount,
@@ -156,7 +158,7 @@ export default function TableManager(): JSX.Element {
     setSubmitting(true)
     try {
       const seatCount = parseInt(editForm.seatCount, 10)
-      await callUpdateTable(config.url, config.key, editingTableId, editForm.label.trim(), seatCount)
+      await callUpdateTable(config.url, accessToken ?? '', editingTableId, editForm.label.trim(), seatCount)
       const updatedLabel = editForm.label.trim()
       setTables((prev) =>
         prev.map((t) =>
@@ -187,7 +189,7 @@ export default function TableManager(): JSX.Element {
     const tableLabel = tables.find((t) => t.id === deletingTableId)?.label
     setSubmitting(true)
     try {
-      await callDeleteTable(config.url, config.key, deletingTableId)
+      await callDeleteTable(config.url, accessToken ?? '', deletingTableId)
       setTables((prev) => prev.filter((t) => t.id !== deletingTableId))
       setDeletingTableId(null)
       showFeedback('success', tableLabel ? `Table "${tableLabel}" deleted.` : 'Table deleted.')

--- a/apps/web/app/admin/tables/tableAdminApi.ts
+++ b/apps/web/app/admin/tables/tableAdminApi.ts
@@ -4,22 +4,22 @@ interface ActionResponse {
   error?: string
 }
 
-function buildHeaders(apiKey: string): Record<string, string> {
+function buildHeaders(accessToken: string): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${accessToken}`,
   }
 }
 
 async function callFunction(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   functionName: string,
   body: unknown,
 ): Promise<ActionResponse> {
   const res = await fetch(`${supabaseUrl}/functions/v1/${functionName}`, {
     method: 'POST',
-    headers: buildHeaders(apiKey),
+    headers: buildHeaders(accessToken),
     body: JSON.stringify(body),
   })
   const json = (await res.json().catch(() => ({ success: false, error: 'Request failed' }))) as ActionResponse
@@ -31,12 +31,12 @@ async function callFunction(
 
 export async function callCreateTable(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   restaurantId: string,
   label: string,
   seatCount: number,
 ): Promise<string> {
-  const result = await callFunction(supabaseUrl, apiKey, 'create_table', {
+  const result = await callFunction(supabaseUrl, accessToken, 'create_table', {
     restaurant_id: restaurantId,
     label,
     seat_count: seatCount,
@@ -49,12 +49,12 @@ export async function callCreateTable(
 
 export async function callUpdateTable(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   tableId: string,
   label: string,
   seatCount: number,
 ): Promise<void> {
-  const result = await callFunction(supabaseUrl, apiKey, 'update_table', {
+  const result = await callFunction(supabaseUrl, accessToken, 'update_table', {
     table_id: tableId,
     label,
     seat_count: seatCount,
@@ -66,10 +66,10 @@ export async function callUpdateTable(
 
 export async function callDeleteTable(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   tableId: string,
 ): Promise<void> {
-  const result = await callFunction(supabaseUrl, apiKey, 'delete_table', {
+  const result = await callFunction(supabaseUrl, accessToken, 'delete_table', {
     table_id: tableId,
   })
   if (!result.success) {

--- a/apps/web/app/admin/users/UserManager.tsx
+++ b/apps/web/app/admin/users/UserManager.tsx
@@ -8,6 +8,7 @@ import { callCreateUser, callToggleUserActive } from './userAdminApi'
 import { getUserRole } from '@/lib/user-role'
 import type { UserRole } from '@/lib/user-role'
 import { createBrowserClient } from '@supabase/ssr'
+import { useUser } from '@/lib/user-context'
 
 interface CreateFormValues {
   email: string
@@ -70,12 +71,13 @@ function roleBadgeClass(role: string): string {
 }
 
 export default function UserManager(): JSX.Element {
+  const { accessToken } = useUser()
   const [users, setUsers] = useState<AdminUser[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState<string | null>(null) // tracks which action is in-flight
 
-  const supabaseConfig = useRef<{ url: string; key: string } | null>(null)
+  const supabaseConfig = useRef<{ url: string } | null>(null)
   const restaurantIdRef = useRef<string>('')
   const [callerRole, setCallerRole] = useState<UserRole | null>(null)
 
@@ -94,7 +96,7 @@ export default function UserManager(): JSX.Element {
       setLoading(false)
       return
     }
-    supabaseConfig.current = { url: supabaseUrl, key: supabaseKey }
+    supabaseConfig.current = { url: supabaseUrl }
 
     // Identify caller's role for role-hierarchy enforcement in the UI
     const supabaseClient = createBrowserClient(supabaseUrl, supabaseKey)
@@ -139,7 +141,7 @@ export default function UserManager(): JSX.Element {
     if (!config || !callerRole) return
     setSubmitting('create')
     try {
-      const newUser = await callCreateUser(config.url, config.key, {
+      const newUser = await callCreateUser(config.url, accessToken ?? '', {
         email: createForm.email.trim().toLowerCase(),
         name: createForm.name.trim() || undefined,
         role: createForm.role,
@@ -164,7 +166,7 @@ export default function UserManager(): JSX.Element {
     const newActive = !user.is_active
     setSubmitting(`toggle-${user.id}`)
     try {
-      await callToggleUserActive(config.url, config.key, user.id, newActive)
+      await callToggleUserActive(config.url, accessToken ?? '', user.id, newActive)
       setUsers((prev) =>
         prev.map((u) => (u.id === user.id ? { ...u, is_active: newActive } : u)),
       )

--- a/apps/web/app/admin/users/userAdminApi.ts
+++ b/apps/web/app/admin/users/userAdminApi.ts
@@ -4,22 +4,22 @@ interface ActionResponse {
   error?: string
 }
 
-function buildHeaders(apiKey: string): Record<string, string> {
+function buildHeaders(accessToken: string): Record<string, string> {
   return {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${accessToken}`,
   }
 }
 
 async function callFunction(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   functionName: string,
   body: unknown,
 ): Promise<ActionResponse> {
   const res = await fetch(`${supabaseUrl}/functions/v1/${functionName}`, {
     method: 'POST',
-    headers: buildHeaders(apiKey),
+    headers: buildHeaders(accessToken),
     body: JSON.stringify(body),
   })
   const json = (await res.json().catch(() => ({ success: false, error: 'Request failed' }))) as ActionResponse
@@ -48,10 +48,10 @@ export interface CreatedUser {
 
 export async function callCreateUser(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   params: CreateUserParams,
 ): Promise<CreatedUser> {
-  const result = await callFunction(supabaseUrl, apiKey, 'create_user', {
+  const result = await callFunction(supabaseUrl, accessToken, 'create_user', {
     email: params.email,
     name: params.name ?? null,
     role: params.role,
@@ -66,11 +66,11 @@ export async function callCreateUser(
 
 export async function callToggleUserActive(
   supabaseUrl: string,
-  apiKey: string,
+  accessToken: string,
   userId: string,
   isActive: boolean,
 ): Promise<void> {
-  const result = await callFunction(supabaseUrl, apiKey, 'toggle_user_active', {
+  const result = await callFunction(supabaseUrl, accessToken, 'toggle_user_active', {
     user_id: userId,
     is_active: isActive,
   })


### PR DESCRIPTION
tableAdminApi.ts and userAdminApi.ts were passing the publishable key as Bearer JWT to create_table, update_table, delete_table, create_user, toggle_user_active. All use verifyAndGetCaller. Fixed by wiring useUser() accessToken and deploying all 5 functions with --no-verify-jwt.