### PR TITLE
feat: staff performance dashboard (#185)

### DIFF
--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react'
 import type { JSX } from 'react'
 import { useUser } from '@/lib/user-context'
 import { callGetReports, callExportOrders } from './reportsApi'
-import type { ReportData, ReportPeriod, CompDetailItem, CompByItem } from './reportsApi'
+import type { ReportData, ReportPeriod, CompDetailItem, CompByItem, StaffPerformanceRow } from './reportsApi'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 import {
   exportRevenueByDay,
@@ -212,6 +212,69 @@ function TopCompedItemsTable({ items }: TopCompedItemsTableProps): JSX.Element {
           </div>
         )
       })}
+    </div>
+  )
+}
+
+interface StaffPerformanceTableProps {
+  rows: StaffPerformanceRow[]
+}
+
+function StaffPerformanceTable({ rows }: StaffPerformanceTableProps): JSX.Element {
+  if (rows.length === 0) {
+    return (
+      <p className="text-zinc-500 text-sm">
+        No staff performance data for this period. Orders created during this range will appear here once orders include server assignments.
+      </p>
+    )
+  }
+  const maxRevenue = Math.max(...rows.map(r => r.total_revenue_cents), 1)
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-zinc-400 border-b border-zinc-700">
+            <th className="pb-2 pr-3 font-medium">#</th>
+            <th className="pb-2 pr-3 font-medium">Staff</th>
+            <th className="pb-2 pr-3 font-medium">Role</th>
+            <th className="pb-2 pr-3 font-medium text-right">Orders</th>
+            <th className="pb-2 pr-3 font-medium text-right">Revenue</th>
+            <th className="pb-2 pr-3 font-medium text-right">Avg Ticket</th>
+            <th className="pb-2 font-medium">Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => {
+            const pct = Math.round((row.total_revenue_cents / maxRevenue) * 100)
+            return (
+              <tr key={row.server_id} className="border-b border-zinc-700/50">
+                <td className="py-2 pr-3 text-zinc-400">{idx + 1}</td>
+                <td className="py-2 pr-3 text-white font-medium">{row.staff_name}</td>
+                <td className="py-2 pr-3">
+                  <span className="px-2 py-0.5 rounded-full bg-zinc-700 text-zinc-300 text-xs font-medium capitalize">
+                    {row.role}
+                  </span>
+                </td>
+                <td className="py-2 pr-3 text-zinc-300 text-right">{row.total_orders}</td>
+                <td className="py-2 pr-3 text-amber-400 text-right font-medium">
+                  {formatPrice(row.total_revenue_cents, DEFAULT_CURRENCY_SYMBOL)}
+                </td>
+                <td className="py-2 pr-3 text-zinc-300 text-right">
+                  {formatPrice(row.avg_ticket_cents, DEFAULT_CURRENCY_SYMBOL)}
+                </td>
+                <td className="py-2 w-32">
+                  <div className="h-2 bg-zinc-700 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-amber-500 rounded-full transition-all"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
     </div>
   )
 }
@@ -536,7 +599,18 @@ export default function ReportsDashboard(): JSX.Element {
             </div>
           )}
 
-          {/* Row 6 — Full Order List Export */}
+          {/* Row 6 — Staff Performance */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+            <div className="flex items-center justify-between gap-3 mb-4">
+              <div>
+                <h2 className="text-base font-semibold text-white">Staff Performance</h2>
+                <p className="text-sm text-zinc-400 mt-0.5">Orders and revenue per server — sorted by revenue</p>
+              </div>
+            </div>
+            <StaffPerformanceTable rows={data.staff_performance ?? []} />
+          </div>
+
+          {/* Row 7 — Full Order List Export */}
           <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div>

--- a/apps/web/app/admin/reports/reportsApi.ts
+++ b/apps/web/app/admin/reports/reportsApi.ts
@@ -56,6 +56,15 @@ export interface CompDetail {
   top_comped_items: CompByItem[]
 }
 
+export interface StaffPerformanceRow {
+  server_id: string
+  staff_name: string
+  role: string
+  total_orders: number
+  total_revenue_cents: number
+  avg_ticket_cents: number
+}
+
 export interface ReportData {
   summary: ReportSummary
   revenue_by_day: RevenueByDay[]
@@ -63,6 +72,7 @@ export interface ReportData {
   payment_breakdown: PaymentBreakdown[]
   discount_summary: DiscountSummary
   comp_detail?: CompDetail
+  staff_performance?: StaffPerformanceRow[]
 }
 
 interface GetReportsResponse {

--- a/supabase/functions/create_order/index.ts
+++ b/supabase/functions/create_order/index.ts
@@ -103,7 +103,7 @@ export async function handler(
     }
     const restaurantId = tables[0].restaurant_id
 
-    // 2. Insert the new order
+    // 2. Insert the new order, capturing the server who created it
     const insertRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders`,
       {
@@ -113,6 +113,7 @@ export async function handler(
           restaurant_id: restaurantId,
           table_id: tableId,
           status: 'open',
+          server_id: caller.actorId,
         }),
       },
     )

--- a/supabase/functions/get_reports/index.ts
+++ b/supabase/functions/get_reports/index.ts
@@ -127,6 +127,12 @@ interface UserRow {
   id: string
   name: string | null
   email: string
+  role?: string
+}
+
+interface StaffOrderRow {
+  server_id: string | null
+  final_total_cents: number | null
 }
 
 export async function handler(
@@ -420,6 +426,70 @@ export async function handler(
       .sort((a, b) => b.total_value_cents - a.total_value_cents)
       .slice(0, 10)
 
+    // 8. Staff performance — aggregate paid orders by server_id
+    // Fetch orders that have a server_id (may be a subset of all paid orders)
+    const staffOrdersRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=server_id,final_total_cents&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&server_id=not.is.null&limit=10000`,
+      { headers: dbHeaders },
+    )
+
+    type StaffPerformanceRow = {
+      server_id: string
+      staff_name: string
+      role: string
+      total_orders: number
+      total_revenue_cents: number
+      avg_ticket_cents: number
+    }
+
+    let staffPerformance: StaffPerformanceRow[] = []
+
+    if (staffOrdersRes.ok) {
+      const staffOrders = (await staffOrdersRes.json()) as StaffOrderRow[]
+
+      // Aggregate by server_id
+      const serverMap: Record<string, { total_orders: number; total_revenue_cents: number }> = {}
+      for (const o of staffOrders) {
+        if (!o.server_id) continue
+        if (!serverMap[o.server_id]) serverMap[o.server_id] = { total_orders: 0, total_revenue_cents: 0 }
+        serverMap[o.server_id].total_orders += 1
+        serverMap[o.server_id].total_revenue_cents += o.final_total_cents ?? 0
+      }
+
+      const serverIds = Object.keys(serverMap)
+      if (serverIds.length > 0) {
+        // Fetch user profiles for names/roles
+        const staffUsersRes = await fetchFn(
+          `${supabaseUrl}/rest/v1/users?select=id,name,email,role&id=in.(${serverIds.join(',')})`,
+          { headers: dbHeaders },
+        )
+
+        if (staffUsersRes.ok) {
+          const staffUsers = (await staffUsersRes.json()) as UserRow[]
+          const userProfileMap: Record<string, { name: string; role: string }> = {}
+          for (const u of staffUsers) {
+            userProfileMap[u.id] = { name: u.name ?? u.email, role: u.role ?? 'server' }
+          }
+
+          staffPerformance = serverIds.map(serverId => {
+            const agg = serverMap[serverId]
+            const profile = userProfileMap[serverId] ?? { name: serverId, role: 'server' }
+            return {
+              server_id: serverId,
+              staff_name: profile.name,
+              role: profile.role,
+              total_orders: agg.total_orders,
+              total_revenue_cents: agg.total_revenue_cents,
+              avg_ticket_cents: agg.total_orders > 0 ? Math.round(agg.total_revenue_cents / agg.total_orders) : 0,
+            }
+          })
+
+          // Sort by revenue descending
+          staffPerformance.sort((a, b) => b.total_revenue_cents - a.total_revenue_cents)
+        }
+      }
+    }
+
     return new Response(
       JSON.stringify({
         success: true,
@@ -446,6 +516,7 @@ export async function handler(
             comp_order_value_cents: compOrderValueCents,
             top_comped_items: topCompedItems,
           },
+          staff_performance: staffPerformance,
         },
       }),
       { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },

--- a/supabase/migrations/20260327230000_add_server_id_to_orders.sql
+++ b/supabase/migrations/20260327230000_add_server_id_to_orders.sql
@@ -1,0 +1,7 @@
+-- Add server_id to orders table for staff performance tracking
+-- Links each order to the staff member who created/handled it
+
+ALTER TABLE orders
+  ADD COLUMN server_id uuid REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_orders_server_id ON orders(server_id);


### PR DESCRIPTION
## Staff Performance Dashboard

Closes #185

### What's in this PR

#### Data Layer
- **Migration** `20260327230000_add_server_id_to_orders.sql`: adds `server_id uuid REFERENCES users(id) ON DELETE SET NULL` + index to the `orders` table
- **`create_order` edge function**: now captures `server_id: caller.actorId` (the authenticated user's ID from their JWT) when inserting a new order — no behaviour change for existing callers

#### Edge Function (`get_reports`)
- New `staff_performance` block added to the response payload
- Queries all paid orders in the date range that have a `server_id`, aggregates by server, joins user profiles for name + role
- Returns a sorted array (revenue desc) of `{ server_id, staff_name, role, total_orders, total_revenue_cents, avg_ticket_cents }`
- Gracefully returns `[]` if no orders have server assignments yet

#### Frontend (`/admin/reports`)
- Added `StaffPerformanceRow` type to `reportsApi.ts` and optional `staff_performance` field on `ReportData`
- New **Staff Performance** section in `ReportsDashboard.tsx` between Comp Detail and Full Order Export:
  - Ranked table: #, Staff name, Role badge, Total orders, Revenue, Avg ticket, proportional share bar
  - Consistent dark Tailwind theme (zinc + amber) matching existing report cards
  - Empty state with helpful message when no server-linked orders exist yet
- Filters by the same date range controls as all other report sections

### Behaviour
- Existing orders without a `server_id` are excluded from the staff table (null = unassigned)
- All new orders created via `create_order` will automatically carry the caller's user ID
- No breaking changes — `staff_performance` is optional in the response type
