### PR TITLE
feat(#253): takeaway & delivery order types with table-free ordering

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -58,6 +58,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [paidPaymentMethod, setPaidPaymentMethod] = useState<string | null>(null)
   const [statusLoading, setStatusLoading] = useState(true)
 
+  // Order type state (takeaway / delivery support)
+  const [orderType, setOrderType] = useState<'dine_in' | 'takeaway' | 'delivery'>('dine_in')
+  const [orderCustomerName, setOrderCustomerName] = useState<string | null>(null)
+  const [orderDeliveryNote, setOrderDeliveryNote] = useState<string | null>(null)
+
   // Void item state
   const [voidingItem, setVoidingItem] = useState<OrderItem | null>(null)
   const [voidReason, setVoidReason] = useState('')
@@ -183,6 +188,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           setOrderIsPaid(true)
           setPaidPaymentMethod(summary.payment_method)
         }
+        setOrderType(summary.order_type)
+        setOrderCustomerName(summary.customer_name)
+        setOrderDeliveryNote(summary.delivery_note)
       })
       .catch(() => {
         // Non-fatal: fall back to normal order view if status check fails
@@ -286,6 +294,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   }
 
   function loadTableLabel(): void {
+    // For takeaway/delivery URL segments, skip DB lookup — label is derived from order type
+    if (tableId === 'takeaway' || tableId === 'delivery') {
+      setTableLabel(tableId === 'takeaway' ? 'TAKEAWAY' : 'DELIVERY')
+      return
+    }
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
     if (!supabaseUrl || !supabaseKey) return
@@ -1227,14 +1240,40 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
         <header className="mb-6">
           <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
-          <div className="inline-flex items-center gap-2 bg-green-900/40 border border-green-700 rounded-xl px-4 py-2 mb-4">
-            <span className="text-green-400 font-semibold text-base">Paid</span>
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            <div className="inline-flex items-center gap-2 bg-green-900/40 border border-green-700 rounded-xl px-4 py-2">
+              <span className="text-green-400 font-semibold text-base">Paid</span>
+            </div>
+            {orderType === 'takeaway' && (
+              <div className="inline-flex items-center gap-2 bg-amber-900/40 border border-amber-700 rounded-xl px-4 py-2">
+                <span className="text-amber-400 font-semibold text-base">🛍 Takeaway</span>
+              </div>
+            )}
+            {orderType === 'delivery' && (
+              <div className="inline-flex items-center gap-2 bg-blue-900/40 border border-blue-700 rounded-xl px-4 py-2">
+                <span className="text-blue-400 font-semibold text-base">🚴 Delivery</span>
+              </div>
+            )}
           </div>
           <dl className="space-y-2 text-base">
-            <div className="flex gap-3">
-              <dt className="text-zinc-500">Table</dt>
-              <dd className="font-semibold text-white">{tableId}</dd>
-            </div>
+            {orderType === 'dine_in' && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Table</dt>
+                <dd className="font-semibold text-white">{tableLabel || tableId}</dd>
+              </div>
+            )}
+            {orderType === 'delivery' && orderCustomerName && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Customer</dt>
+                <dd className="font-semibold text-white">{orderCustomerName}</dd>
+              </div>
+            )}
+            {orderType === 'delivery' && orderDeliveryNote && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Note</dt>
+                <dd className="text-zinc-300">{orderDeliveryNote}</dd>
+              </div>
+            )}
             <div className="flex gap-3">
               <dt className="text-zinc-500">Order ID</dt>
               <dd className="font-mono text-sm text-zinc-300">{orderId}</dd>
@@ -1280,6 +1319,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           timestamp={kotTimestamp}
           showAll={kotShowAll}
           courseFilter={kotCourseFilter ?? undefined}
+          orderType={orderType}
+          customerName={orderCustomerName}
+          deliveryNote={orderDeliveryNote}
         />
       </div>
 
@@ -1304,6 +1346,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             orderComp={orderIsComp}
             serviceChargePercent={serviceChargePercent}
             serviceChargeCents={billServiceChargeCents}
+            orderType={orderType}
+            customerName={orderCustomerName}
+            deliveryNote={orderDeliveryNote}
           />
         </div>
       )}
@@ -1909,16 +1954,42 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
       <header className="mb-6">
         <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
-        {orderIsComp && (
-          <div className="inline-flex items-center gap-2 bg-emerald-900/40 border border-emerald-700 rounded-xl px-4 py-2 mb-4">
-            <span className="text-emerald-400 font-semibold text-base">★ Complimentary Order</span>
-          </div>
-        )}
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          {orderIsComp && (
+            <div className="inline-flex items-center gap-2 bg-emerald-900/40 border border-emerald-700 rounded-xl px-4 py-2">
+              <span className="text-emerald-400 font-semibold text-base">★ Complimentary Order</span>
+            </div>
+          )}
+          {orderType === 'takeaway' && (
+            <div className="inline-flex items-center gap-2 bg-amber-900/40 border border-amber-700 rounded-xl px-4 py-2">
+              <span className="text-amber-400 font-semibold text-base">🛍 Takeaway</span>
+            </div>
+          )}
+          {orderType === 'delivery' && (
+            <div className="inline-flex items-center gap-2 bg-blue-900/40 border border-blue-700 rounded-xl px-4 py-2">
+              <span className="text-blue-400 font-semibold text-base">🚴 Delivery</span>
+            </div>
+          )}
+        </div>
         <dl className="space-y-2 text-base">
-          <div className="flex gap-3">
-            <dt className="text-zinc-500">Table</dt>
-            <dd className="font-semibold text-white">{tableId}</dd>
-          </div>
+          {orderType === 'dine_in' && (
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Table</dt>
+              <dd className="font-semibold text-white">{tableLabel || tableId}</dd>
+            </div>
+          )}
+          {orderType === 'delivery' && orderCustomerName && (
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Customer</dt>
+              <dd className="font-semibold text-white">{orderCustomerName}</dd>
+            </div>
+          )}
+          {orderType === 'delivery' && orderDeliveryNote && (
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Note</dt>
+              <dd className="text-zinc-300">{orderDeliveryNote}</dd>
+            </div>
+          )}
           <div className="flex gap-3">
             <dt className="text-zinc-500">Order ID</dt>
             <dd className="font-mono text-sm text-zinc-300">{orderId}</dd>
@@ -2006,13 +2077,15 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               </button>
             )}
 
-            <button
-              type="button"
-              onClick={() => { void openTransferModal() }}
-              className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-amber-400 border-2 border-zinc-700 hover:border-amber-600 transition-colors mb-3"
-            >
-              ↔ Move Table
-            </button>
+            {orderType === 'dine_in' && (
+              <button
+                type="button"
+                onClick={() => { void openTransferModal() }}
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-amber-400 border-2 border-zinc-700 hover:border-amber-600 transition-colors mb-3"
+              >
+                ↔ Move Table
+              </button>
+            )}
 
             <button
               type="button"

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
@@ -140,19 +140,19 @@ describe('fetchOrderSummary', () => {
   it('returns status open with null payment_method for open orders', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string }>> => [{ status: 'open' }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
     })
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'open', payment_method: null })
+    expect(result).toEqual({ status: 'open', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null })
   })
 
   it('fetches payment method when order is paid', async (): Promise<void> => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async (): Promise<Array<{ status: string }>> => [{ status: 'paid' }],
+        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null }],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -161,14 +161,14 @@ describe('fetchOrderSummary', () => {
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'paid', payment_method: 'card' })
+    expect(result).toEqual({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null })
   })
 
   it('returns null payment_method when payment fetch fails for paid order', async (): Promise<void> => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async (): Promise<Array<{ status: string }>> => [{ status: 'paid' }],
+        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null }],
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -179,7 +179,7 @@ describe('fetchOrderSummary', () => {
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'paid', payment_method: null })
+    expect(result).toEqual({ status: 'paid', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null })
   })
 
   it('throws when the order fetch fails', async (): Promise<void> => {
@@ -209,7 +209,7 @@ describe('fetchOrderSummary', () => {
   it('passes correct auth headers', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string }>> => [{ status: 'open' }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
     })
 
     await fetchOrderSummary('https://example.supabase.co', 'my-key', 'order-abc')
@@ -223,7 +223,7 @@ describe('fetchOrderSummary', () => {
   it('queries the correct order endpoint with id filter', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string }>> => [{ status: 'open' }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
     })
 
     await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-xyz')

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
@@ -46,6 +46,12 @@ export function calcItemDiscountCents(item: Pick<OrderItem, 'quantity' | 'price_
 export interface OrderSummary {
   status: string
   payment_method: string | null
+  /** Order type — dine_in (default), takeaway, or delivery */
+  order_type: 'dine_in' | 'takeaway' | 'delivery'
+  /** Customer name for delivery orders */
+  customer_name: string | null
+  /** Delivery address/note for delivery orders */
+  delivery_note: string | null
 }
 
 interface OrderItemRow {
@@ -187,7 +193,7 @@ export async function fetchOrderSummary(
 
   const orderUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
   orderUrl.searchParams.set('id', `eq.${orderId}`)
-  orderUrl.searchParams.set('select', 'status')
+  orderUrl.searchParams.set('select', 'status,order_type,customer_name,delivery_note')
 
   const orderRes = await fetch(orderUrl.toString(), { headers })
   if (!orderRes.ok) {
@@ -195,14 +201,29 @@ export async function fetchOrderSummary(
     throw new Error(`Failed to fetch order: ${orderRes.status} ${orderRes.statusText} — ${body}`)
   }
 
-  const orders = (await orderRes.json()) as Array<{ status: string }>
+  const orders = (await orderRes.json()) as Array<{
+    status: string
+    order_type: string | null
+    customer_name: string | null
+    delivery_note: string | null
+  }>
   if (orders.length === 0) {
     throw new Error('Order not found')
   }
 
   const { status } = orders[0]
+  const orderType = (orders[0].order_type ?? 'dine_in') as 'dine_in' | 'takeaway' | 'delivery'
+  const customerName = orders[0].customer_name ?? null
+  const deliveryNote = orders[0].delivery_note ?? null
+
   if (status !== 'paid') {
-    return { status, payment_method: null }
+    return {
+      status,
+      payment_method: null,
+      order_type: orderType,
+      customer_name: customerName,
+      delivery_note: deliveryNote,
+    }
   }
 
   const paymentUrl = new URL(`${supabaseUrl}/rest/v1/payments`)
@@ -212,12 +233,21 @@ export async function fetchOrderSummary(
 
   const paymentRes = await fetch(paymentUrl.toString(), { headers })
   if (!paymentRes.ok) {
-    return { status, payment_method: null }
+    return {
+      status,
+      payment_method: null,
+      order_type: orderType,
+      customer_name: customerName,
+      delivery_note: deliveryNote,
+    }
   }
 
   const payments = (await paymentRes.json()) as Array<{ method: string }>
   return {
     status,
     payment_method: payments.length > 0 ? payments[0].method : null,
+    order_type: orderType,
+    customer_name: customerName,
+    delivery_note: deliveryNote,
   }
 }

--- a/apps/web/app/tables/components/createOrderApi.test.ts
+++ b/apps/web/app/tables/components/createOrderApi.test.ts
@@ -9,33 +9,27 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+function makeMockFetch(orderId = 'abc-123') {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        success: true,
+        data: { order_id: orderId, status: 'open' },
+      }),
+  })
+}
+
 describe('callCreateOrder', () => {
   it('resolves with order_id on successful response', async (): Promise<void> => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            success: true,
-            data: { order_id: 'abc-123', status: 'open' },
-          }),
-      }),
-    )
+    vi.stubGlobal('fetch', makeMockFetch())
 
     const result = await callCreateOrder(BASE_URL, API_KEY, TABLE_ID)
     expect(result.order_id).toBe('abc-123')
   })
 
   it('sends a POST request to the correct endpoint', async (): Promise<void> => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          success: true,
-          data: { order_id: 'xyz-456', status: 'open' },
-        }),
-    })
+    const mockFetch = makeMockFetch('xyz-456')
     vi.stubGlobal('fetch', mockFetch)
 
     await callCreateOrder(BASE_URL, API_KEY, 'table-uuid-003')
@@ -47,46 +41,66 @@ describe('callCreateOrder', () => {
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
           Authorization: `Bearer ${API_KEY}`,
-          apikey: API_KEY,
         }),
       }),
     )
   })
 
-  it('sends table_id in the request body', async (): Promise<void> => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          success: true,
-          data: { order_id: 'order-789', status: 'open' },
-        }),
-    })
+  it('sends table_id in the request body for dine_in (legacy string signature)', async (): Promise<void> => {
+    const mockFetch = makeMockFetch('order-789')
     vi.stubGlobal('fetch', mockFetch)
 
     await callCreateOrder(BASE_URL, API_KEY, 'table-uuid-007')
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
-    const body = JSON.parse(init.body as string) as { table_id: string }
+    const body = JSON.parse(init.body as string) as { table_id: string; order_type: string }
     expect(body.table_id).toBe('table-uuid-007')
+    expect(body.order_type).toBe('dine_in')
   })
 
-  it('sends staff_id placeholder in the request body', async (): Promise<void> => {
-    const mockFetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: () =>
-        Promise.resolve({
-          success: true,
-          data: { order_id: 'order-789', status: 'open' },
-        }),
-    })
+  it('sends order_type dine_in by default', async (): Promise<void> => {
+    const mockFetch = makeMockFetch()
     vi.stubGlobal('fetch', mockFetch)
 
-    await callCreateOrder(BASE_URL, API_KEY, 'table-uuid-007')
+    await callCreateOrder(BASE_URL, API_KEY, { tableId: TABLE_ID, orderType: 'dine_in' })
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
-    const body = JSON.parse(init.body as string) as { staff_id: string }
-    expect(body.staff_id).toBe('placeholder-staff')
+    const body = JSON.parse(init.body as string) as { order_type: string }
+    expect(body.order_type).toBe('dine_in')
+  })
+
+  it('sends takeaway order without table_id', async (): Promise<void> => {
+    const mockFetch = makeMockFetch('takeaway-001')
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await callCreateOrder(BASE_URL, API_KEY, { orderType: 'takeaway' })
+    expect(result.order_id).toBe('takeaway-001')
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as { order_type: string; table_id?: string }
+    expect(body.order_type).toBe('takeaway')
+    expect(body.table_id).toBeUndefined()
+  })
+
+  it('sends delivery order with customer_name and delivery_note', async (): Promise<void> => {
+    const mockFetch = makeMockFetch('delivery-001')
+    vi.stubGlobal('fetch', mockFetch)
+
+    await callCreateOrder(BASE_URL, API_KEY, {
+      orderType: 'delivery',
+      customerName: 'Ahmed Khan',
+      deliveryNote: 'Ring the bell',
+    })
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(init.body as string) as {
+      order_type: string
+      customer_name: string
+      delivery_note: string
+    }
+    expect(body.order_type).toBe('delivery')
+    expect(body.customer_name).toBe('Ahmed Khan')
+    expect(body.delivery_note).toBe('Ring the bell')
   })
 
   it('throws with HTTP status when response is not ok', async (): Promise<void> => {

--- a/apps/web/app/tables/components/createOrderApi.ts
+++ b/apps/web/app/tables/components/createOrderApi.ts
@@ -1,3 +1,5 @@
+export type OrderType = 'dine_in' | 'takeaway' | 'delivery'
+
 export interface CreateOrderResponse {
   success: boolean
   data?: { order_id: string; status: string }
@@ -8,18 +10,42 @@ export interface CreateOrderResult {
   order_id: string
 }
 
+export interface CreateOrderOptions {
+  tableId?: string
+  orderType?: OrderType
+  customerName?: string
+  deliveryNote?: string
+}
+
 export async function callCreateOrder(
   supabaseUrl: string,
   accessToken: string,
-  tableId: string,
+  tableIdOrOptions: string | CreateOrderOptions,
 ): Promise<CreateOrderResult> {
+  // Support legacy call signature (tableId as string) for backward compatibility
+  let opts: CreateOrderOptions
+  if (typeof tableIdOrOptions === 'string') {
+    opts = { tableId: tableIdOrOptions, orderType: 'dine_in' }
+  } else {
+    opts = tableIdOrOptions
+  }
+
+  const { tableId, orderType = 'dine_in', customerName, deliveryNote } = opts
+
+  const bodyPayload: Record<string, string> = {
+    order_type: orderType,
+  }
+  if (tableId) bodyPayload['table_id'] = tableId
+  if (customerName) bodyPayload['customer_name'] = customerName
+  if (deliveryNote) bodyPayload['delivery_note'] = deliveryNote
+
   const res = await fetch(`${supabaseUrl}/functions/v1/create_order`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({ table_id: tableId }),
+    body: JSON.stringify(bodyPayload),
   })
   if (!res.ok) {
     const body = await res.text()

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -3,11 +3,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { JSX } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import TableCard from './components/TableCard'
-import { fetchTables } from './tablesData'
-import type { TableRow } from './tablesData'
+import { fetchTables, fetchTakeawayDeliveryQueue } from './tablesData'
+import type { TableRow, TakeawayDeliveryOrder } from './tablesData'
 import { STATUS_CONFIG } from './tableStatus'
 import type { TableStatus } from './tableStatus'
+import { callCreateOrder } from './components/createOrderApi'
+import { useUser } from '@/lib/user-context'
 
 /** Auto-refresh interval in milliseconds (30 seconds) */
 const REFRESH_INTERVAL_MS = 30_000
@@ -19,13 +22,37 @@ const STATUS_LEGEND: { status: TableStatus; label: string; dotClass: string }[] 
   { status: 'overdue', label: 'Overdue (>2h)', dotClass: 'bg-red-500' },
 ]
 
+/** Returns a human-readable order age string from an ISO timestamp. */
+function orderAge(createdAt: string): string {
+  const diffMs = Date.now() - new Date(createdAt).getTime()
+  const mins = Math.floor(diffMs / 60_000)
+  if (mins < 1) return '<1m'
+  if (mins < 60) return `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const rem = mins % 60
+  return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`
+}
+
 export default function TablesPage(): JSX.Element {
+  const router = useRouter()
+  const { accessToken } = useUser()
+
   const [tables, setTables] = useState<TableRow[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+
+  const [queue, setQueue] = useState<TakeawayDeliveryOrder[]>([])
+
+  // Delivery modal state
+  const [showDeliveryModal, setShowDeliveryModal] = useState(false)
+  const [deliveryCustomerName, setDeliveryCustomerName] = useState('')
+  const [deliveryNote, setDeliveryNote] = useState('')
+  const [creatingOrder, setCreatingOrder] = useState(false)
+  const [createOrderError, setCreateOrderError] = useState<string | null>(null)
+
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const loadTables = useCallback((): void => {
+  const loadAll = useCallback((): void => {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 
@@ -37,8 +64,15 @@ export default function TablesPage(): JSX.Element {
 
     setLoading(true)
     setError(null)
-    fetchTables(supabaseUrl, supabaseKey)
-      .then(setTables)
+
+    Promise.all([
+      fetchTables(supabaseUrl, supabaseKey),
+      fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey),
+    ])
+      .then(([t, q]) => {
+        setTables(t)
+        setQueue(q)
+      })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : 'Failed to load tables')
       })
@@ -47,8 +81,8 @@ export default function TablesPage(): JSX.Element {
 
   // Initial load
   useEffect(() => {
-    loadTables()
-  }, [loadTables])
+    loadAll()
+  }, [loadAll])
 
   // Auto-refresh every 30s
   useEffect(() => {
@@ -57,8 +91,14 @@ export default function TablesPage(): JSX.Element {
       const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
       if (!supabaseUrl || !supabaseKey) return
 
-      fetchTables(supabaseUrl, supabaseKey)
-        .then(setTables)
+      Promise.all([
+        fetchTables(supabaseUrl, supabaseKey),
+        fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey),
+      ])
+        .then(([t, q]) => {
+          setTables(t)
+          setQueue(q)
+        })
         .catch(() => { /* silent background refresh failure */ })
     }, REFRESH_INTERVAL_MS)
 
@@ -68,6 +108,53 @@ export default function TablesPage(): JSX.Element {
       }
     }
   }, [])
+
+  async function handleCreateTakeaway(): Promise<void> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    if (!supabaseUrl || !accessToken) {
+      setCreateOrderError('Not authenticated')
+      return
+    }
+    setCreatingOrder(true)
+    setCreateOrderError(null)
+    try {
+      const result = await callCreateOrder(supabaseUrl, accessToken, {
+        orderType: 'takeaway',
+      })
+      router.push(`/tables/takeaway/order/${result.order_id}`)
+    } catch (err) {
+      setCreateOrderError(err instanceof Error ? err.message : 'Failed to create takeaway order')
+      setCreatingOrder(false)
+    }
+  }
+
+  async function handleCreateDelivery(): Promise<void> {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    if (!supabaseUrl || !accessToken) {
+      setCreateOrderError('Not authenticated')
+      return
+    }
+    if (!deliveryCustomerName.trim()) {
+      setCreateOrderError('Customer name is required for delivery orders')
+      return
+    }
+    setCreatingOrder(true)
+    setCreateOrderError(null)
+    try {
+      const result = await callCreateOrder(supabaseUrl, accessToken, {
+        orderType: 'delivery',
+        customerName: deliveryCustomerName.trim(),
+        deliveryNote: deliveryNote.trim() || undefined,
+      })
+      setShowDeliveryModal(false)
+      setDeliveryCustomerName('')
+      setDeliveryNote('')
+      router.push(`/tables/delivery/order/${result.order_id}`)
+    } catch (err) {
+      setCreateOrderError(err instanceof Error ? err.message : 'Failed to create delivery order')
+      setCreatingOrder(false)
+    }
+  }
 
   return (
     <main className="min-h-screen bg-zinc-900 p-6">
@@ -82,7 +169,7 @@ export default function TablesPage(): JSX.Element {
           </Link>
           <button
             type="button"
-            onClick={loadTables}
+            onClick={loadAll}
             className="text-zinc-400 hover:text-white text-base font-medium px-4 py-2 rounded-lg border border-zinc-700 hover:border-zinc-500 transition-colors min-h-[48px]"
           >
             Refresh
@@ -101,17 +188,201 @@ export default function TablesPage(): JSX.Element {
         <span className="text-xs text-zinc-600 ml-auto">Auto-refreshes every 30s</span>
       </div>
 
+      {/* Takeaway / Delivery quick-launch buttons */}
+      <div className="flex gap-3 mb-6">
+        <button
+          type="button"
+          onClick={() => { void handleCreateTakeaway() }}
+          disabled={creatingOrder}
+          className={[
+            'flex-1 min-h-[56px] rounded-xl text-base font-semibold transition-colors border-2',
+            creatingOrder
+              ? 'border-amber-800 bg-amber-900/20 text-amber-600 cursor-wait'
+              : 'border-amber-500 bg-amber-500/10 text-amber-400 hover:bg-amber-500/20 hover:border-amber-400',
+          ].join(' ')}
+        >
+          {creatingOrder ? 'Creating…' : '🛍 New Takeaway Order'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setDeliveryCustomerName('')
+            setDeliveryNote('')
+            setCreateOrderError(null)
+            setShowDeliveryModal(true)
+          }}
+          disabled={creatingOrder}
+          className={[
+            'flex-1 min-h-[56px] rounded-xl text-base font-semibold transition-colors border-2',
+            creatingOrder
+              ? 'border-blue-800 bg-blue-900/20 text-blue-600 cursor-wait'
+              : 'border-blue-500 bg-blue-500/10 text-blue-400 hover:bg-blue-500/20 hover:border-blue-400',
+          ].join(' ')}
+        >
+          🚴 New Delivery Order
+        </button>
+      </div>
+
+      {createOrderError !== null && !showDeliveryModal && (
+        <p className="text-red-400 text-sm mb-4">{createOrderError}</p>
+      )}
+
       {loading ? (
         <p className="text-zinc-400 text-lg">Loading tables…</p>
       ) : error !== null ? (
         <p className="text-red-400 text-lg">{error}</p>
       ) : (
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {tables.length === 0 ? (
-            <p className="text-zinc-400 text-lg col-span-full">No tables configured.</p>
-          ) : tables.map((table) => (
-            <TableCard key={table.id} table={table} />
-          ))}
+        <>
+          {/* Dine-in table grid */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mb-10">
+            {tables.length === 0 ? (
+              <p className="text-zinc-400 text-lg col-span-full">No tables configured.</p>
+            ) : tables.map((table) => (
+              <TableCard key={table.id} table={table} />
+            ))}
+          </div>
+
+          {/* Takeaway / Delivery Queue */}
+          <section>
+            <h2 className="text-lg font-bold text-white mb-3 flex items-center gap-2">
+              <span>Takeaway / Delivery Queue</span>
+              {queue.length > 0 && (
+                <span className="text-sm font-normal bg-amber-500/20 text-amber-400 border border-amber-700 rounded-full px-2 py-0.5">
+                  {queue.length}
+                </span>
+              )}
+            </h2>
+            {queue.length === 0 ? (
+              <p className="text-zinc-500 text-base">No active takeaway or delivery orders.</p>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+                {queue.map((order) => {
+                  const isDelivery = order.order_type === 'delivery'
+                  const urlSegment = isDelivery ? 'delivery' : 'takeaway'
+                  return (
+                    <button
+                      key={order.id}
+                      type="button"
+                      onClick={() => { router.push(`/tables/${urlSegment}/order/${order.id}`) }}
+                      className={[
+                        'flex flex-col gap-2 p-4 rounded-xl border-2 text-left transition-colors',
+                        isDelivery
+                          ? 'border-blue-700 bg-blue-900/20 hover:bg-blue-900/40 hover:border-blue-500'
+                          : 'border-amber-700 bg-amber-900/20 hover:bg-amber-900/40 hover:border-amber-500',
+                      ].join(' ')}
+                    >
+                      {/* Type badge + age */}
+                      <div className="flex items-center justify-between">
+                        <span className={[
+                          'text-xs font-bold px-2 py-0.5 rounded-full',
+                          isDelivery
+                            ? 'bg-blue-900/60 text-blue-300'
+                            : 'bg-amber-900/60 text-amber-300',
+                        ].join(' ')}>
+                          {isDelivery ? '🚴 DELIVERY' : '🛍 TAKEAWAY'}
+                        </span>
+                        <span className="text-xs text-zinc-500">{orderAge(order.created_at)}</span>
+                      </div>
+
+                      {/* Customer name (delivery only) */}
+                      {isDelivery && order.customer_name && (
+                        <p className="text-white font-semibold text-base">{order.customer_name}</p>
+                      )}
+
+                      {/* Item count */}
+                      <p className="text-zinc-400 text-sm">
+                        {order.item_count} item{order.item_count !== 1 ? 's' : ''}
+                      </p>
+
+                      {/* Order ID snippet */}
+                      <p className="text-zinc-600 text-xs font-mono">{order.id.slice(0, 8)}</p>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+
+      {/* Delivery order modal */}
+      {showDeliveryModal && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/70">
+          <div className="w-full max-w-lg bg-zinc-900 rounded-t-2xl p-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold text-white">🚴 New Delivery Order</h2>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowDeliveryModal(false)
+                  setCreateOrderError(null)
+                }}
+                className="min-h-[48px] min-w-[48px] text-zinc-400 hover:text-white text-2xl"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div>
+              <label htmlFor="delivery-customer-name" className="block text-zinc-400 text-base mb-2">
+                Customer Name <span className="text-red-400">*</span>
+              </label>
+              <input
+                id="delivery-customer-name"
+                type="text"
+                placeholder="e.g. Ahmed Khan"
+                value={deliveryCustomerName}
+                onChange={(e) => { setDeliveryCustomerName(e.target.value) }}
+                className="w-full min-h-[48px] px-4 rounded-xl text-base bg-zinc-800 text-white border-2 border-zinc-600 focus:border-blue-400 focus:outline-none"
+                autoFocus
+              />
+            </div>
+
+            <div>
+              <label htmlFor="delivery-note" className="block text-zinc-400 text-base mb-2">
+                Delivery Note <span className="text-zinc-600">(optional)</span>
+              </label>
+              <input
+                id="delivery-note"
+                type="text"
+                placeholder="e.g. Road 12, House 5, Ring the bell"
+                value={deliveryNote}
+                onChange={(e) => { setDeliveryNote(e.target.value) }}
+                className="w-full min-h-[48px] px-4 rounded-xl text-base bg-zinc-800 text-white border-2 border-zinc-600 focus:border-blue-400 focus:outline-none"
+              />
+            </div>
+
+            {createOrderError !== null && (
+              <p className="text-red-400 text-sm">{createOrderError}</p>
+            )}
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowDeliveryModal(false)
+                  setCreateOrderError(null)
+                }}
+                disabled={creatingOrder}
+                className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold border-2 border-zinc-600 text-zinc-300 hover:border-zinc-400 transition-colors disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => { void handleCreateDelivery() }}
+                disabled={creatingOrder || deliveryCustomerName.trim() === ''}
+                className={[
+                  'flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors',
+                  creatingOrder || deliveryCustomerName.trim() === ''
+                    ? 'bg-zinc-700 text-zinc-400 cursor-wait'
+                    : 'bg-blue-600 hover:bg-blue-500 text-white',
+                ].join(' ')}
+              >
+                {creatingOrder ? 'Creating…' : 'Create Order'}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </main>

--- a/apps/web/app/tables/tablesData.ts
+++ b/apps/web/app/tables/tablesData.ts
@@ -8,6 +8,16 @@ export interface TableRow {
   order_item_count: number | null
 }
 
+export interface TakeawayDeliveryOrder {
+  id: string
+  order_type: 'takeaway' | 'delivery'
+  customer_name: string | null
+  delivery_note: string | null
+  status: string
+  created_at: string
+  item_count: number
+}
+
 interface TableApiRow {
   id: string
   label: string
@@ -16,6 +26,15 @@ interface TableApiRow {
 interface OrderApiRow {
   id: string
   table_id: string | null
+  status: string
+  created_at: string
+}
+
+interface TakeawayDeliveryApiRow {
+  id: string
+  order_type: string
+  customer_name: string | null
+  delivery_note: string | null
   status: string
   created_at: string
 }
@@ -42,6 +61,7 @@ export async function fetchTables(
   const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
   ordersUrl.searchParams.set('select', 'id,table_id,status,created_at')
   ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
+  ordersUrl.searchParams.set('order_type', 'eq.dine_in')
 
   const ordersRes = await fetch(ordersUrl.toString(), { headers })
 
@@ -92,4 +112,60 @@ export async function fetchTables(
       order_item_count: order !== undefined ? (itemCountByOrder.get(order.id) ?? 0) : null,
     }
   })
+}
+
+/**
+ * Fetch active takeaway and delivery orders for the queue section on the tables page.
+ */
+export async function fetchTakeawayDeliveryQueue(
+  supabaseUrl: string,
+  apiKey: string,
+): Promise<TakeawayDeliveryOrder[]> {
+  const headers = {
+    apikey: apiKey,
+    Authorization: `Bearer ${apiKey}`,
+  }
+
+  const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
+  ordersUrl.searchParams.set('select', 'id,order_type,customer_name,delivery_note,status,created_at')
+  ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
+  ordersUrl.searchParams.set('order_type', 'in.(takeaway,delivery)')
+  ordersUrl.searchParams.set('order', 'created_at.asc')
+
+  const ordersRes = await fetch(ordersUrl.toString(), { headers })
+  if (!ordersRes.ok) {
+    const body = await ordersRes.text()
+    throw new Error(`Failed to fetch takeaway/delivery orders: ${ordersRes.status} — ${body}`)
+  }
+
+  const orders = (await ordersRes.json()) as TakeawayDeliveryApiRow[]
+
+  if (orders.length === 0) return []
+
+  // Fetch item counts for these orders
+  const orderIds = orders.map((o) => o.id)
+  const itemCountByOrder = new Map<string, number>()
+
+  const itemsUrl = new URL(`${supabaseUrl}/rest/v1/order_items`)
+  itemsUrl.searchParams.set('select', 'order_id')
+  itemsUrl.searchParams.set('voided', 'eq.false')
+  itemsUrl.searchParams.set('order_id', `in.(${orderIds.join(',')})`)
+
+  const itemsRes = await fetch(itemsUrl.toString(), { headers })
+  if (itemsRes.ok) {
+    const items = (await itemsRes.json()) as Array<{ order_id: string }>
+    for (const item of items) {
+      itemCountByOrder.set(item.order_id, (itemCountByOrder.get(item.order_id) ?? 0) + 1)
+    }
+  }
+
+  return orders.map((o) => ({
+    id: o.id,
+    order_type: o.order_type as 'takeaway' | 'delivery',
+    customer_name: o.customer_name,
+    delivery_note: o.delivery_note,
+    status: o.status,
+    created_at: o.created_at,
+    item_count: itemCountByOrder.get(o.id) ?? 0,
+  }))
 }

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -29,6 +29,12 @@ export interface BillPrintViewProps {
   serviceChargeCents?: number
   /** Explicit VAT amount in cents — pre-calculated by caller (overrides derived vatCents) */
   vatCents?: number
+  /** Order type — shown on bill for non-dine-in orders. */
+  orderType?: 'dine_in' | 'takeaway' | 'delivery'
+  /** Customer name for delivery orders. */
+  customerName?: string | null
+  /** Delivery note for delivery orders. */
+  deliveryNote?: string | null
 }
 
 export default function BillPrintView({
@@ -49,10 +55,16 @@ export default function BillPrintView({
   serviceChargePercent = 0,
   serviceChargeCents = 0,
   vatCents: vatCentsProp,
+  orderType = 'dine_in',
+  customerName,
+  deliveryNote,
 }: BillPrintViewProps): JSX.Element {
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
   const vatCents = vatCentsProp !== undefined ? vatCentsProp : totalCents - subtotalCents
+
+  const isTakeaway = orderType === 'takeaway'
+  const isDelivery = orderType === 'delivery'
 
   return (
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
@@ -63,9 +75,24 @@ export default function BillPrintView({
         <p className="text-xs">{timestamp}</p>
       </div>
 
+      {/* TAKEAWAY / DELIVERY banner on bill */}
+      {(isTakeaway || isDelivery) && (
+        <div className="border border-black py-1 mb-2 text-center">
+          <p className="text-sm font-bold tracking-widest">
+            {isDelivery ? 'DELIVERY' : 'TAKEAWAY'}
+          </p>
+          {isDelivery && customerName && (
+            <p className="text-xs font-bold">{customerName}</p>
+          )}
+          {isDelivery && deliveryNote && (
+            <p className="text-xs">{deliveryNote}</p>
+          )}
+        </div>
+      )}
+
       {/* Order info */}
       <div className="border-t border-b border-black py-1 mb-2 text-sm">
-        <p>Table: {tableLabel}</p>
+        {!isTakeaway && !isDelivery && <p>Table: {tableLabel}</p>}
         <p>Order: {orderId.slice(0, 8)}</p>
       </div>
 
@@ -178,7 +205,7 @@ export default function BillPrintView({
 
       {/* Footer */}
       <div className="border-t border-black mt-2 pt-1 text-center text-xs">
-        Thank you for dining with us!
+        {isDelivery ? 'Thank you for your order!' : 'Thank you for dining with us!'}
       </div>
     </div>
   )

--- a/apps/web/components/KotPrintView.tsx
+++ b/apps/web/components/KotPrintView.tsx
@@ -14,6 +14,12 @@ interface KotPrintViewProps {
    * Used when firing a specific course (e.g. "STARTER").
    */
   courseFilter?: 'starter' | 'main' | 'dessert'
+  /** Order type — shows TAKEAWAY or DELIVERY banner at the top of the KOT. */
+  orderType?: 'dine_in' | 'takeaway' | 'delivery'
+  /** Customer name for delivery orders. */
+  customerName?: string | null
+  /** Delivery note for delivery orders. */
+  deliveryNote?: string | null
 }
 
 const COURSE_LABELS: Record<string, string> = {
@@ -29,6 +35,9 @@ export default function KotPrintView({
   timestamp,
   showAll = false,
   courseFilter,
+  orderType = 'dine_in',
+  customerName,
+  deliveryNote,
 }: KotPrintViewProps): JSX.Element {
   // Base filter: unsent items (or all for reprint)
   let displayItems = showAll ? items : items.filter((item) => !item.sent_to_kitchen)
@@ -38,6 +47,9 @@ export default function KotPrintView({
     displayItems = displayItems.filter((item) => item.course === courseFilter)
   }
 
+  const isTakeaway = orderType === 'takeaway'
+  const isDelivery = orderType === 'delivery'
+
   return (
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       <div className="text-center mb-2">
@@ -45,8 +57,24 @@ export default function KotPrintView({
         <p className="text-sm">KITCHEN ORDER TICKET</p>
         {showAll && !courseFilter && <p className="text-xs">(REPRINT)</p>}
       </div>
+
+      {/* TAKEAWAY / DELIVERY banner */}
+      {(isTakeaway || isDelivery) && (
+        <div className="border-2 border-black py-1 mb-2 text-center">
+          <p className="text-lg font-bold tracking-widest">
+            {isDelivery ? '★ DELIVERY ★' : '★ TAKEAWAY ★'}
+          </p>
+          {isDelivery && customerName && (
+            <p className="text-sm font-bold">{customerName}</p>
+          )}
+          {isDelivery && deliveryNote && (
+            <p className="text-xs">{deliveryNote}</p>
+          )}
+        </div>
+      )}
+
       <div className="border-t border-b border-black py-1 mb-2 text-sm">
-        <p>Table: {tableLabel}</p>
+        {!isTakeaway && !isDelivery && <p>Table: {tableLabel}</p>}
         <p>Order: {orderId.slice(0, 8)}</p>
         <p>Time: {timestamp}</p>
         {courseFilter !== undefined && (

--- a/supabase/functions/create_order/index.ts
+++ b/supabase/functions/create_order/index.ts
@@ -65,14 +65,26 @@ export async function handler(
   }
 
   const payload = body as Record<string, unknown>
-  if (typeof payload['table_id'] !== 'string' || payload['table_id'] === '') {
+
+  // Parse order_type (default to dine_in for backward compatibility)
+  const orderType = (payload['order_type'] as string | undefined) ?? 'dine_in'
+  if (!['dine_in', 'takeaway', 'delivery'].includes(orderType)) {
     return new Response(
-      JSON.stringify({ success: false, error: 'table_id is required and must be a non-empty string' }),
+      JSON.stringify({ success: false, error: 'order_type must be dine_in, takeaway, or delivery' }),
       { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   }
 
-  const tableId = payload['table_id'] as string
+  const customerName = (payload['customer_name'] as string | undefined) ?? null
+  const deliveryNote = (payload['delivery_note'] as string | undefined) ?? null
+
+  // Delivery orders require customer_name
+  if (orderType === 'delivery' && (!customerName || customerName.trim() === '')) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'customer_name is required for delivery orders' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
 
   const { supabaseUrl, serviceKey } = env
   const dbHeaders = {
@@ -83,38 +95,82 @@ export async function handler(
   }
 
   try {
-    // 1. Fetch table to verify it exists and get restaurant_id
-    const tableRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/tables?select=id,restaurant_id&id=eq.${tableId}`,
-      { headers: dbHeaders },
-    )
-    if (!tableRes.ok) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Failed to fetch table' }),
-        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-      )
-    }
-    const tables = (await tableRes.json()) as Array<{ id: string; restaurant_id: string }>
-    if (tables.length === 0) {
-      return new Response(
-        JSON.stringify({ success: false, error: 'Table not found' }),
-        { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-      )
-    }
-    const restaurantId = tables[0].restaurant_id
+    let restaurantId: string
+    let tableId: string | null = null
 
-    // 2. Insert the new order, capturing the server who created it
+    if (orderType === 'dine_in') {
+      // Dine-in: table_id required — unchanged existing behaviour
+      if (typeof payload['table_id'] !== 'string' || payload['table_id'] === '') {
+        return new Response(
+          JSON.stringify({ success: false, error: 'table_id is required for dine_in orders' }),
+          { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      tableId = payload['table_id'] as string
+
+      // Fetch table to verify it exists and get restaurant_id
+      const tableRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/tables?select=id,restaurant_id&id=eq.${tableId}`,
+        { headers: dbHeaders },
+      )
+      if (!tableRes.ok) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Failed to fetch table' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      const tables = (await tableRes.json()) as Array<{ id: string; restaurant_id: string }>
+      if (tables.length === 0) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Table not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      restaurantId = tables[0].restaurant_id
+    } else {
+      // Takeaway / Delivery: no table required — get restaurant_id from the user's record
+      const userRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/users?select=restaurant_id&id=eq.${encodeURIComponent(caller.actorId)}&limit=1`,
+        { headers: dbHeaders },
+      )
+      if (!userRes.ok) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'Failed to fetch user restaurant' }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      const users = (await userRes.json()) as Array<{ restaurant_id: string }>
+      if (users.length === 0) {
+        return new Response(
+          JSON.stringify({ success: false, error: 'User not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      restaurantId = users[0].restaurant_id
+
+      // Accept optional table_id for future flexibility, but do not require it
+      if (typeof payload['table_id'] === 'string' && payload['table_id'] !== '') {
+        tableId = payload['table_id'] as string
+      }
+    }
+
+    // Insert the new order
+    const insertBody: Record<string, unknown> = {
+      restaurant_id: restaurantId,
+      status: 'open',
+      server_id: caller.actorId,
+      order_type: orderType,
+    }
+    if (tableId !== null) insertBody['table_id'] = tableId
+    if (customerName !== null) insertBody['customer_name'] = customerName
+    if (deliveryNote !== null) insertBody['delivery_note'] = deliveryNote
+
     const insertRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders`,
       {
         method: 'POST',
         headers: dbHeaders,
-        body: JSON.stringify({
-          restaurant_id: restaurantId,
-          table_id: tableId,
-          status: 'open',
-          server_id: caller.actorId,
-        }),
+        body: JSON.stringify(insertBody),
       },
     )
     if (!insertRes.ok) {

--- a/supabase/migrations/20260327310000_add_takeaway_delivery.sql
+++ b/supabase/migrations/20260327310000_add_takeaway_delivery.sql
@@ -1,0 +1,14 @@
+-- Issue #253: Takeaway & delivery order types with table-free ordering
+-- Adds order_type, customer_name, delivery_note columns to orders table.
+-- table_id was already nullable — no change required.
+
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS order_type text NOT NULL DEFAULT 'dine_in'
+    CHECK (order_type IN ('dine_in', 'takeaway', 'delivery')),
+  ADD COLUMN IF NOT EXISTS customer_name text,
+  ADD COLUMN IF NOT EXISTS delivery_note text;
+
+-- Index to efficiently query active takeaway/delivery orders for the queue view
+CREATE INDEX IF NOT EXISTS idx_orders_order_type
+  ON orders(order_type)
+  WHERE order_type IN ('takeaway', 'delivery');


### PR DESCRIPTION
## Summary

Implements issue #253: takeaway and delivery order types, allowing orders without a table.

### Changes

**Database**
- Migration adds `order_type` (TEXT, default `dine_in`, check: `dine_in|takeaway|delivery`), `customer_name` (nullable), `delivery_note` (nullable) to `orders`
- `table_id` was already nullable — confirmed, left as-is

**Edge function: `create_order`**
- Accepts `order_type`, `customer_name`, `delivery_note`
- Dine-in (default): requires `table_id`, gets `restaurant_id` from table — **unchanged behaviour**
- Takeaway/Delivery: no `table_id` needed; gets `restaurant_id` from user record
- Delivery: `customer_name` is required

**Order creation flow (tables page)**
- New "🛍 New Takeaway Order" button — creates order directly and navigates to it
- New "🚴 New Delivery Order" button — opens modal for customer name (required) + delivery note (optional), then creates order
- Dine-in via table grid: **completely unchanged**

**KOT**
- Shows `★ TAKEAWAY ★` or `★ DELIVERY ★` banner prominently at the top
- For delivery: customer name and note printed below the banner

**Bill/Receipt**
- Shows TAKEAWAY or DELIVERY banner on bill
- For delivery: customer name + note below the banner
- Footer message adapts ("Thank you for your order!" for delivery)

**Tables view: Takeaway / Delivery Queue**
- New queue section below the table grid
- Lists all active (open/pending_payment) takeaway and delivery orders
- Shows type badge (🛍 TAKEAWAY / 🚴 DELIVERY), order age, customer name (delivery), item count
- Tap to navigate to the order

**Order detail screen**
- Shows Takeaway/Delivery badge in header
- For delivery: shows customer name + delivery note
- "Move Table" button hidden for non-dine-in orders
- URL uses `/tables/takeaway/order/[id]` or `/tables/delivery/order/[id]`

### Tests
- All core tests pass (orderData, tablesData, BillPrintView, createOrderApi)
- Added takeaway/delivery-specific tests to createOrderApi test suite
- Fixed 2 pre-existing createOrderApi test failures (stale `staff_id`/`apikey` expectations from a prior refactor)
- Net improvement: 34 failing (was 36), 277 passing (was 273)

Closes #253