### PR TITLE
feat(#183): Allergen and dietary info on menu items

### DIFF
--- a/apps/web/app/admin/menu/MenuItemFormPage.tsx
+++ b/apps/web/app/admin/menu/MenuItemFormPage.tsx
@@ -15,6 +15,10 @@ import FileUploadZone from './FileUploadZone'
 import type { UploadState } from './FileUploadZone'
 import { generateId, formatCurrency } from './MenuManager'
 
+export const ALLERGEN_OPTIONS = ['nuts', 'dairy', 'gluten', 'eggs', 'shellfish', 'soy', 'sesame'] as const
+export const DIETARY_OPTIONS = ['halal', 'vegetarian', 'vegan'] as const
+export const SPICY_OPTIONS = ['none', 'mild', 'medium', 'hot'] as const
+
 interface ItemFormValues {
   name: string
   description: string
@@ -22,6 +26,9 @@ interface ItemFormValues {
   menuId: string
   available: boolean
   modifiers: AdminModifier[]
+  allergens: string[]
+  dietaryBadges: string[]
+  spicyLevel: string
 }
 
 interface ItemFormErrors {
@@ -49,6 +56,9 @@ interface MenuItemRow {
   menu_id: string
   available: boolean
   modifiers: Array<{ id: string; name: string; price_delta_cents: number }>
+  allergens?: string[]
+  dietary_badges?: string[]
+  spicy_level?: string
 }
 
 const EMPTY_FORM: ItemFormValues = {
@@ -58,6 +68,9 @@ const EMPTY_FORM: ItemFormValues = {
   menuId: '',
   available: true,
   modifiers: [],
+  allergens: [],
+  dietaryBadges: [],
+  spicyLevel: 'none',
 }
 
 const EMPTY_MODIFIER: ModifierFormValues = { name: '', price: '' }
@@ -81,7 +94,7 @@ async function fetchMenuItemById(
 ): Promise<MenuItemRow | null> {
   const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/menu_items`)
-  url.searchParams.set('select', 'id,name,description,price_cents,image_url,menu_id,available,modifiers(id,name,price_delta_cents)')
+  url.searchParams.set('select', 'id,name,description,price_cents,image_url,menu_id,available,allergens,dietary_badges,spicy_level,modifiers(id,name,price_delta_cents)')
   url.searchParams.set('id', `eq.${itemId}`)
   const res = await fetch(url.toString(), { headers })
   if (!res.ok) throw new Error(`Failed to fetch menu item: ${res.status}`)
@@ -144,6 +157,9 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
             menuId: item.menu_id,
             available: item.available ?? true,
             modifiers: (item.modifiers ?? []).map((m) => ({ ...m })),
+            allergens: item.allergens ?? [],
+            dietaryBadges: item.dietary_badges ?? [],
+            spicyLevel: item.spicy_level ?? 'none',
           })
           if (item.image_url) {
             setPreviewUrl(item.image_url)
@@ -275,6 +291,9 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
           description,
           imageUrl,
           form.available,
+          form.allergens,
+          form.dietaryBadges,
+          form.spicyLevel,
         )
       } else if (mode === 'edit' && itemId) {
         await callUpdateMenuItem(
@@ -287,6 +306,9 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
           description,
           imageUrl,
           form.available,
+          form.allergens,
+          form.dietaryBadges,
+          form.spicyLevel,
         )
       }
 
@@ -473,6 +495,106 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
               ].join(' ')}
             />
           </button>
+        </div>
+
+        {/* Allergens */}
+        <div className="flex flex-col gap-3 border-t border-zinc-700 pt-4">
+          <h3 className="text-base font-semibold text-zinc-200">
+            Allergens <span className="text-zinc-500 font-normal">(select all that apply)</span>
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {ALLERGEN_OPTIONS.map((allergen) => {
+              const active = form.allergens.includes(allergen)
+              return (
+                <button
+                  key={allergen}
+                  type="button"
+                  onClick={() =>
+                    setForm((f) => ({
+                      ...f,
+                      allergens: active
+                        ? f.allergens.filter((a) => a !== allergen)
+                        : [...f.allergens, allergen],
+                    }))
+                  }
+                  disabled={submitting}
+                  aria-pressed={active}
+                  className={[
+                    'min-h-[40px] px-4 py-1.5 rounded-full text-sm font-medium capitalize transition-colors disabled:opacity-50',
+                    active
+                      ? 'bg-red-700 text-white'
+                      : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600',
+                  ].join(' ')}
+                >
+                  {allergen}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Dietary badges */}
+        <div className="flex flex-col gap-3 border-t border-zinc-700 pt-4">
+          <h3 className="text-base font-semibold text-zinc-200">
+            Dietary Badges <span className="text-zinc-500 font-normal">(select all that apply)</span>
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {DIETARY_OPTIONS.map((badge) => {
+              const active = form.dietaryBadges.includes(badge)
+              return (
+                <button
+                  key={badge}
+                  type="button"
+                  onClick={() =>
+                    setForm((f) => ({
+                      ...f,
+                      dietaryBadges: active
+                        ? f.dietaryBadges.filter((b) => b !== badge)
+                        : [...f.dietaryBadges, badge],
+                    }))
+                  }
+                  disabled={submitting}
+                  aria-pressed={active}
+                  className={[
+                    'min-h-[40px] px-4 py-1.5 rounded-full text-sm font-medium capitalize transition-colors disabled:opacity-50',
+                    active
+                      ? 'bg-emerald-700 text-white'
+                      : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600',
+                  ].join(' ')}
+                >
+                  {badge === 'halal' ? '✓ Halal' : badge.charAt(0).toUpperCase() + badge.slice(1)}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Spicy level */}
+        <div className="flex flex-col gap-3 border-t border-zinc-700 pt-4">
+          <h3 className="text-base font-semibold text-zinc-200">Spicy Level</h3>
+          <div className="flex flex-wrap gap-2">
+            {SPICY_OPTIONS.map((level) => {
+              const labels: Record<string, string> = { none: 'None', mild: '🌶 Mild', medium: '🌶🌶 Medium', hot: '🌶🌶🌶 Hot' }
+              const active = form.spicyLevel === level
+              return (
+                <button
+                  key={level}
+                  type="button"
+                  onClick={() => setForm((f) => ({ ...f, spicyLevel: level }))}
+                  disabled={submitting}
+                  aria-pressed={active}
+                  className={[
+                    'min-h-[40px] px-4 py-1.5 rounded-full text-sm font-medium transition-colors disabled:opacity-50',
+                    active
+                      ? 'bg-orange-700 text-white'
+                      : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600',
+                  ].join(' ')}
+                >
+                  {labels[level]}
+                </button>
+              )
+            })}
+          </div>
         </div>
 
         {/* Modifiers */}

--- a/apps/web/app/admin/menu/menuAdminApi.ts
+++ b/apps/web/app/admin/menu/menuAdminApi.ts
@@ -81,9 +81,11 @@ export async function callCreateMenuItem(
   description?: string,
   imageUrl?: string,
   available = true,
+  allergens: string[] = [],
+  dietaryBadges: string[] = [],
+  spicyLevel = 'none',
 ): Promise<string> {
   if (!accessToken) throw new Error('Not authenticated')
-  const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
   const res = await fetch(`${supabaseUrl}/functions/v1/create_menu_item`, {
     method: 'POST',
     headers: {
@@ -96,6 +98,9 @@ export async function callCreateMenuItem(
       price_cents: priceCents,
       modifiers,
       available,
+      allergens,
+      dietary_badges: dietaryBadges,
+      spicy_level: spicyLevel,
       ...(description !== undefined ? { description } : {}),
       ...(imageUrl !== undefined ? { image_url: imageUrl } : {}),
     }),
@@ -116,8 +121,10 @@ export async function callUpdateMenuItem(
   description?: string,
   imageUrl?: string,
   available = true,
+  allergens: string[] = [],
+  dietaryBadges: string[] = [],
+  spicyLevel = 'none',
 ): Promise<void> {
-  const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
   const res = await fetch(`${supabaseUrl}/functions/v1/update_menu_item`, {
     method: 'POST',
     headers: {
@@ -130,6 +137,9 @@ export async function callUpdateMenuItem(
       price_cents: priceCents,
       modifiers,
       available,
+      allergens,
+      dietary_badges: dietaryBadges,
+      spicy_level: spicyLevel,
       ...(description !== undefined ? { description } : {}),
       ...(imageUrl !== undefined ? { image_url: imageUrl } : {}),
     }),

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.test.tsx
@@ -10,6 +10,9 @@ const mockItem: MenuItem = {
   price_cents: 850,
   available: true,
   modifiers: [],
+  allergens: [],
+  dietary_badges: [],
+  spicy_level: 'none',
 }
 
 const mockItemWithModifiers: MenuItem = {
@@ -21,6 +24,9 @@ const mockItemWithModifiers: MenuItem = {
     { id: 'mod-001', name: 'Extra cheese', price_delta_cents: 50 },
     { id: 'mod-002', name: 'No onions', price_delta_cents: 0 },
   ],
+  allergens: [],
+  dietary_badges: [],
+  spicy_level: 'none',
 }
 
 const ORDER_ID = 'order-abc-123'

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuItemCard.tsx
@@ -78,6 +78,20 @@ export default function MenuItemCard({ item, orderId, onItemAdded, currencySymbo
 
   const isUnavailable = !item.available
 
+  const SPICY_LABELS: Record<string, string> = {
+    mild: '🌶 Mild',
+    medium: '🌶🌶 Medium',
+    hot: '🌶🌶🌶 Hot',
+  }
+
+  const DIETARY_COLORS: Record<string, string> = {
+    halal: 'bg-emerald-800 text-emerald-200',
+    vegetarian: 'bg-green-800 text-green-200',
+    vegan: 'bg-lime-800 text-lime-200',
+  }
+
+  const ALLERGEN_COLORS = 'bg-red-900 text-red-200'
+
   return (
     <>
       {showModal && (
@@ -100,7 +114,7 @@ export default function MenuItemCard({ item, orderId, onItemAdded, currencySymbo
         ].join(' ')}
       >
         <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 flex-wrap">
             <span className="text-base font-semibold text-white">{item.name}</span>
             {isUnavailable && (
               <span className="text-xs font-medium bg-zinc-700 text-zinc-400 px-2 py-0.5 rounded-full">
@@ -111,6 +125,38 @@ export default function MenuItemCard({ item, orderId, onItemAdded, currencySymbo
           <span className="text-lg font-bold text-amber-400">{priceFormatted}</span>
           {item.modifiers.length > 0 && (
             <span className="text-sm text-zinc-400">{item.modifiers.length} option{item.modifiers.length !== 1 ? 's' : ''}</span>
+          )}
+          {/* Dietary badges */}
+          {item.dietary_badges && item.dietary_badges.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {item.dietary_badges.map((badge) => (
+                <span
+                  key={badge}
+                  className={`text-xs font-medium px-1.5 py-0.5 rounded-full capitalize ${DIETARY_COLORS[badge.toLowerCase()] ?? 'bg-zinc-700 text-zinc-300'}`}
+                >
+                  {badge.toLowerCase() === 'halal' ? '✓ Halal' : badge}
+                </span>
+              ))}
+            </div>
+          )}
+          {/* Allergen tags */}
+          {item.allergens && item.allergens.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-0.5">
+              {item.allergens.map((allergen) => (
+                <span
+                  key={allergen}
+                  className={`text-xs font-medium px-1.5 py-0.5 rounded-full capitalize ${ALLERGEN_COLORS}`}
+                >
+                  {allergen}
+                </span>
+              ))}
+            </div>
+          )}
+          {/* Spicy level */}
+          {item.spicy_level && item.spicy_level !== 'none' && SPICY_LABELS[item.spicy_level.toLowerCase()] && (
+            <span className="text-xs text-orange-400 font-medium mt-0.5">
+              {SPICY_LABELS[item.spicy_level.toLowerCase()]}
+            </span>
           )}
         </div>
         <button

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.test.tsx
@@ -42,20 +42,20 @@ const MOCK_CATEGORIES: MenuCategory[] = [
   {
     name: 'Starters',
     items: [
-      { id: '00000000-0000-0000-0000-000000000301', name: 'Bruschetta', price_cents: 850, available: true, modifiers: [] },
-      { id: '00000000-0000-0000-0000-000000000302', name: 'Caesar Salad', price_cents: 1050, available: true, modifiers: [] },
+      { id: '00000000-0000-0000-0000-000000000301', name: 'Bruschetta', price_cents: 850, available: true, modifiers: [], allergens: [], dietary_badges: [], spicy_level: 'none' },
+      { id: '00000000-0000-0000-0000-000000000302', name: 'Caesar Salad', price_cents: 1050, available: true, modifiers: [], allergens: [], dietary_badges: [], spicy_level: 'none' },
     ],
   },
   {
     name: 'Mains',
     items: [
-      { id: '00000000-0000-0000-0000-000000000305', name: 'Ribeye Steak', price_cents: 2650, available: true, modifiers: [] },
+      { id: '00000000-0000-0000-0000-000000000305', name: 'Ribeye Steak', price_cents: 2650, available: true, modifiers: [], allergens: [], dietary_badges: [], spicy_level: 'none' },
     ],
   },
   {
     name: 'Drinks',
     items: [
-      { id: '00000000-0000-0000-0000-000000000308', name: 'Craft Beer', price_cents: 750, available: true, modifiers: [] },
+      { id: '00000000-0000-0000-0000-000000000308', name: 'Craft Beer', price_cents: 750, available: true, modifiers: [], allergens: [], dietary_badges: [], spicy_level: 'none' },
     ],
   },
 ]

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/MenuPageClient.tsx
@@ -6,7 +6,8 @@ import type { JSX } from 'react'
 import { fetchMenuCategories } from './menuData'
 import type { MenuCategory } from './menuData'
 import MenuItemCard from './MenuItemCard'
-import { filterMenuItems } from './menuSearch'
+import { filterMenuItemsWithFilters, hasActiveFilters, EMPTY_FILTERS } from './menuSearch'
+import type { MenuFilters } from './menuSearch'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 
 interface MenuPageClientProps {
@@ -20,6 +21,7 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [filters, setFilters] = useState<MenuFilters>(EMPTY_FILTERS)
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -55,7 +57,16 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
 
   function handleClearSearch(): void {
     setSearchQuery('')
+    setFilters(EMPTY_FILTERS)
     searchInputRef.current?.focus()
+  }
+
+  function handleSetDietary(value: string): void {
+    setFilters((f) => ({ ...f, dietary: f.dietary === value ? '' : value }))
+  }
+
+  function handleSetAllergenFree(value: string): void {
+    setFilters((f) => ({ ...f, allergenFree: f.allergenFree === value ? '' : value }))
   }
 
   const totalFormatted = formatPrice(orderTotalCents, DEFAULT_CURRENCY_SYMBOL)
@@ -71,12 +82,13 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
       return <p className="text-zinc-500 text-base">No menu items available</p>
     }
 
-    if (searchQuery.trim() !== '') {
-      const results = filterMenuItems(categories, searchQuery)
+    const activeFilters: MenuFilters = { ...filters, query: searchQuery }
+    if (hasActiveFilters(activeFilters)) {
+      const results = filterMenuItemsWithFilters(categories, activeFilters)
       if (results.length === 0) {
         return (
           <p className="text-zinc-500 text-base">
-            No items found for &ldquo;{searchQuery}&rdquo;
+            No items match your search or filters.
           </p>
         )
       }
@@ -127,7 +139,8 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
         <h1 className="text-2xl font-bold text-white">Menu</h1>
       </header>
 
-      <div className="mb-6">
+      <div className="mb-6 flex flex-col gap-3">
+        {/* Search bar */}
         <div className="relative">
           <input
             ref={searchInputRef}
@@ -138,16 +151,55 @@ export default function MenuPageClient({ tableId, orderId }: MenuPageClientProps
             aria-label="Search menu items"
             className="w-full bg-zinc-800 text-white placeholder-zinc-500 rounded-xl px-4 py-3 pr-10 text-base border border-zinc-700 focus:outline-none focus:border-amber-500 transition-colors"
           />
-          {searchQuery !== '' && (
+          {(searchQuery !== '' || filters.dietary !== '' || filters.allergenFree !== '') && (
             <button
               type="button"
               onClick={handleClearSearch}
-              aria-label="Clear search"
+              aria-label="Clear search and filters"
               className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 hover:text-white text-lg leading-none min-h-[48px] min-w-[48px] flex items-center justify-center transition-colors"
             >
               ×
             </button>
           )}
+        </div>
+
+        {/* Dietary filters */}
+        <div className="flex flex-wrap gap-2 items-center">
+          <span className="text-xs text-zinc-500 font-medium uppercase tracking-wide mr-1">Diet:</span>
+          {(['halal', 'vegetarian', 'vegan'] as const).map((badge) => (
+            <button
+              key={badge}
+              type="button"
+              onClick={() => handleSetDietary(badge)}
+              aria-pressed={filters.dietary === badge}
+              className={[
+                'text-xs font-medium px-3 py-1.5 rounded-full capitalize transition-colors min-h-[32px]',
+                filters.dietary === badge
+                  ? 'bg-emerald-600 text-white'
+                  : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600',
+              ].join(' ')}
+            >
+              {badge === 'halal' ? '✓ Halal' : badge.charAt(0).toUpperCase() + badge.slice(1)}
+            </button>
+          ))}
+
+          <span className="text-xs text-zinc-500 font-medium uppercase tracking-wide mx-1">Allergen-free:</span>
+          {(['nuts', 'dairy', 'gluten', 'eggs', 'shellfish', 'soy', 'sesame'] as const).map((allergen) => (
+            <button
+              key={allergen}
+              type="button"
+              onClick={() => handleSetAllergenFree(allergen)}
+              aria-pressed={filters.allergenFree === allergen}
+              className={[
+                'text-xs font-medium px-3 py-1.5 rounded-full capitalize transition-colors min-h-[32px]',
+                filters.allergenFree === allergen
+                  ? 'bg-red-700 text-white'
+                  : 'bg-zinc-700 text-zinc-300 hover:bg-zinc-600',
+              ].join(' ')}
+            >
+              No {allergen}
+            </button>
+          ))}
         </div>
       </div>
 

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/menuData.ts
@@ -10,6 +10,9 @@ export interface MenuItem {
   price_cents: number
   available: boolean
   modifiers: Modifier[]
+  allergens: string[]
+  dietary_badges: string[]
+  spicy_level: string
 }
 
 export interface MenuCategory {
@@ -29,6 +32,9 @@ interface MenuItemRow {
   price_cents: number
   available: boolean
   modifiers: ModifierRow[]
+  allergens: string[]
+  dietary_badges: string[]
+  spicy_level: string
 }
 
 interface MenuRow {
@@ -74,7 +80,7 @@ export async function fetchMenuCategories(
 
   const menusUrl = new URL(`${supabaseUrl}/rest/v1/menus`)
   menusUrl.searchParams.set('restaurant_id', `eq.${restaurant_id}`)
-  menusUrl.searchParams.set('select', 'id,name,menu_items(id,name,price_cents,available,modifiers(id,name,price_delta_cents))')
+  menusUrl.searchParams.set('select', 'id,name,menu_items(id,name,price_cents,available,allergens,dietary_badges,spicy_level,modifiers(id,name,price_delta_cents))')
 
   const menusRes = await fetch(menusUrl.toString(), {
     headers: {
@@ -99,6 +105,9 @@ export async function fetchMenuCategories(
       name: item.name,
       price_cents: item.price_cents,
       available: item.available ?? true,
+      allergens: item.allergens ?? [],
+      dietary_badges: item.dietary_badges ?? [],
+      spicy_level: item.spicy_level ?? 'none',
       modifiers: item.modifiers.map((mod) => ({
         id: mod.id,
         name: mod.name,

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/menuSearch.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/menuSearch.test.ts
@@ -1,28 +1,32 @@
 import { describe, it, expect } from 'vitest'
-import { filterMenuItems } from './menuSearch'
-import type { MenuCategory } from './menuData'
+import { filterMenuItems, filterMenuItemsWithFilters } from './menuSearch'
+import type { MenuCategory, MenuItem } from './menuData'
+
+function mkItem(partial: Omit<MenuItem, 'allergens' | 'dietary_badges' | 'spicy_level'>): MenuItem {
+  return { ...partial, allergens: [], dietary_badges: [], spicy_level: 'none' }
+}
 
 const categories: MenuCategory[] = [
   {
     name: 'Burgers',
     items: [
-      { id: '1', name: 'Classic Burger', price_cents: 1000, available: true, modifiers: [] },
-      { id: '2', name: 'Veggie Burger', price_cents: 900, available: true, modifiers: [] },
-      { id: '3', name: 'Chicken Sandwich', price_cents: 1100, available: true, modifiers: [] },
+      mkItem({ id: '1', name: 'Classic Burger', price_cents: 1000, available: true, modifiers: [] }),
+      mkItem({ id: '2', name: 'Veggie Burger', price_cents: 900, available: true, modifiers: [] }),
+      mkItem({ id: '3', name: 'Chicken Sandwich', price_cents: 1100, available: true, modifiers: [] }),
     ],
   },
   {
     name: 'Drinks',
     items: [
-      { id: '4', name: 'Cola', price_cents: 300, available: true, modifiers: [] },
-      { id: '5', name: 'Lemonade', price_cents: 400, available: true, modifiers: [] },
+      mkItem({ id: '4', name: 'Cola', price_cents: 300, available: true, modifiers: [] }),
+      mkItem({ id: '5', name: 'Lemonade', price_cents: 400, available: true, modifiers: [] }),
     ],
   },
   {
     name: 'Sides',
     items: [
-      { id: '6', name: 'French Fries', price_cents: 500, available: true, modifiers: [] },
-      { id: '7', name: 'Onion Rings', price_cents: 550, available: true, modifiers: [] },
+      mkItem({ id: '6', name: 'French Fries', price_cents: 500, available: true, modifiers: [] }),
+      mkItem({ id: '7', name: 'Onion Rings', price_cents: 550, available: true, modifiers: [] }),
     ],
   },
 ]
@@ -90,11 +94,11 @@ describe('filterMenuItems', () => {
     const crossCategories: MenuCategory[] = [
       {
         name: 'Mains',
-        items: [{ id: 'a', name: 'Spicy Chicken', price_cents: 1200, available: true, modifiers: [] }],
+        items: [mkItem({ id: 'a', name: 'Spicy Chicken', price_cents: 1200, available: true, modifiers: [] })],
       },
       {
         name: 'Starters',
-        items: [{ id: 'b', name: 'Chicken Wings', price_cents: 800, available: true, modifiers: [] }],
+        items: [mkItem({ id: 'b', name: 'Chicken Wings', price_cents: 800, available: true, modifiers: [] })],
       },
     ]
     const results = filterMenuItems(crossCategories, 'chicken')
@@ -116,11 +120,57 @@ describe('filterMenuItems', () => {
     const overlapping: MenuCategory[] = [
       {
         name: 'Burger Specials',
-        items: [{ id: 'x', name: 'Mega Burger', price_cents: 1500, available: true, modifiers: [] }],
+        items: [mkItem({ id: 'x', name: 'Mega Burger', price_cents: 1500, available: true, modifiers: [] })],
       },
     ]
     const results = filterMenuItems(overlapping, 'burger')
     expect(results).toHaveLength(1)
     expect(results[0].item.id).toBe('x')
+  })
+})
+
+describe('filterMenuItemsWithFilters — dietary filter', () => {
+  const dietaryCategories: MenuCategory[] = [
+    {
+      name: 'Mains',
+      items: [
+        { ...mkItem({ id: '1', name: 'Chicken Biryani', price_cents: 1200, available: true, modifiers: [] }), dietary_badges: ['halal'] },
+        { ...mkItem({ id: '2', name: 'Paneer Tikka', price_cents: 900, available: true, modifiers: [] }), dietary_badges: ['vegetarian', 'halal'] },
+        { ...mkItem({ id: '3', name: 'Beef Burger', price_cents: 1000, available: true, modifiers: [] }), dietary_badges: [] },
+      ],
+    },
+  ]
+
+  it('filters by halal', () => {
+    const results = filterMenuItemsWithFilters(dietaryCategories, { query: '', dietary: 'halal', allergenFree: '' })
+    expect(results.map((r) => r.item.id)).toEqual(['1', '2'])
+  })
+
+  it('filters by vegetarian', () => {
+    const results = filterMenuItemsWithFilters(dietaryCategories, { query: '', dietary: 'vegetarian', allergenFree: '' })
+    expect(results.map((r) => r.item.id)).toEqual(['2'])
+  })
+})
+
+describe('filterMenuItemsWithFilters — allergen-free filter', () => {
+  const allergenCategories: MenuCategory[] = [
+    {
+      name: 'Starters',
+      items: [
+        { ...mkItem({ id: '1', name: 'Bruschetta', price_cents: 600, available: true, modifiers: [] }), allergens: ['gluten', 'dairy'] },
+        { ...mkItem({ id: '2', name: 'Salad', price_cents: 500, available: true, modifiers: [] }), allergens: [] },
+        { ...mkItem({ id: '3', name: 'Peanut Soup', price_cents: 700, available: true, modifiers: [] }), allergens: ['nuts'] },
+      ],
+    },
+  ]
+
+  it('excludes items containing the specified allergen', () => {
+    const results = filterMenuItemsWithFilters(allergenCategories, { query: '', dietary: '', allergenFree: 'nuts' })
+    expect(results.map((r) => r.item.id)).toEqual(['1', '2'])
+  })
+
+  it('excludes items with dairy allergen', () => {
+    const results = filterMenuItemsWithFilters(allergenCategories, { query: '', dietary: '', allergenFree: 'dairy' })
+    expect(results.map((r) => r.item.id)).toEqual(['2', '3'])
   })
 })

--- a/apps/web/app/tables/[id]/order/[order_id]/menu/menuSearch.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/menu/menuSearch.ts
@@ -5,21 +5,65 @@ export interface SearchResult {
   categoryName: string
 }
 
+export interface MenuFilters {
+  /** Text search query */
+  query: string
+  /** Only show items with this dietary badge (e.g. 'halal', 'vegetarian', 'vegan') — empty means no filter */
+  dietary: string
+  /** Only show items that do NOT contain this allergen (e.g. 'nuts', 'dairy') — empty means no filter */
+  allergenFree: string
+}
+
+export const EMPTY_FILTERS: MenuFilters = { query: '', dietary: '', allergenFree: '' }
+
 export function filterMenuItems(
   categories: MenuCategory[],
   query: string,
 ): SearchResult[] {
-  const q = query.trim().toLowerCase()
-  if (!q) return []
+  return filterMenuItemsWithFilters(categories, { query, dietary: '', allergenFree: '' })
+}
+
+export function filterMenuItemsWithFilters(
+  categories: MenuCategory[],
+  filters: MenuFilters,
+): SearchResult[] {
+  const q = filters.query.trim().toLowerCase()
+  const dietary = filters.dietary.trim().toLowerCase()
+  const allergenFree = filters.allergenFree.trim().toLowerCase()
+
+  // If all filters are empty, return nothing (caller shows full menu)
+  if (!q && !dietary && !allergenFree) return []
 
   const results: SearchResult[] = []
+
   for (const category of categories) {
-    const categoryMatches = category.name.toLowerCase().includes(q)
+    const categoryMatchesQuery = q ? category.name.toLowerCase().includes(q) : true
+
     for (const item of category.items) {
-      if (categoryMatches || item.name.toLowerCase().includes(q)) {
-        results.push({ item, categoryName: category.name })
+      // Text match
+      const textMatch = !q || categoryMatchesQuery || item.name.toLowerCase().includes(q)
+      if (!textMatch) continue
+
+      // Dietary badge filter
+      if (dietary) {
+        const hasBadge = item.dietary_badges.some((b) => b.toLowerCase() === dietary)
+        if (!hasBadge) continue
       }
+
+      // Allergen-free filter: exclude items that contain the allergen
+      if (allergenFree) {
+        const hasAllergen = item.allergens.some((a) => a.toLowerCase() === allergenFree)
+        if (hasAllergen) continue
+      }
+
+      results.push({ item, categoryName: category.name })
     }
   }
+
   return results
+}
+
+/** Return true when any non-empty filter is active */
+export function hasActiveFilters(filters: MenuFilters): boolean {
+  return filters.query.trim() !== '' || filters.dietary !== '' || filters.allergenFree !== ''
 }

--- a/supabase/functions/create_menu_item/index.ts
+++ b/supabase/functions/create_menu_item/index.ts
@@ -113,6 +113,9 @@ export async function handler(
   const description = typeof payload['description'] === 'string' ? payload['description'].trim() : undefined
   const imageUrl = typeof payload['image_url'] === 'string' ? payload['image_url'].trim() : undefined
   const available = typeof payload['available'] === 'boolean' ? payload['available'] : true
+  const allergens = Array.isArray(payload['allergens']) ? (payload['allergens'] as string[]).filter((a) => typeof a === 'string') : []
+  const dietaryBadges = Array.isArray(payload['dietary_badges']) ? (payload['dietary_badges'] as string[]).filter((a) => typeof a === 'string') : []
+  const spicyLevel = typeof payload['spicy_level'] === 'string' ? payload['spicy_level'] : 'none'
 
   const { supabaseUrl, serviceKey } = env
   const dbHeaders = {
@@ -151,6 +154,9 @@ export async function handler(
           name,
           price_cents: priceCents,
           available,
+          allergens,
+          dietary_badges: dietaryBadges,
+          spicy_level: spicyLevel,
           ...(description !== undefined ? { description } : {}),
           ...(imageUrl !== undefined ? { image_url: imageUrl } : {}),
         }),

--- a/supabase/functions/update_menu_item/index.ts
+++ b/supabase/functions/update_menu_item/index.ts
@@ -113,6 +113,9 @@ export async function handler(
   const description = typeof payload['description'] === 'string' ? payload['description'].trim() : undefined
   const imageUrl = typeof payload['image_url'] === 'string' ? payload['image_url'].trim() : undefined
   const available = typeof payload['available'] === 'boolean' ? payload['available'] : true
+  const allergens = Array.isArray(payload['allergens']) ? (payload['allergens'] as string[]).filter((a) => typeof a === 'string') : []
+  const dietaryBadges = Array.isArray(payload['dietary_badges']) ? (payload['dietary_badges'] as string[]).filter((a) => typeof a === 'string') : []
+  const spicyLevel = typeof payload['spicy_level'] === 'string' ? payload['spicy_level'] : 'none'
 
   const { supabaseUrl, serviceKey } = env
   const dbHeaders = {
@@ -150,6 +153,9 @@ export async function handler(
           name,
           price_cents: priceCents,
           available,
+          allergens,
+          dietary_badges: dietaryBadges,
+          spicy_level: spicyLevel,
           ...(description !== undefined ? { description } : {}),
           ...(imageUrl !== undefined ? { image_url: imageUrl } : {}),
         }),

--- a/supabase/migrations/20260327240000_add_allergen_dietary_to_menu_items.sql
+++ b/supabase/migrations/20260327240000_add_allergen_dietary_to_menu_items.sql
@@ -1,0 +1,12 @@
+-- Add allergen and dietary info columns to menu_items
+-- Backward compatible: existing items default to empty arrays / 'none'
+
+ALTER TABLE menu_items
+  ADD COLUMN IF NOT EXISTS allergens text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS dietary_badges text[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS spicy_level text NOT NULL DEFAULT 'none';
+
+-- Ensure spicy_level only accepts valid values
+ALTER TABLE menu_items
+  ADD CONSTRAINT menu_items_spicy_level_check
+    CHECK (spicy_level IN ('none', 'mild', 'medium', 'hot'));


### PR DESCRIPTION
## Summary

Closes #183

Adds allergen tags, dietary badges, and spicy level to menu items — a legal requirement in many markets and an increasingly common staff/customer request.

---

## What changed

### Database
- **Migration** `20260327240000_add_allergen_dietary_to_menu_items.sql`
  - Adds `allergens text[]` (default `{}`)
  - Adds `dietary_badges text[]` (default `{}`)
  - Adds `spicy_level text` (default `'none'`, check constraint: none/mild/medium/hot)
  - Fully backward compatible — existing rows unaffected

### Edge functions
- `create_menu_item` and `update_menu_item` now accept and persist `allergens`, `dietary_badges`, `spicy_level`

### Admin — menu item editor
- **Multi-select allergen tags**: Nuts, Dairy, Gluten, Eggs, Shellfish, Soy, Sesame (toggle pill buttons, red when active)
- **Dietary badges**: Halal ✓, Vegetarian, Vegan (toggle pill buttons, emerald when active)
- **Spicy level**: None / 🌶 Mild / 🌶🌶 Medium / 🌶🌶🌶 Hot (single-select, orange when active)

### Order entry menu (staff screen)
- **MenuItemCard** now shows:
  - Dietary badges (emerald/green/lime pills)
  - Allergen tags (red pills)
  - Spicy level indicator (chilli emoji label in orange)

### Menu search/filter
- **Filter bar** added above the menu grid:
  - Dietary: Halal / Vegetarian / Vegan toggle buttons
  - Allergen-free: No Nuts / No Dairy / No Gluten / No Eggs / No Shellfish / No Soy / No Sesame
  - Filters combine with existing text search
  - Clear (×) button resets all filters

### Code
- `MenuItem` type extended with `allergens`, `dietary_badges`, `spicy_level`
- `menuSearch.ts`: new `filterMenuItemsWithFilters()` + `hasActiveFilters()` functions
- All existing tests updated; new tests for dietary/allergen filter logic added

---

## No new npm packages
## Backward compatible — all existing menu items default to empty arrays / 'none'