### PR TITLE
fix: Back to Tables on empty order keeps table occupied (#233)

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -327,13 +327,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 
-    // Empty order — auto-cancel and go straight back, no KOT needed
-    if (items.length === 0 && supabaseUrl && accessToken) {
-      try {
-        await callCancelOrder(supabaseUrl, accessToken, orderId, 'Empty order — no items added')
-      } catch {
-        // Non-fatal: navigate anyway
-      }
+    // Empty order — just navigate back, keep the order open so the table stays occupied.
+    // (Auto-cancel only happens on explicit "Close Order" — see handleCloseOrder)
+    if (items.length === 0) {
       router.push('/tables')
       return
     }


### PR DESCRIPTION
Fixes #233. PR #221 auto-cancelled the order when Back to Tables was clicked with no items, clearing the occupied state. Now it just navigates back without cancelling — table stays occupied. Auto-cancel is kept on 'Close Order' for explicit cleanup.