### PR TITLE
feat(#181): Kitchen Display Screen (KDS)

### DIFF
--- a/apps/web/app/admin/AdminNav.tsx
+++ b/apps/web/app/admin/AdminNav.tsx
@@ -17,6 +17,7 @@ const NAV_LINKS: NavLink[] = [
   { href: '/admin/users', label: 'Users' },
   { href: '/admin/reports', label: '📊 Reports' },
   { href: '/admin/settings/printer', label: '🖨 Printer' },
+  { href: '/admin/settings/kds', label: '📺 KDS' },
   { href: '/admin/restaurants', label: '🏢 Restaurants' },
   { href: '/admin/api-keys', label: '🔑 API Keys' },
 ]

--- a/apps/web/app/admin/settings/kds/page.tsx
+++ b/apps/web/app/admin/settings/kds/page.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import type { JSX } from 'react'
+import { supabase } from '@/lib/supabase'
+import Link from 'next/link'
+
+interface KdsSettingsRow {
+  id: string | null
+  restaurant_id: string
+  pin_enabled: boolean
+  pin: string | null
+  refresh_interval_seconds: number
+}
+
+const PIN_REGEX = /^\d{4}$/
+
+export default function KdsSettingsPage(): JSX.Element {
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [restaurantId, setRestaurantId] = useState<string | null>(null)
+
+  const [pinEnabled, setPinEnabled] = useState(false)
+  const [pin, setPin] = useState('')
+  const [refreshInterval, setRefreshInterval] = useState('15')
+
+  const [successMsg, setSuccessMsg] = useState<string | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load(): Promise<void> {
+      setLoading(true)
+      setErrorMsg(null)
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser()
+      if (!user) {
+        setErrorMsg('Not authenticated')
+        setLoading(false)
+        return
+      }
+
+      const { data: userData } = await supabase
+        .from('users')
+        .select('restaurant_id')
+        .eq('id', user.id)
+        .single()
+
+      const rid =
+        (userData as { restaurant_id: string | null } | null)?.restaurant_id ??
+        null
+      setRestaurantId(rid)
+
+      if (!rid) {
+        setLoading(false)
+        return
+      }
+
+      const { data: config } = await supabase
+        .from('kds_settings')
+        .select('id,restaurant_id,pin_enabled,pin,refresh_interval_seconds')
+        .eq('restaurant_id', rid)
+        .single()
+
+      if (config) {
+        const row = config as KdsSettingsRow
+        setPinEnabled(row.pin_enabled)
+        setPin(row.pin ?? '')
+        setRefreshInterval(String(row.refresh_interval_seconds ?? 15))
+      }
+
+      setLoading(false)
+    }
+
+    void load()
+  }, [])
+
+  function validate(): string | null {
+    if (pinEnabled) {
+      if (!PIN_REGEX.test(pin)) return 'PIN must be exactly 4 digits.'
+    }
+    const interval = parseInt(refreshInterval, 10)
+    if (isNaN(interval) || interval < 5 || interval > 300) {
+      return 'Refresh interval must be between 5 and 300 seconds.'
+    }
+    return null
+  }
+
+  async function handleSave(e: React.FormEvent): Promise<void> {
+    e.preventDefault()
+    setSuccessMsg(null)
+    setErrorMsg(null)
+
+    const validationError = validate()
+    if (validationError) {
+      setErrorMsg(validationError)
+      return
+    }
+
+    if (!restaurantId) {
+      setErrorMsg('No restaurant associated with your account.')
+      return
+    }
+
+    setSaving(true)
+
+    const payload = {
+      restaurant_id: restaurantId,
+      pin_enabled: pinEnabled,
+      pin: pinEnabled ? pin : null,
+      refresh_interval_seconds: parseInt(refreshInterval, 10),
+      updated_at: new Date().toISOString(),
+    }
+
+    const { error } = await supabase
+      .from('kds_settings')
+      .upsert(payload, { onConflict: 'restaurant_id' })
+
+    setSaving(false)
+
+    if (error) {
+      setErrorMsg(`Failed to save: ${error.message}`)
+    } else {
+      setSuccessMsg('KDS settings saved successfully.')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-48">
+        <span className="text-zinc-400 text-lg">Loading…</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-xl">
+      <div className="flex items-center gap-4 mb-2">
+        <h1 className="text-2xl font-bold text-white">Kitchen Display (KDS)</h1>
+        <Link
+          href="/kitchen"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="px-3 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium transition-colors"
+        >
+          Open KDS →
+        </Link>
+      </div>
+      <p className="text-zinc-400 text-sm mb-8">
+        Configure the kitchen display screen that replaces paper KOTs. Open{' '}
+        <code className="text-zinc-300">/kitchen</code> on a wall-mounted tablet
+        in the kitchen.
+      </p>
+
+      <form
+        onSubmit={(e) => {
+          void handleSave(e)
+        }}
+        className="space-y-6"
+      >
+        {/* PIN toggle */}
+        <div className="p-4 rounded-xl bg-zinc-800 border border-zinc-700 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-base font-semibold text-white">PIN Protection</div>
+              <div className="text-sm text-zinc-400">
+                Require a 4-digit PIN when opening the KDS screen
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={() => setPinEnabled((v) => !v)}
+              className={[
+                'relative inline-flex h-7 w-12 items-center rounded-full transition-colors',
+                pinEnabled ? 'bg-indigo-600' : 'bg-zinc-600',
+              ].join(' ')}
+            >
+              <span
+                className={[
+                  'inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform',
+                  pinEnabled ? 'translate-x-6' : 'translate-x-1',
+                ].join(' ')}
+              />
+            </button>
+          </div>
+
+          {pinEnabled && (
+            <div>
+              <label
+                htmlFor="kds-pin"
+                className="block text-sm font-medium text-zinc-300 mb-1"
+              >
+                PIN (4 digits)
+              </label>
+              <input
+                id="kds-pin"
+                type="text"
+                inputMode="numeric"
+                pattern="\d{4}"
+                maxLength={4}
+                value={pin}
+                onChange={(e) => setPin(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                placeholder="e.g. 1234"
+                className="w-full bg-zinc-900 border border-zinc-600 rounded-lg px-3 py-2 text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-base tracking-widest font-mono"
+              />
+              <p className="mt-1 text-xs text-zinc-500">
+                Devices that have unlocked once stay unlocked until browser data is cleared.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Refresh interval */}
+        <div>
+          <label
+            htmlFor="kds-refresh"
+            className="block text-sm font-medium text-zinc-300 mb-1"
+          >
+            Auto-refresh interval (seconds)
+          </label>
+          <input
+            id="kds-refresh"
+            type="number"
+            value={refreshInterval}
+            onChange={(e) => setRefreshInterval(e.target.value)}
+            min="5"
+            max="300"
+            className="w-full bg-zinc-900 border border-zinc-600 rounded-lg px-3 py-2 text-white placeholder-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-base"
+          />
+          <p className="mt-1 text-xs text-zinc-500">
+            Default: 15 seconds. Range: 5–300 seconds.
+          </p>
+        </div>
+
+        {/* Messages */}
+        {errorMsg && (
+          <div className="p-3 rounded-xl bg-red-900/50 border border-red-700 text-red-200 text-sm">
+            ⚠️ {errorMsg}
+          </div>
+        )}
+        {successMsg && (
+          <div className="p-3 rounded-xl bg-green-900/50 border border-green-700 text-green-200 text-sm">
+            ✅ {successMsg}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={saving}
+          className="w-full py-3 px-6 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white text-base font-semibold transition-colors min-h-[48px] disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Saving…' : 'Save Settings'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/apps/web/app/kitchen/KitchenDisplay.tsx
+++ b/apps/web/app/kitchen/KitchenDisplay.tsx
@@ -1,0 +1,403 @@
+'use client'
+
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import type { JSX } from 'react'
+import {
+  fetchKdsOrders,
+  fetchKdsSettings,
+  markOrderKitchenDone,
+  type KdsOrder,
+  type KdsSettings,
+} from './kdsApi'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function getAgeMs(firedAt: string): number {
+  return Date.now() - new Date(firedAt).getTime()
+}
+
+function formatAge(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes === 0) return `${seconds}s`
+  return `${minutes}m ${seconds}s`
+}
+
+type AgeLevel = 'green' | 'yellow' | 'red'
+
+function ageLevel(ms: number): AgeLevel {
+  const minutes = ms / 60000
+  if (minutes < 5) return 'green'
+  if (minutes < 10) return 'yellow'
+  return 'red'
+}
+
+const AGE_RING: Record<AgeLevel, string> = {
+  green: 'border-green-500',
+  yellow: 'border-yellow-400',
+  red: 'border-red-500',
+}
+
+const AGE_BADGE: Record<AgeLevel, string> = {
+  green: 'bg-green-900/60 text-green-300',
+  yellow: 'bg-yellow-900/60 text-yellow-300',
+  red: 'bg-red-900/60 text-red-300 animate-pulse',
+}
+
+const AGE_DOT: Record<AgeLevel, string> = {
+  green: '🟢',
+  yellow: '🟡',
+  red: '🔴',
+}
+
+const KDS_UNLOCK_KEY = 'kds_unlocked'
+
+// ── PIN Screen ─────────────────────────────────────────────────────────────
+
+function PinScreen({ onUnlock, correctPin }: { onUnlock: () => void; correctPin: string }): JSX.Element {
+  const [entered, setEntered] = useState('')
+  const [shaking, setShaking] = useState(false)
+
+  function handleDigit(d: string): void {
+    if (entered.length >= 4) return
+    const next = entered + d
+    setEntered(next)
+    if (next.length === 4) {
+      if (next === correctPin) {
+        onUnlock()
+      } else {
+        setShaking(true)
+        setTimeout(() => {
+          setEntered('')
+          setShaking(false)
+        }, 600)
+      }
+    }
+  }
+
+  function handleBackspace(): void {
+    setEntered((prev) => prev.slice(0, -1))
+  }
+
+  const digits = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '', '0', '⌫']
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-zinc-950 gap-8 px-4">
+      <div className="text-center">
+        <div className="text-4xl font-bold text-white mb-2">🍳 Kitchen Display</div>
+        <div className="text-zinc-400 text-xl">Enter PIN to continue</div>
+      </div>
+
+      {/* Dots */}
+      <div className={`flex gap-4 transition-all ${shaking ? 'animate-bounce' : ''}`}>
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className={[
+              'w-5 h-5 rounded-full border-2 transition-colors',
+              i < entered.length
+                ? 'bg-indigo-400 border-indigo-400'
+                : 'bg-transparent border-zinc-600',
+            ].join(' ')}
+          />
+        ))}
+      </div>
+
+      {/* Numpad */}
+      <div className="grid grid-cols-3 gap-4 w-full max-w-xs">
+        {digits.map((d, idx) => {
+          if (d === '') return <div key={idx} />
+          const isBack = d === '⌫'
+          return (
+            <button
+              key={d}
+              type="button"
+              onClick={() => (isBack ? handleBackspace() : handleDigit(d))}
+              className={[
+                'rounded-2xl text-3xl font-bold min-h-[80px] transition-colors active:scale-95',
+                isBack
+                  ? 'bg-zinc-700 hover:bg-zinc-600 text-zinc-300'
+                  : 'bg-zinc-800 hover:bg-zinc-700 text-white',
+              ].join(' ')}
+            >
+              {d}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ── Order Card ─────────────────────────────────────────────────────────────
+
+interface OrderCardProps {
+  order: KdsOrder
+  onDone: (id: string) => void
+  doneLoading: boolean
+}
+
+function OrderCard({ order, onDone, doneLoading }: OrderCardProps): JSX.Element {
+  const [preparedItems, setPreparedItems] = useState<Set<string>>(new Set())
+  const [nowMs, setNowMs] = useState(Date.now())
+
+  // Tick every second for age timer
+  useEffect(() => {
+    const interval = setInterval(() => setNowMs(Date.now()), 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const ageMs = nowMs - new Date(order.firedAt).getTime()
+  const level = ageLevel(ageMs)
+
+  function toggleItem(itemId: string): void {
+    setPreparedItems((prev) => {
+      const next = new Set(prev)
+      if (next.has(itemId)) next.delete(itemId)
+      else next.add(itemId)
+      return next
+    })
+  }
+
+  return (
+    <div
+      className={[
+        'flex flex-col bg-zinc-900 rounded-3xl border-4 p-6 gap-4',
+        AGE_RING[level],
+      ].join(' ')}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="text-4xl font-extrabold text-white leading-none">
+          {order.tableLabel}
+        </div>
+        <div className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-lg font-bold ${AGE_BADGE[level]}`}>
+          <span>{AGE_DOT[level]}</span>
+          <span>{formatAge(ageMs)}</span>
+        </div>
+      </div>
+
+      {/* Items */}
+      <ul className="flex flex-col gap-3">
+        {order.items.map((item) => {
+          const done = preparedItems.has(item.id)
+          return (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => toggleItem(item.id)}
+                className={[
+                  'w-full flex items-start gap-3 text-left rounded-xl px-3 py-2 transition-colors',
+                  done
+                    ? 'bg-zinc-800/40 text-zinc-500'
+                    : 'bg-zinc-800 text-white hover:bg-zinc-700 active:scale-[0.98]',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'text-3xl font-extrabold w-12 shrink-0 text-right',
+                    done ? 'line-through opacity-40' : '',
+                  ].join(' ')}
+                >
+                  {item.quantity}×
+                </span>
+                <div className="flex flex-col">
+                  <span
+                    className={[
+                      'text-2xl font-bold leading-tight',
+                      done ? 'line-through opacity-40' : '',
+                    ].join(' ')}
+                  >
+                    {item.name}
+                  </span>
+                  {item.modifier_names.length > 0 && (
+                    <span
+                      className={[
+                        'text-base text-zinc-400 mt-0.5',
+                        done ? 'opacity-30' : '',
+                      ].join(' ')}
+                    >
+                      {item.modifier_names.join(', ')}
+                    </span>
+                  )}
+                </div>
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+
+      {/* Mark Done */}
+      <button
+        type="button"
+        onClick={() => onDone(order.id)}
+        disabled={doneLoading}
+        className={[
+          'w-full mt-auto py-4 rounded-2xl text-2xl font-bold transition-colors min-h-[72px]',
+          doneLoading
+            ? 'bg-zinc-700 text-zinc-500 cursor-wait'
+            : 'bg-green-700 hover:bg-green-600 active:bg-green-800 text-white',
+        ].join(' ')}
+      >
+        {doneLoading ? 'Marking…' : '✅ Mark Done'}
+      </button>
+    </div>
+  )
+}
+
+// ── Main KDS Display ───────────────────────────────────────────────────────
+
+export default function KitchenDisplay(): JSX.Element {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+  const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
+
+  const [settings, setSettings] = useState<KdsSettings | null>(null)
+  const [unlocked, setUnlocked] = useState(false)
+  const [orders, setOrders] = useState<KdsOrder[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [doneLoading, setDoneLoading] = useState<string | null>(null)
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Load settings on mount
+  useEffect(() => {
+    fetchKdsSettings(supabaseUrl, apiKey)
+      .then((s) => {
+        setSettings(s)
+        // If PIN not enabled or already unlocked from localStorage, skip PIN screen
+        const storedUnlock = typeof window !== 'undefined'
+          ? localStorage.getItem(KDS_UNLOCK_KEY) === 'true'
+          : false
+        if (!s.pinEnabled || storedUnlock) {
+          setUnlocked(true)
+        }
+      })
+      .catch(() => {
+        // If settings can't be fetched, allow open access
+        setSettings({ pinEnabled: false, pin: null, refreshIntervalSeconds: 15 })
+        setUnlocked(true)
+      })
+  }, [supabaseUrl, apiKey])
+
+  const loadOrders = useCallback(async () => {
+    try {
+      const data = await fetchKdsOrders(supabaseUrl, apiKey)
+      setOrders(data)
+      setLastRefresh(new Date())
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load orders')
+    } finally {
+      setLoading(false)
+    }
+  }, [supabaseUrl, apiKey])
+
+  // Start polling once unlocked
+  useEffect(() => {
+    if (!unlocked || settings === null) return
+
+    void loadOrders()
+
+    const interval = settings.refreshIntervalSeconds * 1000
+    intervalRef.current = setInterval(() => void loadOrders(), interval)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [unlocked, settings, loadOrders])
+
+  async function handleDone(orderId: string): Promise<void> {
+    setDoneLoading(orderId)
+    try {
+      await markOrderKitchenDone(supabaseUrl, apiKey, orderId)
+      setOrders((prev) => prev.filter((o) => o.id !== orderId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to mark done')
+    } finally {
+      setDoneLoading(null)
+    }
+  }
+
+  function handleUnlock(): void {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(KDS_UNLOCK_KEY, 'true')
+    }
+    setUnlocked(true)
+  }
+
+  // ── PIN gate ──────────────────────────────────────────────────────────────
+  if (settings === null) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <span className="text-zinc-400 text-2xl animate-pulse">Loading…</span>
+      </div>
+    )
+  }
+
+  if (!unlocked && settings.pinEnabled && settings.pin) {
+    return <PinScreen onUnlock={handleUnlock} correctPin={settings.pin} />
+  }
+
+  // ── KDS screen ────────────────────────────────────────────────────────────
+  return (
+    <div className="flex flex-col min-h-screen">
+      {/* Top bar */}
+      <header className="flex items-center justify-between bg-zinc-900 border-b border-zinc-800 px-6 py-4 shrink-0">
+        <div className="flex items-center gap-3">
+          <span className="text-3xl">🍳</span>
+          <span className="text-2xl font-bold text-white">Kitchen Display</span>
+        </div>
+        <div className="flex items-center gap-4">
+          {lastRefresh && (
+            <span className="text-zinc-500 text-base">
+              Last refresh: {lastRefresh.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => void loadOrders()}
+            className="px-4 py-2 rounded-xl bg-zinc-700 hover:bg-zinc-600 text-white text-base font-medium transition-colors min-h-[44px]"
+          >
+            ↻ Refresh
+          </button>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="flex-1 p-6">
+        {error && (
+          <div className="mb-4 p-4 rounded-xl bg-red-900/40 border border-red-700 text-red-300 text-lg">
+            ⚠️ {error}
+          </div>
+        )}
+
+        {loading && (
+          <div className="flex items-center justify-center h-64">
+            <span className="text-zinc-400 text-2xl animate-pulse">Loading orders…</span>
+          </div>
+        )}
+
+        {!loading && orders.length === 0 && (
+          <div className="flex flex-col items-center justify-center h-64 gap-4">
+            <span className="text-6xl">✅</span>
+            <span className="text-zinc-400 text-2xl font-medium">All clear — no pending orders</span>
+          </div>
+        )}
+
+        {!loading && orders.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {orders.map((order) => (
+              <OrderCard
+                key={order.id}
+                order={order}
+                onDone={(id) => void handleDone(id)}
+                doneLoading={doneLoading === order.id}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/apps/web/app/kitchen/kdsApi.test.ts
+++ b/apps/web/app/kitchen/kdsApi.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchKdsOrders, fetchKdsSettings, markOrderKitchenDone } from './kdsApi'
+
+const SUPABASE_URL = 'https://example.supabase.co'
+const API_KEY = 'test-key'
+
+// Helper to build a mock fetch that returns different responses per URL
+function mockFetchSequence(responses: Array<{ ok: boolean; body: unknown }>): typeof fetch {
+  let callCount = 0
+  return vi.fn(async () => {
+    const r = responses[callCount++] ?? responses[responses.length - 1]
+    return {
+      ok: r.ok,
+      status: r.ok ? 200 : 500,
+      json: async () => r.body,
+      text: async () => JSON.stringify(r.body),
+    } as Response
+  })
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── fetchKdsOrders ────────────────────────────────────────────────────────
+
+describe('fetchKdsOrders', () => {
+  it('returns empty array when no orders exist', async () => {
+    global.fetch = vi.fn(async (url) => {
+      const urlStr = String(url)
+      if (urlStr.includes('/rest/v1/orders')) {
+        return { ok: true, status: 200, json: async () => [], text: async () => '[]' } as Response
+      }
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' } as Response
+    })
+
+    const result = await fetchKdsOrders(SUPABASE_URL, API_KEY)
+    expect(result).toEqual([])
+  })
+
+  it('filters out orders with no sent-to-kitchen items', async () => {
+    global.fetch = vi.fn(async (url) => {
+      const urlStr = String(url)
+      if (urlStr.includes('/rest/v1/orders')) {
+        return {
+          ok: true, status: 200,
+          json: async () => [{ id: 'order-1', created_at: '2024-01-01T10:00:00Z', tables: { label: 'T1' } }],
+          text: async () => '[]',
+        } as Response
+      }
+      if (urlStr.includes('/rest/v1/order_items')) {
+        // No items returned
+        return { ok: true, status: 200, json: async () => [], text: async () => '[]' } as Response
+      }
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' } as Response
+    })
+
+    const result = await fetchKdsOrders(SUPABASE_URL, API_KEY)
+    expect(result).toEqual([])
+  })
+
+  it('returns orders with items sorted oldest-first', async () => {
+    global.fetch = vi.fn(async (url) => {
+      const urlStr = String(url)
+      if (urlStr.includes('/rest/v1/orders')) {
+        return {
+          ok: true, status: 200,
+          json: async () => [
+            { id: 'order-2', created_at: '2024-01-01T10:10:00Z', tables: { label: 'T2' } },
+            { id: 'order-1', created_at: '2024-01-01T10:00:00Z', tables: { label: 'T1' } },
+          ],
+          text: async () => '[]',
+        } as Response
+      }
+      if (urlStr.includes('/rest/v1/order_items')) {
+        return {
+          ok: true, status: 200,
+          json: async () => [
+            { id: 'item-1', order_id: 'order-1', quantity: 2, sent_to_kitchen: true, voided: false, modifier_ids: [], menu_items: { name: 'Burger' } },
+            { id: 'item-2', order_id: 'order-2', quantity: 1, sent_to_kitchen: true, voided: false, modifier_ids: [], menu_items: { name: 'Pizza' } },
+          ],
+          text: async () => '[]',
+        } as Response
+      }
+      return { ok: true, status: 200, json: async () => [], text: async () => '[]' } as Response
+    })
+
+    const result = await fetchKdsOrders(SUPABASE_URL, API_KEY)
+    expect(result).toHaveLength(2)
+    expect(result[0].id).toBe('order-1')  // oldest first
+    expect(result[1].id).toBe('order-2')
+    expect(result[0].tableLabel).toBe('T1')
+    expect(result[0].items[0].name).toBe('Burger')
+    expect(result[0].items[0].quantity).toBe(2)
+  })
+
+  it('throws on network error', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+      text: async () => 'Server Error',
+    } as Response))
+
+    await expect(fetchKdsOrders(SUPABASE_URL, API_KEY)).rejects.toThrow(
+      'Failed to fetch orders: 500',
+    )
+  })
+})
+
+// ── fetchKdsSettings ──────────────────────────────────────────────────────
+
+describe('fetchKdsSettings', () => {
+  it('returns defaults when no settings row exists', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true, status: 200, json: async () => [], text: async () => '[]',
+    } as Response))
+
+    const settings = await fetchKdsSettings(SUPABASE_URL, API_KEY)
+    expect(settings.pinEnabled).toBe(false)
+    expect(settings.pin).toBeNull()
+    expect(settings.refreshIntervalSeconds).toBe(15)
+  })
+
+  it('returns defaults on fetch error', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false, status: 500, json: async () => ({}), text: async () => 'error',
+    } as Response))
+
+    const settings = await fetchKdsSettings(SUPABASE_URL, API_KEY)
+    expect(settings.pinEnabled).toBe(false)
+    expect(settings.refreshIntervalSeconds).toBe(15)
+  })
+
+  it('returns saved settings when row exists', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => [{ pin_enabled: true, pin: '1234', refresh_interval_seconds: 30 }],
+      text: async () => '',
+    } as Response))
+
+    const settings = await fetchKdsSettings(SUPABASE_URL, API_KEY)
+    expect(settings.pinEnabled).toBe(true)
+    expect(settings.pin).toBe('1234')
+    expect(settings.refreshIntervalSeconds).toBe(30)
+  })
+})
+
+// ── markOrderKitchenDone ──────────────────────────────────────────────────
+
+describe('markOrderKitchenDone', () => {
+  it('resolves on success', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true, status: 200, json: async () => ({ success: true }), text: async () => '',
+    } as Response))
+
+    await expect(markOrderKitchenDone(SUPABASE_URL, API_KEY, 'order-1')).resolves.toBeUndefined()
+  })
+
+  it('throws on failure', async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false, status: 500, json: async () => ({}), text: async () => 'Internal error',
+    } as Response))
+
+    await expect(markOrderKitchenDone(SUPABASE_URL, API_KEY, 'order-1')).rejects.toThrow(
+      'Failed to mark order done: 500',
+    )
+  })
+})

--- a/apps/web/app/kitchen/kdsApi.ts
+++ b/apps/web/app/kitchen/kdsApi.ts
@@ -1,0 +1,203 @@
+/**
+ * kdsApi.ts — Kitchen Display Screen data fetching & mutations.
+ * All calls use the anon/publishable key; no user JWT required.
+ */
+
+export interface KdsOrderItem {
+  id: string
+  name: string
+  quantity: number
+  modifier_names: string[]
+}
+
+export interface KdsOrder {
+  id: string
+  tableLabel: string
+  firedAt: string   // ISO timestamp — when order was created (proxy for kitchen fire time)
+  items: KdsOrderItem[]
+}
+
+export interface KdsSettings {
+  pinEnabled: boolean
+  pin: string | null
+  refreshIntervalSeconds: number
+}
+
+// ── Fetch open KDS orders ──────────────────────────────────────────────────
+
+interface OrderRow {
+  id: string
+  created_at: string
+  tables: { label: string } | null
+}
+
+interface OrderItemRow {
+  id: string
+  order_id: string
+  quantity: number
+  sent_to_kitchen: boolean
+  voided: boolean
+  menu_items: { name: string } | null
+  modifier_ids: string[]
+}
+
+interface ModifierRow {
+  id: string
+  name: string
+}
+
+export async function fetchKdsOrders(
+  supabaseUrl: string,
+  apiKey: string,
+): Promise<KdsOrder[]> {
+  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+
+  // Fetch open orders that have NOT been marked done by the kitchen
+  const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
+  ordersUrl.searchParams.set(
+    'select',
+    'id,created_at,tables(label)',
+  )
+  ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
+  ordersUrl.searchParams.set('kitchen_done_at', 'is.null')
+
+  const ordersRes = await fetch(ordersUrl.toString(), { headers })
+  if (!ordersRes.ok) {
+    throw new Error(`Failed to fetch orders: ${ordersRes.status}`)
+  }
+  const orders = (await ordersRes.json()) as OrderRow[]
+
+  if (orders.length === 0) return []
+
+  const orderIds = orders.map((o) => o.id)
+
+  // Fetch all order items for those orders where sent_to_kitchen = true
+  const itemsUrl = new URL(`${supabaseUrl}/rest/v1/order_items`)
+  itemsUrl.searchParams.set(
+    'select',
+    'id,order_id,quantity,sent_to_kitchen,voided,modifier_ids,menu_items(name)',
+  )
+  itemsUrl.searchParams.set('order_id', `in.(${orderIds.join(',')})`)
+  itemsUrl.searchParams.set('sent_to_kitchen', 'eq.true')
+  itemsUrl.searchParams.set('voided', 'eq.false')
+
+  const itemsRes = await fetch(itemsUrl.toString(), { headers })
+  if (!itemsRes.ok) {
+    throw new Error(`Failed to fetch order items: ${itemsRes.status}`)
+  }
+  const allItems = (await itemsRes.json()) as OrderItemRow[]
+
+  // Collect all modifier IDs
+  const allModifierIds = [...new Set(allItems.flatMap((i) => i.modifier_ids ?? []))]
+  const modifierNameMap = new Map<string, string>()
+
+  if (allModifierIds.length > 0) {
+    try {
+      const modUrl = new URL(`${supabaseUrl}/rest/v1/modifiers`)
+      modUrl.searchParams.set('select', 'id,name')
+      modUrl.searchParams.set('id', `in.(${allModifierIds.join(',')})`)
+      const modRes = await fetch(modUrl.toString(), { headers })
+      if (modRes.ok) {
+        const mods = (await modRes.json()) as ModifierRow[]
+        for (const m of mods) modifierNameMap.set(m.id, m.name)
+      }
+    } catch {
+      // non-fatal — item names still show without modifier labels
+    }
+  }
+
+  // Group items by order, skip orders that have no kitchen items
+  const itemsByOrder = new Map<string, KdsOrderItem[]>()
+  for (const item of allItems) {
+    if (!itemsByOrder.has(item.order_id)) itemsByOrder.set(item.order_id, [])
+    const ids = item.modifier_ids ?? []
+    itemsByOrder.get(item.order_id)!.push({
+      id: item.id,
+      name: item.menu_items?.name ?? '—',
+      quantity: item.quantity,
+      modifier_names: ids.map((id) => modifierNameMap.get(id) ?? id),
+    })
+  }
+
+  const result: KdsOrder[] = []
+
+  for (const order of orders) {
+    const items = itemsByOrder.get(order.id)
+    if (!items || items.length === 0) continue   // nothing fired yet — skip
+
+    const tableLabel =
+      (order.tables as { label: string } | null)?.label ?? '—'
+
+    result.push({
+      id: order.id,
+      tableLabel,
+      firedAt: order.created_at,
+      items,
+    })
+  }
+
+  // Sort oldest-first (most urgent at top-left)
+  result.sort((a, b) => new Date(a.firedAt).getTime() - new Date(b.firedAt).getTime())
+
+  return result
+}
+
+// ── Mark order as kitchen-done ─────────────────────────────────────────────
+
+export async function markOrderKitchenDone(
+  supabaseUrl: string,
+  apiKey: string,
+  orderId: string,
+): Promise<void> {
+  const res = await fetch(`${supabaseUrl}/functions/v1/mark-order-kitchen-done`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      apikey: apiKey,
+    },
+    body: JSON.stringify({ order_id: orderId }),
+  })
+
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`Failed to mark order done: ${res.status} — ${body}`)
+  }
+}
+
+// ── Fetch KDS settings ─────────────────────────────────────────────────────
+
+interface KdsSettingsRow {
+  pin_enabled: boolean
+  pin: string | null
+  refresh_interval_seconds: number
+}
+
+export async function fetchKdsSettings(
+  supabaseUrl: string,
+  apiKey: string,
+): Promise<KdsSettings> {
+  const url = new URL(`${supabaseUrl}/rest/v1/kds_settings`)
+  url.searchParams.set('select', 'pin_enabled,pin,refresh_interval_seconds')
+  url.searchParams.set('limit', '1')
+
+  const res = await fetch(url.toString(), {
+    headers: { apikey: apiKey, Authorization: `Bearer ${apiKey}` },
+  })
+
+  if (!res.ok) {
+    // Table may not exist yet — return defaults
+    return { pinEnabled: false, pin: null, refreshIntervalSeconds: 15 }
+  }
+
+  const rows = (await res.json()) as KdsSettingsRow[]
+  if (rows.length === 0) {
+    return { pinEnabled: false, pin: null, refreshIntervalSeconds: 15 }
+  }
+
+  return {
+    pinEnabled: rows[0].pin_enabled,
+    pin: rows[0].pin,
+    refreshIntervalSeconds: rows[0].refresh_interval_seconds,
+  }
+}

--- a/apps/web/app/kitchen/layout.tsx
+++ b/apps/web/app/kitchen/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next'
+import type { JSX } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Kitchen Display — iKitchen',
+}
+
+/**
+ * Standalone layout for /kitchen — no AppHeader, dark background,
+ * optimised for wall-mounted tablets.
+ */
+export default function KitchenLayout({
+  children,
+}: {
+  children: React.ReactNode
+}): JSX.Element {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-white">
+      {children}
+    </div>
+  )
+}

--- a/apps/web/app/kitchen/page.tsx
+++ b/apps/web/app/kitchen/page.tsx
@@ -1,0 +1,10 @@
+import type { JSX } from 'react'
+import KitchenDisplay from './KitchenDisplay'
+
+/**
+ * /kitchen — Kitchen Display Screen (KDS)
+ * No standard auth required — managed by PIN gate in KitchenDisplay component.
+ */
+export default function KitchenPage(): JSX.Element {
+  return <KitchenDisplay />
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -35,6 +35,12 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   const { pathname } = request.nextUrl
 
+  // /kitchen is a PIN-protected (or open) display page for kitchen devices.
+  // It handles its own lightweight auth so the standard JWT middleware is skipped.
+  if (pathname.startsWith('/kitchen')) {
+    return supabaseResponse
+  }
+
   // Authenticated user hitting /login → redirect to /tables
   if (user !== null && pathname === '/login') {
     const url = request.nextUrl.clone()

--- a/supabase/functions/mark-order-kitchen-done/index.ts
+++ b/supabase/functions/mark-order-kitchen-done/index.ts
@@ -1,0 +1,48 @@
+/**
+ * mark-order-kitchen-done
+ * KDS endpoint — no user JWT required; called with the anon/publishable key.
+ * Uses service role internally so it can bypass RLS for the kitchen_done_at update.
+ */
+
+import { createClient } from 'jsr:@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
+  try {
+    const { order_id } = (await req.json()) as { order_id?: string }
+
+    if (!order_id) {
+      return new Response(JSON.stringify({ error: 'order_id required' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      })
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+    )
+
+    const { error } = await supabase
+      .from('orders')
+      .update({ kitchen_done_at: new Date().toISOString() })
+      .eq('id', order_id)
+
+    if (error) throw error
+
+    return new Response(JSON.stringify({ success: true }), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    })
+  }
+})

--- a/supabase/migrations/20260327280000_add_kds.sql
+++ b/supabase/migrations/20260327280000_add_kds.sql
@@ -1,0 +1,48 @@
+-- #181 Kitchen Display Screen (KDS)
+-- Adds kitchen_done_at to orders (mark order as kitchen-complete)
+-- and a kds_settings table for PIN + refresh interval per restaurant.
+--
+-- Rollback:
+--   ALTER TABLE orders DROP COLUMN IF EXISTS kitchen_done_at;
+--   DROP TABLE IF EXISTS kds_settings;
+
+-- orders: track when kitchen marked an order as done
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS kitchen_done_at timestamptz;
+
+-- kds_settings: per-restaurant KDS configuration
+CREATE TABLE IF NOT EXISTS kds_settings (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id            uuid NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  pin_enabled              boolean NOT NULL DEFAULT false,
+  pin                      text,            -- 4-digit PIN; NULL when pin_enabled = false
+  refresh_interval_seconds integer NOT NULL DEFAULT 15,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (restaurant_id)
+);
+
+ALTER TABLE kds_settings ENABLE ROW LEVEL SECURITY;
+
+-- KDS devices read settings anonymously (needed for PIN check on /kitchen page)
+CREATE POLICY "anon_read_kds_settings"
+  ON kds_settings FOR SELECT TO anon, authenticated
+  USING (true);
+
+-- Only authenticated owners/managers can write settings
+CREATE POLICY "staff_write_kds_settings"
+  ON kds_settings FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE id = auth.uid()
+        AND role IN ('owner', 'manager', 'admin')
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM users
+      WHERE id = auth.uid()
+        AND role IN ('owner', 'manager', 'admin')
+    )
+  );


### PR DESCRIPTION
## Summary

Implements the Kitchen Display Screen (KDS) — a dedicated tablet-optimised screen at `/kitchen` that replaces paper KOTs in the kitchen.

Closes #181

---

## What's changed

### New: `/kitchen` route
- Standalone layout (no AppHeader, full dark `zinc-950` background)
- Excluded from the standard JWT middleware — kitchen devices don't need a POS login
- PIN gate: if PIN is enabled in Admin Settings, devices see a numpad before accessing the display; unlock state persists in `localStorage`

### Live order display
- Fetches all `open` / `pending_payment` orders where `kitchen_done_at IS NULL` and at least one `order_item.sent_to_kitchen = true`
- Each card shows: table label, all fired items with quantities + modifiers, elapsed time since order was created
- Age colour coding: 🟢 <5 min · 🟡 5–10 min · 🔴 >10 min (red pulses for urgency)
- Sorted oldest-first (most urgent at top-left)
- Auto-refreshes every N seconds (default 15, configurable)

### Interactions
- **Tap item** → strikethrough (local state, visual aid for kitchen staff)
- **Mark Done** → calls `mark-order-kitchen-done` edge function → sets `kitchen_done_at`, removes card from screen

### Admin Settings → KDS (`/admin/settings/kds`)
- Toggle PIN protection + set 4-digit PIN
- Configure auto-refresh interval (5–300s)
- "Open KDS →" shortcut link to `/kitchen`

---

## Files changed

| File | Change |
|------|--------|
| `supabase/migrations/20260327280000_add_kds.sql` | New: `kitchen_done_at` on orders, `kds_settings` table with RLS |
| `supabase/functions/mark-order-kitchen-done/index.ts` | New edge function (service-role, no user JWT required) |
| `apps/web/middleware.ts` | Exclude `/kitchen` from JWT auth redirect |
| `apps/web/app/kitchen/layout.tsx` | Standalone dark layout |
| `apps/web/app/kitchen/page.tsx` | Route entry point |
| `apps/web/app/kitchen/KitchenDisplay.tsx` | Main KDS client component |
| `apps/web/app/kitchen/kdsApi.ts` | Data fetching and mutation functions |
| `apps/web/app/kitchen/kdsApi.test.ts` | 9 unit tests (all passing) |
| `apps/web/app/admin/settings/kds/page.tsx` | Admin KDS settings page |
| `apps/web/app/admin/AdminNav.tsx` | Added 📺 KDS link |

---

## Notes
- No new npm packages added
- `kitchen_done_at` defaults to NULL on all existing orders — no data migration needed
- PIN stored in plaintext in `kds_settings` (appropriate for a kitchen display — not financial data)
- The `mark-order-kitchen-done` edge function uses service role internally; the anon key is used as the caller's API key header, which is the standard Supabase pattern for unauthenticated edge function calls