### PR TITLE
feat(#227): CSV export from admin reporting dashboard

### DIFF
--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -3,9 +3,16 @@
 import { useState, useEffect, useCallback } from 'react'
 import type { JSX } from 'react'
 import { useUser } from '@/lib/user-context'
-import { callGetReports } from './reportsApi'
+import { callGetReports, callExportOrders } from './reportsApi'
 import type { ReportData, ReportPeriod, CompDetailItem, CompByItem } from './reportsApi'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
+import {
+  exportRevenueByDay,
+  exportTopItems,
+  exportPaymentBreakdown,
+  exportCompDetail,
+  exportOrderList,
+} from './csvExport'
 
 const PERIOD_LABELS: { value: ReportPeriod; label: string }[] = [
   { value: 'today', label: 'Today' },
@@ -13,6 +20,36 @@ const PERIOD_LABELS: { value: ReportPeriod; label: string }[] = [
   { value: 'month', label: 'This Month' },
   { value: 'custom', label: 'Custom' },
 ]
+
+interface ExportButtonProps {
+  onClick: () => void
+  loading?: boolean
+  label?: string
+}
+
+function ExportButton({ onClick, loading = false, label = 'Export CSV' }: ExportButtonProps): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={loading}
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-700 hover:bg-zinc-600 text-zinc-200 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-zinc-600"
+      aria-label={label}
+    >
+      {loading ? (
+        <svg className="animate-spin w-3.5 h-3.5 shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+      ) : (
+        <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
+        </svg>
+      )}
+      {label}
+    </button>
+  )
+}
 
 function SummaryCard({ label, value }: { label: string; value: string | number }): JSX.Element {
   return (
@@ -188,6 +225,8 @@ export default function ReportsDashboard(): JSX.Element {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [compTab, setCompTab] = useState<'detail' | 'breakdown'>('breakdown')
+  const [exportingOrders, setExportingOrders] = useState(false)
+  const [exportOrdersError, setExportOrdersError] = useState<string | null>(null)
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
 
@@ -218,6 +257,26 @@ export default function ReportsDashboard(): JSX.Element {
   function handleCustomFetch(): void {
     if (!customFrom || !customTo) return
     void fetchReports('custom', customFrom, customTo)
+  }
+
+  async function handleExportOrders(): Promise<void> {
+    if (!accessToken) return
+    setExportingOrders(true)
+    setExportOrdersError(null)
+    try {
+      const orders = await callExportOrders(
+        supabaseUrl,
+        accessToken,
+        period,
+        customFrom || undefined,
+        customTo || undefined,
+      )
+      exportOrderList(orders, period, customFrom || undefined, customTo || undefined)
+    } catch (err) {
+      setExportOrdersError(err instanceof Error ? err.message : 'Failed to export orders')
+    } finally {
+      setExportingOrders(false)
+    }
   }
 
   const totalRevenue = data ? formatPrice(data.summary.total_revenue_cents, DEFAULT_CURRENCY_SYMBOL) : '—'
@@ -306,7 +365,13 @@ export default function ReportsDashboard(): JSX.Element {
 
           {/* Row 2 — Revenue chart */}
           <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
-            <h2 className="text-base font-semibold text-white mb-4">Revenue by Day</h2>
+            <div className="flex items-center justify-between gap-3 mb-4">
+              <h2 className="text-base font-semibold text-white">Revenue by Day</h2>
+              <ExportButton
+                onClick={() => exportRevenueByDay(data, period, customFrom || undefined, customTo || undefined)}
+                label="Export CSV"
+              />
+            </div>
             <BarChart data={data.revenue_by_day} />
           </div>
 
@@ -314,7 +379,13 @@ export default function ReportsDashboard(): JSX.Element {
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
             {/* Top Items */}
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
-              <h2 className="text-base font-semibold text-white mb-4">Top Items</h2>
+              <div className="flex items-center justify-between gap-3 mb-4">
+                <h2 className="text-base font-semibold text-white">Top Items</h2>
+                <ExportButton
+                  onClick={() => exportTopItems(data, period, customFrom || undefined, customTo || undefined)}
+                  label="Export CSV"
+                />
+              </div>
               {data.top_items.length === 0 ? (
                 <p className="text-zinc-500 text-sm">No item data for this period</p>
               ) : (
@@ -345,7 +416,13 @@ export default function ReportsDashboard(): JSX.Element {
 
             {/* Payment Breakdown */}
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
-              <h2 className="text-base font-semibold text-white mb-4">Payment Methods</h2>
+              <div className="flex items-center justify-between gap-3 mb-4">
+                <h2 className="text-base font-semibold text-white">Payment Methods</h2>
+                <ExportButton
+                  onClick={() => exportPaymentBreakdown(data, period, customFrom || undefined, customTo || undefined)}
+                  label="Export CSV"
+                />
+              </div>
               {data.payment_breakdown.length === 0 ? (
                 <p className="text-zinc-500 text-sm">No payment data for this period</p>
               ) : (
@@ -411,7 +488,7 @@ export default function ReportsDashboard(): JSX.Element {
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
                 <h2 className="text-base font-semibold text-white">Comp Item Detail</h2>
-                <div className="flex gap-2">
+                <div className="flex items-center gap-2 flex-wrap">
                   <button
                     type="button"
                     onClick={() => setCompTab('breakdown')}
@@ -436,6 +513,10 @@ export default function ReportsDashboard(): JSX.Element {
                   >
                     Full Log
                   </button>
+                  <ExportButton
+                    onClick={() => exportCompDetail(data, period, customFrom || undefined, customTo || undefined)}
+                    label="Export CSV"
+                  />
                 </div>
               </div>
 
@@ -446,6 +527,26 @@ export default function ReportsDashboard(): JSX.Element {
               )}
             </div>
           )}
+
+          {/* Row 6 — Full Order List Export */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+              <div>
+                <h2 className="text-base font-semibold text-white">Full Order List</h2>
+                <p className="text-sm text-zinc-400 mt-0.5">
+                  Export all paid orders for this period — includes table, totals, payment method, discounts &amp; comps.
+                </p>
+              </div>
+              <ExportButton
+                onClick={() => void handleExportOrders()}
+                loading={exportingOrders}
+                label={exportingOrders ? 'Exporting…' : 'Export Orders CSV'}
+              />
+            </div>
+            {exportOrdersError && (
+              <p className="mt-3 text-sm text-red-400">{exportOrdersError}</p>
+            )}
+          </div>
         </>
       )}
 

--- a/apps/web/app/admin/reports/csvExport.ts
+++ b/apps/web/app/admin/reports/csvExport.ts
@@ -1,0 +1,136 @@
+import type { ReportData, ReportPeriod } from './reportsApi'
+import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+function escapeCell(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) return ''
+  const str = String(value)
+  // Wrap in quotes if it contains comma, quote, or newline
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+function buildCSV(headers: string[], rows: Array<Array<string | number | null | undefined>>): string {
+  const lines: string[] = [headers.map(escapeCell).join(',')]
+  for (const row of rows) {
+    lines.push(row.map(escapeCell).join(','))
+  }
+  return lines.join('\n')
+}
+
+export function downloadCSV(csvContent: string, filename: string): void {
+  const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  setTimeout(() => URL.revokeObjectURL(url), 10_000)
+}
+
+// ---------------------------------------------------------------------------
+// Filename helpers
+// ---------------------------------------------------------------------------
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function makeFilename(section: string, period: ReportPeriod, customFrom?: string, customTo?: string): string {
+  const periodLabel =
+    period === 'custom' && customFrom && customTo
+      ? `${customFrom}_to_${customTo}`
+      : period
+  return `ikitchen-report-${section}-${periodLabel}-${todayISO()}.csv`
+}
+
+// ---------------------------------------------------------------------------
+// Per-section export helpers
+// ---------------------------------------------------------------------------
+
+export function exportRevenueByDay(data: ReportData, period: ReportPeriod, customFrom?: string, customTo?: string): void {
+  const headers = ['Date', 'Order Count', 'Revenue']
+  const rows = data.revenue_by_day.map(r => [
+    r.date,
+    (r as { date: string; revenue_cents: number; order_count?: number }).order_count ?? '',
+    formatPrice(r.revenue_cents, DEFAULT_CURRENCY_SYMBOL),
+  ])
+  downloadCSV(buildCSV(headers, rows), makeFilename('revenue-by-day', period, customFrom, customTo))
+}
+
+export function exportTopItems(data: ReportData, period: ReportPeriod, customFrom?: string, customTo?: string): void {
+  const headers = ['Rank', 'Item', 'Qty Sold', 'Revenue']
+  const rows = data.top_items.map((item, idx) => [
+    idx + 1,
+    item.name,
+    item.quantity_sold,
+    formatPrice(item.revenue_cents, DEFAULT_CURRENCY_SYMBOL),
+  ])
+  downloadCSV(buildCSV(headers, rows), makeFilename('top-items', period, customFrom, customTo))
+}
+
+export function exportPaymentBreakdown(data: ReportData, period: ReportPeriod, customFrom?: string, customTo?: string): void {
+  const headers = ['Payment Method', 'Order Count', 'Revenue']
+  const rows = data.payment_breakdown.map(p => [
+    p.method,
+    p.count,
+    formatPrice(p.revenue_cents, DEFAULT_CURRENCY_SYMBOL),
+  ])
+  downloadCSV(buildCSV(headers, rows), makeFilename('payment-breakdown', period, customFrom, customTo))
+}
+
+export function exportCompDetail(data: ReportData, period: ReportPeriod, customFrom?: string, customTo?: string): void {
+  if (!data.comp_detail) return
+  const headers = ['Date', 'Type', 'Item', 'Qty', 'Unit Price', 'Total Value', 'Reason', 'Authorised By']
+  const rows = data.comp_detail.items.map(item => [
+    item.date.slice(0, 10),
+    item.type,
+    item.item_name,
+    item.quantity,
+    formatPrice(item.unit_price_cents, DEFAULT_CURRENCY_SYMBOL),
+    formatPrice(item.total_value_cents, DEFAULT_CURRENCY_SYMBOL),
+    item.reason ?? '',
+    item.authorised_by ?? '',
+  ])
+  downloadCSV(buildCSV(headers, rows), makeFilename('comp-detail', period, customFrom, customTo))
+}
+
+// ---------------------------------------------------------------------------
+// Full order list (data comes from export_orders edge function)
+// ---------------------------------------------------------------------------
+
+export interface ExportOrderRow {
+  order_id: string
+  table_label: string | null
+  created_at: string
+  final_total_cents: number
+  payment_methods: string
+  discount_amount_cents: number
+  order_comp: boolean
+}
+
+export function exportOrderList(
+  orders: ExportOrderRow[],
+  period: ReportPeriod,
+  customFrom?: string,
+  customTo?: string,
+): void {
+  const headers = ['Order ID', 'Table', 'Date', 'Total', 'Payment Method', 'Discount', 'Comp']
+  const rows = orders.map(o => [
+    o.order_id,
+    o.table_label ?? '',
+    o.created_at.slice(0, 19).replace('T', ' '),
+    formatPrice(o.final_total_cents, DEFAULT_CURRENCY_SYMBOL),
+    o.payment_methods,
+    o.discount_amount_cents > 0 ? formatPrice(o.discount_amount_cents, DEFAULT_CURRENCY_SYMBOL) : '',
+    o.order_comp ? 'Yes' : 'No',
+  ])
+  downloadCSV(buildCSV(headers, rows), makeFilename('orders', period, customFrom, customTo))
+}

--- a/apps/web/app/admin/reports/reportsApi.ts
+++ b/apps/web/app/admin/reports/reportsApi.ts
@@ -8,6 +8,7 @@ export interface ReportSummary {
 export interface RevenueByDay {
   date: string
   revenue_cents: number
+  order_count?: number
 }
 
 export interface TopItem {
@@ -70,6 +71,56 @@ interface GetReportsResponse {
 }
 
 export type ReportPeriod = 'today' | 'week' | 'month' | 'custom'
+
+export interface ExportOrderRow {
+  order_id: string
+  table_label: string | null
+  created_at: string
+  final_total_cents: number
+  payment_methods: string
+  discount_amount_cents: number
+  order_comp: boolean
+}
+
+interface ExportOrdersResponse {
+  success: boolean
+  data?: ExportOrderRow[]
+  error?: string
+}
+
+export async function callExportOrders(
+  supabaseUrl: string,
+  accessToken: string,
+  period: ReportPeriod,
+  from?: string,
+  to?: string,
+): Promise<ExportOrderRow[]> {
+  const body: { period: ReportPeriod; from?: string; to?: string } = { period }
+  if (period === 'custom' && from && to) {
+    body.from = from
+    body.to = to
+  }
+
+  const res = await fetch(`${supabaseUrl}/functions/v1/export_orders`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`export_orders failed: ${res.status} ${res.statusText} — ${text}`)
+  }
+
+  const json = (await res.json()) as ExportOrdersResponse
+  if (!json.success || !json.data) {
+    throw new Error(json.error ?? 'Failed to export orders')
+  }
+  return json.data
+}
 
 export async function callGetReports(
   supabaseUrl: string,

--- a/supabase/functions/export_orders/index.ts
+++ b/supabase/functions/export_orders/index.ts
@@ -1,0 +1,273 @@
+import { verifyAndGetCaller } from '../_shared/auth.ts'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+type Period = 'today' | 'week' | 'month' | 'custom'
+
+interface RequestBody {
+  period: Period
+  from?: string
+  to?: string
+}
+
+function getDateRange(period: Period, from?: string, to?: string): { start: string; end: string } {
+  const now = new Date()
+  if (period === 'custom' && from && to) {
+    return {
+      start: `${from}T00:00:00.000Z`,
+      end: `${to}T23:59:59.999Z`,
+    }
+  }
+  if (period === 'today') {
+    const dateStr = now.toISOString().slice(0, 10)
+    return {
+      start: `${dateStr}T00:00:00.000Z`,
+      end: `${dateStr}T23:59:59.999Z`,
+    }
+  }
+  if (period === 'week') {
+    const day = now.getUTCDay()
+    const diff = now.getUTCDate() - day + (day === 0 ? -6 : 1)
+    const monday = new Date(now)
+    monday.setUTCDate(diff)
+    const start = monday.toISOString().slice(0, 10)
+    const end = now.toISOString().slice(0, 10)
+    return {
+      start: `${start}T00:00:00.000Z`,
+      end: `${end}T23:59:59.999Z`,
+    }
+  }
+  // month
+  const year = now.getUTCFullYear()
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const start = `${year}-${month}-01`
+  const end = now.toISOString().slice(0, 10)
+  return {
+    start: `${start}T00:00:00.000Z`,
+    end: `${end}T23:59:59.999Z`,
+  }
+}
+
+interface OrderRow {
+  id: string
+  table_id: string | null
+  created_at: string
+  final_total_cents: number | null
+  discount_amount_cents: number | null
+  order_comp: boolean | null
+}
+
+interface TableRow {
+  id: string
+  label: string
+}
+
+interface PaymentRow {
+  order_id: string
+  method: string
+}
+
+export interface ExportOrderRow {
+  order_id: string
+  table_label: string | null
+  created_at: string
+  final_total_cents: number
+  payment_methods: string
+  discount_amount_cents: number
+  order_comp: boolean
+}
+
+export interface ExportOrdersResponse {
+  success: boolean
+  data?: ExportOrderRow[]
+  error?: string
+}
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const caller = await verifyAndGetCaller(req, env.supabaseUrl, env.serviceKey, 'owner', fetchFn)
+  if ('error' in caller) {
+    return new Response(
+      JSON.stringify({ success: false, error: caller.error }),
+      { status: caller.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  const period = payload['period'] as Period | undefined
+  if (!period || !['today', 'week', 'month', 'custom'].includes(period)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'period must be one of: today, week, month, custom' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (period === 'custom') {
+    if (typeof payload['from'] !== 'string' || typeof payload['to'] !== 'string') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'from and to are required for custom period' }),
+        { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+  }
+
+  const { start, end } = getDateRange(
+    period,
+    payload['from'] as string | undefined,
+    payload['to'] as string | undefined,
+  )
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+  }
+
+  try {
+    // Fetch paid orders in range (paginated with limit/offset to support large datasets)
+    const PAGE_SIZE = 1000
+    let offset = 0
+    const allOrders: OrderRow[] = []
+
+    while (true) {
+      const ordersRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/orders?select=id,table_id,created_at,final_total_cents,discount_amount_cents,order_comp` +
+          `&status=eq.paid` +
+          `&created_at=gte.${encodeURIComponent(start)}` +
+          `&created_at=lte.${encodeURIComponent(end)}` +
+          `&order=created_at.asc` +
+          `&limit=${PAGE_SIZE}&offset=${offset}`,
+        { headers: dbHeaders },
+      )
+      if (!ordersRes.ok) {
+        const errText = await ordersRes.text()
+        return new Response(
+          JSON.stringify({ success: false, error: `Failed to fetch orders: ${errText}` }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      const page = (await ordersRes.json()) as OrderRow[]
+      allOrders.push(...page)
+      if (page.length < PAGE_SIZE) break
+      offset += PAGE_SIZE
+    }
+
+    if (allOrders.length === 0) {
+      return new Response(
+        JSON.stringify({ success: true, data: [] }),
+        { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    const orderIds = allOrders.map(o => o.id)
+
+    // Fetch table labels for all unique table IDs
+    const tableIds = [...new Set(allOrders.map(o => o.table_id).filter((id): id is string => id !== null))]
+    const tableLabelMap: Record<string, string> = {}
+    if (tableIds.length > 0) {
+      const tablesRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/tables?select=id,label&id=in.(${tableIds.join(',')})`,
+        { headers: dbHeaders },
+      )
+      if (tablesRes.ok) {
+        const tables = (await tablesRes.json()) as TableRow[]
+        for (const t of tables) {
+          tableLabelMap[t.id] = t.label
+        }
+      }
+    }
+
+    // Fetch payments for all orders (paginated)
+    const paymentMethodMap: Record<string, string[]> = {}
+    let payOffset = 0
+    while (true) {
+      // PostgREST in(...) supports up to ~10k IDs but we chunk to be safe
+      const chunk = orderIds.slice(payOffset, payOffset + 500)
+      if (chunk.length === 0) break
+      const paymentsRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/payments?select=order_id,method&order_id=in.(${chunk.join(',')})&limit=5000`,
+        { headers: dbHeaders },
+      )
+      if (paymentsRes.ok) {
+        const payments = (await paymentsRes.json()) as PaymentRow[]
+        for (const p of payments) {
+          if (!paymentMethodMap[p.order_id]) paymentMethodMap[p.order_id] = []
+          if (!paymentMethodMap[p.order_id].includes(p.method)) {
+            paymentMethodMap[p.order_id].push(p.method)
+          }
+        }
+      }
+      payOffset += 500
+    }
+
+    // Build result rows
+    const result: ExportOrderRow[] = allOrders.map(o => ({
+      order_id: o.id,
+      table_label: o.table_id ? (tableLabelMap[o.table_id] ?? null) : null,
+      created_at: o.created_at,
+      final_total_cents: o.final_total_cents ?? 0,
+      payment_methods: (paymentMethodMap[o.id] ?? []).join(' + '),
+      discount_amount_cents: o.discount_amount_cents ?? 0,
+      order_comp: o.order_comp ?? false,
+    }))
+
+    return new Response(
+      JSON.stringify({ success: true, data: result }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ success: false, error: err instanceof Error ? err.message : 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+}
+
+if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
+}

--- a/supabase/functions/get_reports/index.ts
+++ b/supabase/functions/get_reports/index.ts
@@ -215,13 +215,15 @@ export async function handler(
     const avgOrderCents = orderCount > 0 ? Math.round(totalRevenueCents / orderCount) : 0
 
     // 2. Revenue by day
-    const revenueByDayMap: Record<string, number> = {}
+    const revenueByDayMap: Record<string, { revenue_cents: number; order_count: number }> = {}
     for (const o of orders) {
       const date = o.created_at.slice(0, 10)
-      revenueByDayMap[date] = (revenueByDayMap[date] ?? 0) + (o.final_total_cents ?? 0)
+      if (!revenueByDayMap[date]) revenueByDayMap[date] = { revenue_cents: 0, order_count: 0 }
+      revenueByDayMap[date].revenue_cents += o.final_total_cents ?? 0
+      revenueByDayMap[date].order_count += 1
     }
     const revenueByDay = Object.entries(revenueByDayMap)
-      .map(([date, revenue_cents]) => ({ date, revenue_cents }))
+      .map(([date, v]) => ({ date, revenue_cents: v.revenue_cents, order_count: v.order_count }))
       .sort((a, b) => a.date.localeCompare(b.date))
 
     // 3. Payment method breakdown — from the payments table (method stored there, not on orders)


### PR DESCRIPTION
## Summary

Closes #227 — adds CSV export functionality to the admin reporting dashboard.

## What was built

### Frontend changes
- **`csvExport.ts`** — new client-side CSV utility:
  - `exportRevenueByDay` — date, order count, revenue
  - `exportTopItems` — rank, item name, qty sold, revenue
  - `exportPaymentBreakdown` — payment method, order count, revenue
  - `exportCompDetail` — full comp log (date, type, item, qty, prices, reason, authorised by)
  - `exportOrderList` — full order list from `export_orders` edge function
  - Filename format: `ikitchen-report-{section}-{period}-{date}.csv`
  - UTF-8 BOM for Excel compatibility; no new npm packages

- **`ReportsDashboard.tsx`** — added:
  - `ExportButton` component (consistent dark Tailwind style with spinner state)
  - Per-section export buttons on: Revenue by Day, Top Items, Payment Methods, Comp Item Detail
  - New **Full Order List** section at the bottom with async export (calls `export_orders`)
  - Loading + error state for orders export

- **`reportsApi.ts`** — added:
  - `callExportOrders()` function targeting the new edge function
  - `ExportOrderRow` type
  - Extended `RevenueByDay` with optional `order_count`

### Backend changes
- **`supabase/functions/export_orders/index.ts`** — new edge function:
  - Owner-role auth (same pattern as `get_reports`)
  - Paginated order fetch (1 000 rows/page) for large datasets
  - Joins table label from `tables` table
  - Aggregates payment methods from `payments` table (chunked requests)
  - Returns: `order_id`, `table_label`, `created_at`, `final_total_cents`, `payment_methods`, `discount_amount_cents`, `order_comp`

- **`supabase/functions/get_reports/index.ts`** — minor enhancement:
  - `revenue_by_day` now includes `order_count` per day (used in CSV export)

## Testing
- TypeScript compiles cleanly (zero new errors in report files)
- All existing functionality unchanged