### PR TITLE
feat(#186): table status colours and floor plan view

### DIFF
--- a/apps/web/app/tables/components/TableCard.test.tsx
+++ b/apps/web/app/tables/components/TableCard.test.tsx
@@ -10,11 +10,14 @@ vi.mock('next/navigation', () => ({
   useRouter: (): { push: (url: string) => void } => ({ push: mockPush }),
 }))
 
-const emptyTable: TableRow = { id: 'table-uuid-001', label: '1', open_order_id: null }
+const emptyTable: TableRow = { id: 'table-uuid-001', label: '1', open_order_id: null, order_status: null, order_created_at: null }
+// order_created_at is 30 min ago so it always resolves to 'occupied' (not overdue)
 const occupiedTable: TableRow = {
   id: 'table-uuid-002',
   label: '2',
   open_order_id: 'order-abc-123',
+  order_status: 'open',
+  order_created_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
 }
 
 describe('TableCard', () => {

--- a/apps/web/app/tables/components/TableCard.tsx
+++ b/apps/web/app/tables/components/TableCard.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react'
 import { callCreateOrder } from './createOrderApi'
 import { useUser } from '@/lib/user-context'
 import type { TableRow } from '../tablesData'
+import { getTableStatus, STATUS_CONFIG } from '../tableStatus'
 
 interface TableCardProps {
   table: TableRow
@@ -16,6 +17,9 @@ export default function TableCard({ table }: TableCardProps): JSX.Element {
   const { accessToken } = useUser()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const status = getTableStatus(table)
+  const { label: statusLabel, cardClass, badgeClass } = STATUS_CONFIG[status]
   const isOccupied = table.open_order_id !== null
 
   async function handleTap(): Promise<void> {
@@ -51,9 +55,7 @@ export default function TableCard({ table }: TableCardProps): JSX.Element {
         'min-h-[160px] p-6 rounded-2xl border-2',
         'transition-colors select-none w-full',
         loading ? 'opacity-60 cursor-wait' : '',
-        isOccupied
-          ? 'bg-amber-700 border-amber-500 hover:bg-amber-600'
-          : 'bg-zinc-800 border-zinc-600 hover:border-zinc-400',
+        cardClass,
       ].join(' ')}
     >
       <span className="text-3xl font-bold text-white">
@@ -62,12 +64,10 @@ export default function TableCard({ table }: TableCardProps): JSX.Element {
       <span
         className={[
           'text-base font-semibold px-3 py-1 rounded-full',
-          isOccupied
-            ? 'bg-amber-500 text-white'
-            : 'bg-zinc-700 text-zinc-300',
+          badgeClass,
         ].join(' ')}
       >
-        {loading ? 'Creating…' : isOccupied ? 'Occupied' : 'Empty'}
+        {loading ? 'Creating…' : statusLabel}
       </span>
       {error !== null && (
         <span className="text-xs text-red-400 text-center break-words max-w-full">{error}</span>

--- a/apps/web/app/tables/page.test.tsx
+++ b/apps/web/app/tables/page.test.tsx
@@ -16,9 +16,9 @@ vi.mock('./components/TableCard', () => ({
 }))
 
 const MOCK_TABLES: TableRow[] = [
-  { id: 'table-uuid-001', label: '1', open_order_id: null },
-  { id: 'table-uuid-002', label: '2', open_order_id: 'order-uuid-001' },
-  { id: 'table-uuid-003', label: '3', open_order_id: null },
+  { id: 'table-uuid-001', label: '1', open_order_id: null, order_status: null, order_created_at: null },
+  { id: 'table-uuid-002', label: '2', open_order_id: 'order-uuid-001', order_status: 'open', order_created_at: '2026-03-27T10:00:00Z' },
+  { id: 'table-uuid-003', label: '3', open_order_id: null, order_status: null, order_created_at: null },
 ]
 
 const originalEnv = process.env

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -1,16 +1,29 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { JSX } from 'react'
 import Link from 'next/link'
 import TableCard from './components/TableCard'
 import { fetchTables } from './tablesData'
 import type { TableRow } from './tablesData'
+import { STATUS_CONFIG } from './tableStatus'
+import type { TableStatus } from './tableStatus'
+
+/** Auto-refresh interval in milliseconds (30 seconds) */
+const REFRESH_INTERVAL_MS = 30_000
+
+const STATUS_LEGEND: { status: TableStatus; label: string; dotClass: string }[] = [
+  { status: 'available', label: 'Empty', dotClass: 'bg-zinc-500' },
+  { status: 'occupied', label: 'Occupied', dotClass: 'bg-green-500' },
+  { status: 'bill_requested', label: 'Bill Requested', dotClass: 'bg-orange-500' },
+  { status: 'overdue', label: 'Overdue (>2h)', dotClass: 'bg-red-500' },
+]
 
 export default function TablesPage(): JSX.Element {
   const [tables, setTables] = useState<TableRow[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   const loadTables = useCallback((): void => {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -32,13 +45,33 @@ export default function TablesPage(): JSX.Element {
       .finally(() => { setLoading(false) })
   }, [])
 
+  // Initial load
   useEffect(() => {
     loadTables()
   }, [loadTables])
 
+  // Auto-refresh every 30s
+  useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+      const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+      if (!supabaseUrl || !supabaseKey) return
+
+      fetchTables(supabaseUrl, supabaseKey)
+        .then(setTables)
+        .catch(() => { /* silent background refresh failure */ })
+    }, REFRESH_INTERVAL_MS)
+
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current)
+      }
+    }
+  }, [])
+
   return (
     <main className="min-h-screen bg-zinc-900 p-6">
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-4">
         <h1 className="text-2xl font-bold text-white">Tables</h1>
         <div className="flex items-center gap-3">
           <Link
@@ -56,6 +89,18 @@ export default function TablesPage(): JSX.Element {
           </button>
         </div>
       </div>
+
+      {/* Status legend */}
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-2 mb-6">
+        {STATUS_LEGEND.map(({ status, label, dotClass }) => (
+          <span key={status} className="flex items-center gap-1.5 text-sm text-zinc-400">
+            <span className={`inline-block w-3 h-3 rounded-full ${dotClass}`} />
+            {label}
+          </span>
+        ))}
+        <span className="text-xs text-zinc-600 ml-auto">Auto-refreshes every 30s</span>
+      </div>
+
       {loading ? (
         <p className="text-zinc-400 text-lg">Loading tables…</p>
       ) : error !== null ? (

--- a/apps/web/app/tables/tableStatus.test.ts
+++ b/apps/web/app/tables/tableStatus.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { getTableStatus, OVERDUE_THRESHOLD_MINUTES } from './tableStatus'
+import type { TableRow } from './tablesData'
+
+function makeTable(overrides: Partial<TableRow> = {}): TableRow {
+  return {
+    id: 'table-1',
+    label: 'T1',
+    open_order_id: null,
+    order_status: null,
+    order_created_at: null,
+    ...overrides,
+  }
+}
+
+const NOW = new Date('2026-03-27T12:00:00Z').getTime()
+const RECENT = new Date('2026-03-27T11:30:00Z').toISOString()   // 30 min ago → occupied
+const OVERDUE_AT = new Date(NOW - (OVERDUE_THRESHOLD_MINUTES + 1) * 60 * 1000).toISOString() // just past threshold
+
+describe('getTableStatus', () => {
+  it('returns "available" when there is no open order', () => {
+    expect(getTableStatus(makeTable(), NOW)).toBe('available')
+  })
+
+  it('returns "occupied" when there is a recent open order', () => {
+    const table = makeTable({ open_order_id: 'order-1', order_status: 'open', order_created_at: RECENT })
+    expect(getTableStatus(table, NOW)).toBe('occupied')
+  })
+
+  it('returns "bill_requested" when order status is pending_payment', () => {
+    const table = makeTable({ open_order_id: 'order-1', order_status: 'pending_payment', order_created_at: RECENT })
+    expect(getTableStatus(table, NOW)).toBe('bill_requested')
+  })
+
+  it('returns "overdue" when order is open and past the threshold', () => {
+    const table = makeTable({ open_order_id: 'order-1', order_status: 'open', order_created_at: OVERDUE_AT })
+    expect(getTableStatus(table, NOW)).toBe('overdue')
+  })
+
+  it('prioritises "bill_requested" over overdue age', () => {
+    const table = makeTable({ open_order_id: 'order-1', order_status: 'pending_payment', order_created_at: OVERDUE_AT })
+    expect(getTableStatus(table, NOW)).toBe('bill_requested')
+  })
+
+  it('returns "occupied" when order_created_at is null but order exists', () => {
+    const table = makeTable({ open_order_id: 'order-1', order_status: 'open', order_created_at: null })
+    expect(getTableStatus(table, NOW)).toBe('occupied')
+  })
+})

--- a/apps/web/app/tables/tableStatus.ts
+++ b/apps/web/app/tables/tableStatus.ts
@@ -1,0 +1,54 @@
+import type { TableRow } from './tablesData'
+
+/**
+ * Overdue threshold in minutes.
+ * TODO: make this configurable via the admin config table (key: 'table_overdue_minutes').
+ */
+export const OVERDUE_THRESHOLD_MINUTES = 120
+
+export type TableStatus = 'available' | 'occupied' | 'bill_requested' | 'overdue'
+
+export function getTableStatus(
+  table: TableRow,
+  nowMs: number = Date.now(),
+): TableStatus {
+  if (table.open_order_id === null) return 'available'
+
+  if (table.order_status === 'pending_payment') return 'bill_requested'
+
+  if (table.order_created_at !== null) {
+    const ageMs = nowMs - new Date(table.order_created_at).getTime()
+    if (ageMs > OVERDUE_THRESHOLD_MINUTES * 60 * 1000) return 'overdue'
+  }
+
+  return 'occupied'
+}
+
+export interface StatusConfig {
+  label: string
+  cardClass: string
+  badgeClass: string
+}
+
+export const STATUS_CONFIG: Record<TableStatus, StatusConfig> = {
+  available: {
+    label: 'Empty',
+    cardClass: 'bg-zinc-800 border-zinc-600 hover:border-zinc-400',
+    badgeClass: 'bg-zinc-700 text-zinc-300',
+  },
+  occupied: {
+    label: 'Occupied',
+    cardClass: 'bg-green-900 border-green-600 hover:bg-green-800',
+    badgeClass: 'bg-green-600 text-white',
+  },
+  bill_requested: {
+    label: 'Bill Requested',
+    cardClass: 'bg-orange-900 border-orange-500 hover:bg-orange-800',
+    badgeClass: 'bg-orange-500 text-white',
+  },
+  overdue: {
+    label: 'Overdue',
+    cardClass: 'bg-red-900 border-red-500 hover:bg-red-800',
+    badgeClass: 'bg-red-500 text-white',
+  },
+}

--- a/apps/web/app/tables/tablesData.test.ts
+++ b/apps/web/app/tables/tablesData.test.ts
@@ -26,14 +26,14 @@ describe('fetchTables', () => {
   it('returns tables with open_order_id populated when an open order exists', async (): Promise<void> => {
     mockFetch([
       { ok: true, body: [{ id: 'table-1', label: 'Table 1' }, { id: 'table-2', label: 'Table 2' }] },
-      { ok: true, body: [{ id: 'order-1', table_id: 'table-1' }] },
+      { ok: true, body: [{ id: 'order-1', table_id: 'table-1', status: 'open', created_at: '2026-03-27T08:00:00Z' }] },
     ])
 
     const result = await fetchTables(BASE_URL, API_KEY)
 
     expect(result).toEqual([
-      { id: 'table-1', label: 'Table 1', open_order_id: 'order-1' },
-      { id: 'table-2', label: 'Table 2', open_order_id: null },
+      { id: 'table-1', label: 'Table 1', open_order_id: 'order-1', order_status: 'open', order_created_at: '2026-03-27T08:00:00Z' },
+      { id: 'table-2', label: 'Table 2', open_order_id: null, order_status: null, order_created_at: null },
     ])
   })
 
@@ -46,9 +46,21 @@ describe('fetchTables', () => {
     const result = await fetchTables(BASE_URL, API_KEY)
 
     expect(result).toEqual([
-      { id: 'table-1', label: 'Table 1', open_order_id: null },
-      { id: 'table-2', label: 'Table 2', open_order_id: null },
+      { id: 'table-1', label: 'Table 1', open_order_id: null, order_status: null, order_created_at: null },
+      { id: 'table-2', label: 'Table 2', open_order_id: null, order_status: null, order_created_at: null },
     ])
+  })
+
+  it('populates order_status from the order record', async (): Promise<void> => {
+    mockFetch([
+      { ok: true, body: [{ id: 'table-1', label: 'Table 1' }] },
+      { ok: true, body: [{ id: 'order-1', table_id: 'table-1', status: 'pending_payment', created_at: '2026-03-27T08:00:00Z' }] },
+    ])
+
+    const result = await fetchTables(BASE_URL, API_KEY)
+
+    expect(result[0].order_status).toBe('pending_payment')
+    expect(result[0].order_created_at).toBe('2026-03-27T08:00:00Z')
   })
 
   it('sends correct apikey and Authorization headers', async (): Promise<void> => {
@@ -83,7 +95,7 @@ describe('fetchTables', () => {
     expect(tablesCall).toContain('select=id%2Clabel')
   })
 
-  it('queries orders with status=eq.open', async (): Promise<void> => {
+  it('queries orders with status=in.(open,pending_payment)', async (): Promise<void> => {
     const fetchMock = vi.fn(async () => ({
       ok: true,
       json: async () => [],
@@ -95,7 +107,7 @@ describe('fetchTables', () => {
 
     const ordersCall = fetchMock.mock.calls[1][0] as string
     expect(ordersCall).toContain('/rest/v1/orders')
-    expect(ordersCall).toContain('status=eq.open')
+    expect(ordersCall).toContain('status=in.')
   })
 
   it('throws when the tables request fails', async (): Promise<void> => {

--- a/apps/web/app/tables/tablesData.ts
+++ b/apps/web/app/tables/tablesData.ts
@@ -2,6 +2,8 @@ export interface TableRow {
   id: string
   label: string
   open_order_id: string | null
+  order_status: string | null
+  order_created_at: string | null
 }
 
 interface TableApiRow {
@@ -12,6 +14,8 @@ interface TableApiRow {
 interface OrderApiRow {
   id: string
   table_id: string | null
+  status: string
+  created_at: string
 }
 
 export async function fetchTables(
@@ -34,8 +38,8 @@ export async function fetchTables(
   }
 
   const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
-  ordersUrl.searchParams.set('select', 'id,table_id')
-  ordersUrl.searchParams.set('status', 'eq.open')
+  ordersUrl.searchParams.set('select', 'id,table_id,status,created_at')
+  ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
 
   const ordersRes = await fetch(ordersUrl.toString(), { headers })
 
@@ -47,16 +51,21 @@ export async function fetchTables(
   const tables = (await tablesRes.json()) as TableApiRow[]
   const orders = (await ordersRes.json()) as OrderApiRow[]
 
-  const openOrderByTable = new Map<string, string>()
+  const openOrderByTable = new Map<string, OrderApiRow>()
   for (const order of orders) {
     if (order.table_id !== null) {
-      openOrderByTable.set(order.table_id, order.id)
+      openOrderByTable.set(order.table_id, order)
     }
   }
 
-  return tables.map((table) => ({
-    id: table.id,
-    label: table.label,
-    open_order_id: openOrderByTable.get(table.id) ?? null,
-  }))
+  return tables.map((table) => {
+    const order = openOrderByTable.get(table.id)
+    return {
+      id: table.id,
+      label: table.label,
+      open_order_id: order?.id ?? null,
+      order_status: order?.status ?? null,
+      order_created_at: order?.created_at ?? null,
+    }
+  })
 }

--- a/supabase/migrations/20260327210000_add_grid_position_to_tables.sql
+++ b/supabase/migrations/20260327210000_add_grid_position_to_tables.sql
@@ -1,0 +1,11 @@
+-- Add optional grid position columns to tables for the floor plan view.
+-- NULL = auto-positioned by the frontend grid layout.
+-- Non-null x/y = admin-configured position (future drag-and-drop in admin settings).
+
+ALTER TABLE tables
+  ADD COLUMN IF NOT EXISTS grid_x integer DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS grid_y integer DEFAULT NULL;
+
+-- Rollback:
+-- ALTER TABLE tables DROP COLUMN IF EXISTS grid_x;
+-- ALTER TABLE tables DROP COLUMN IF EXISTS grid_y;


### PR DESCRIPTION
## Summary

Closes #186

Upgrades the tables grid into a colour-coded floor plan view so staff can instantly read table status at a glance.

## Status colours

| Colour | Status | Condition |
|--------|--------|-----------|
| 🩶 Grey | Empty | No active order |
| 🟢 Green | Occupied | Open order, within 2 h |
| 🟠 Orange | Bill Requested | Order status = `pending_payment` |
| 🔴 Red | Overdue | Open order older than 2 h |

## Changes

### `tablesData.ts`
- Extends `TableRow` with `order_status` and `order_created_at` fields
- `fetchTables` now queries `status=in.(open,pending_payment)` (previously only `open`) so bill-requested orders are included

### `tableStatus.ts` _(new)_
- `getTableStatus()` pure function derives `TableStatus` from a `TableRow`
- `STATUS_CONFIG` map provides Tailwind classes and labels per status
- `OVERDUE_THRESHOLD_MINUTES = 120` constant (TODO: pull from admin `config` table)

### `TableCard.tsx`
- Reads status from `getTableStatus()` and applies correct card/badge colours
- Navigation behaviour unchanged (tap occupied table → open order; tap empty → create order)

### `page.tsx`
- 30-second auto-refresh via `setInterval` (silent background fetch, no loading spinner)
- Status legend strip above the grid

### Migration
- `20260327210000_add_grid_position_to_tables.sql` — adds nullable `grid_x` / `grid_y` columns on `tables` as a foundation for future drag-to-reposition admin UI (no frontend wired yet)

## Tests
- New `tableStatus.test.ts` — 6 unit tests covering all status transitions
- Updated `tablesData.test.ts` — updated fixtures, new test for `order_status` population
- Updated `page.test.tsx` and `TableCard.test.tsx` — fixtures extended with new fields

## Out of scope
- Drag-and-drop positioning (DB columns added, UI deferred)
- Multi-floor support