### PR TITLE
feat(#261): Enhanced bill/receipt format — BIN, bill number, customer details

### DIFF
--- a/apps/web/app/admin/AdminNav.tsx
+++ b/apps/web/app/admin/AdminNav.tsx
@@ -15,6 +15,7 @@ import {
   Monitor,
   Building2,
   KeyRound,
+  Store,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -34,6 +35,7 @@ const NAV_LINKS: NavLink[] = [
   { href: '/admin/reports', label: 'Reports', icon: BarChart2 },
   { href: '/admin/settings/printer', label: 'Printer', icon: Printer },
   { href: '/admin/settings/kds', label: 'KDS', icon: Monitor },
+  { href: '/admin/settings/restaurant', label: 'Restaurant', icon: Store },
   { href: '/admin/restaurants', label: 'Restaurants', icon: Building2 },
   { href: '/admin/api-keys', label: 'API Keys', icon: KeyRound },
 ]

--- a/apps/web/app/admin/settings/restaurant/page.tsx
+++ b/apps/web/app/admin/settings/restaurant/page.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+/**
+ * Admin → Settings → Restaurant
+ *
+ * Issue #261: Configure BIN number and register name for bill printing.
+ * Also supports restaurant address line shown on printed receipts.
+ *
+ * Stores settings in the `config` table (same upsert pattern as VAT/currency config).
+ */
+
+import React, { useState, useEffect, useRef } from 'react'
+import type { JSX } from 'react'
+import Link from 'next/link'
+import { callUpsertConfig } from '@/app/admin/pricing/pricingAdminApi'
+import { fetchConfigValue } from '@/app/admin/pricing/pricingAdminData'
+
+type FeedbackType = 'success' | 'error'
+interface Feedback {
+  type: FeedbackType
+  message: string
+}
+
+export default function RestaurantSettingsPage(): JSX.Element {
+  const [loading, setLoading] = useState(true)
+  const [restaurantId, setRestaurantId] = useState<string>('')
+  const [fetchError, setFetchError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback | null>(null)
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Form state
+  const [binNumber, setBinNumber] = useState('')
+  const [registerName, setRegisterName] = useState('')
+  const [restaurantAddress, setRestaurantAddress] = useState('')
+
+  // Supabase config ref
+  const supabaseConfig = useRef<{ url: string; key: string } | null>(null)
+
+  useEffect(() => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
+    if (!supabaseUrl || !supabaseKey) {
+      setFetchError('API not configured')
+      setLoading(false)
+      return
+    }
+    supabaseConfig.current = { url: supabaseUrl, key: supabaseKey }
+
+    // Fetch restaurant id then load config keys
+    const headers = { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` }
+    fetch(`${supabaseUrl}/rest/v1/restaurants?select=id&limit=1`, { headers })
+      .then((r) => r.json() as Promise<Array<{ id: string }>>)
+      .then(async (rows) => {
+        if (rows.length === 0) throw new Error('No restaurant found')
+        const rid = rows[0].id
+        setRestaurantId(rid)
+        const [binVal, regVal, addrVal] = await Promise.all([
+          fetchConfigValue(supabaseUrl, supabaseKey, rid, 'bin_number', ''),
+          fetchConfigValue(supabaseUrl, supabaseKey, rid, 'register_name', ''),
+          fetchConfigValue(supabaseUrl, supabaseKey, rid, 'restaurant_address', ''),
+        ])
+        setBinNumber(binVal)
+        setRegisterName(regVal)
+        setRestaurantAddress(addrVal)
+      })
+      .catch((err: unknown) => {
+        setFetchError(err instanceof Error ? err.message : 'Failed to load settings')
+      })
+      .finally(() => { setLoading(false) })
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
+    }
+  }, [])
+
+  function showFeedback(type: FeedbackType, message: string): void {
+    if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
+    setFeedback({ type, message })
+    feedbackTimerRef.current = setTimeout(() => { setFeedback(null) }, 4000)
+  }
+
+  async function handleSave(): Promise<void> {
+    const config = supabaseConfig.current
+    if (!config || !restaurantId) return
+    setSubmitting(true)
+    try {
+      await Promise.all([
+        binNumber.trim()
+          ? callUpsertConfig(config.url, config.key, restaurantId, 'bin_number', binNumber.trim())
+          : Promise.resolve(),
+        registerName.trim()
+          ? callUpsertConfig(config.url, config.key, restaurantId, 'register_name', registerName.trim())
+          : Promise.resolve(),
+        restaurantAddress.trim()
+          ? callUpsertConfig(config.url, config.key, restaurantId, 'restaurant_address', restaurantAddress.trim())
+          : Promise.resolve(),
+      ])
+      showFeedback('success', 'Restaurant settings saved.')
+    } catch (err) {
+      showFeedback('error', err instanceof Error ? err.message : 'Failed to save settings.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <h1 className="text-2xl font-bold text-white">Restaurant Settings</h1>
+        <p className="text-zinc-400 text-base">Loading…</p>
+      </div>
+    )
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex flex-col gap-6">
+        <h1 className="text-2xl font-bold text-white">Restaurant Settings</h1>
+        <p className="text-red-400 text-base">Unable to load settings. Please try again.</p>
+        <p className="text-red-300 text-sm font-mono">{fetchError}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-8 max-w-2xl">
+      {/* Page header */}
+      <div className="flex items-center gap-3">
+        <Link
+          href="/admin"
+          className="flex items-center min-h-[48px] px-3 py-2 rounded-xl text-base font-medium text-zinc-400 hover:text-white hover:bg-zinc-700 transition-colors"
+        >
+          ← Admin
+        </Link>
+        <h1 className="text-2xl font-bold text-white">Restaurant Settings</h1>
+      </div>
+
+      {/* Feedback banner */}
+      {feedback && (
+        <div
+          role="status"
+          className={[
+            'px-5 py-3 rounded-xl text-base font-medium',
+            feedback.type === 'success'
+              ? 'bg-green-800 text-green-100'
+              : 'bg-red-800 text-red-100',
+          ].join(' ')}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      {/* Bill printing section */}
+      <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6 flex flex-col gap-6">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Bill / Receipt Settings</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            These details appear on every printed bill and receipt.
+          </p>
+        </div>
+
+        {/* Restaurant Address */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="restaurant-address" className="text-sm font-medium text-zinc-300">
+            Restaurant Address
+          </label>
+          <input
+            id="restaurant-address"
+            type="text"
+            value={restaurantAddress}
+            onChange={(e) => { setRestaurantAddress(e.target.value) }}
+            disabled={submitting}
+            placeholder="e.g. 123 Main Street, Dhaka 1200"
+            className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-900 text-white border border-zinc-600 focus:border-indigo-500 focus:outline-none text-base disabled:opacity-50 placeholder-zinc-600"
+          />
+          <p className="text-xs text-zinc-500">Shown below restaurant name on the printed bill.</p>
+        </div>
+
+        {/* BIN Number */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="bin-number" className="text-sm font-medium text-zinc-300">
+            BIN Number <span className="text-zinc-500 font-normal">(VAT Registration)</span>
+          </label>
+          <input
+            id="bin-number"
+            type="text"
+            value={binNumber}
+            onChange={(e) => { setBinNumber(e.target.value) }}
+            disabled={submitting}
+            placeholder="e.g. 003206332-0101 -Musak6.3"
+            className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-900 text-white border border-zinc-600 focus:border-indigo-500 focus:outline-none text-base disabled:opacity-50 placeholder-zinc-600"
+          />
+          <p className="text-xs text-zinc-500">
+            Your VAT / BIN registration number printed on every receipt. Leave blank to hide.
+          </p>
+        </div>
+
+        {/* Register Name */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="register-name" className="text-sm font-medium text-zinc-300">
+            Register / Terminal Name
+          </label>
+          <input
+            id="register-name"
+            type="text"
+            value={registerName}
+            onChange={(e) => { setRegisterName(e.target.value) }}
+            disabled={submitting}
+            placeholder="e.g. Cashier 1"
+            className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-900 text-white border border-zinc-600 focus:border-indigo-500 focus:outline-none text-base disabled:opacity-50 placeholder-zinc-600"
+          />
+          <p className="text-xs text-zinc-500">
+            Terminal identifier printed on each bill (e.g. &ldquo;Cashier 1&rdquo;, &ldquo;Front Desk&rdquo;).
+          </p>
+        </div>
+
+        {/* Save button */}
+        <div>
+          <button
+            onClick={() => { void handleSave() }}
+            disabled={submitting || !restaurantId}
+            className="min-h-[48px] px-6 py-2 rounded-xl bg-indigo-600 text-white text-base font-medium hover:bg-indigo-500 transition-colors disabled:opacity-50"
+          >
+            {submitting ? 'Saving…' : 'Save Settings'}
+          </button>
+        </div>
+      </div>
+
+      {/* Info box */}
+      <div className="bg-zinc-800/60 border border-zinc-700 rounded-2xl p-5 text-sm text-zinc-400">
+        <p className="font-semibold text-zinc-300 mb-2">Bill Number Sequence</p>
+        <p>
+          Bill numbers are auto-generated sequentially when an order is closed (e.g. <span className="font-mono text-zinc-200">RN0001234</span>).
+          The counter is per-restaurant and cannot be reset here — contact support if needed.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -64,7 +64,7 @@ describe('OrderDetailClient', () => {
     const { fetchOrderItems } = await import('./orderData')
     vi.mocked(fetchOrderItems).mockResolvedValue(mockItems)
     const { fetchOrderSummary } = await import('./orderData')
-    vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'open', payment_method: null })
+    vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'open', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
   })
 
   afterEach((): void => {
@@ -893,7 +893,7 @@ describe('OrderDetailClient', () => {
       const { fetchOrderSummary } = await import('./orderData')
       const { fetchOrderItems } = await import('./orderData')
 
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
       vi.mocked(fetchOrderItems).mockResolvedValue([
         {
           id: '1',
@@ -924,7 +924,7 @@ describe('OrderDetailClient', () => {
   describe('paid order read-only view', () => {
     it('shows read-only paid state when navigating to an already-paid order', async (): Promise<void> => {
       const { fetchOrderSummary } = await import('./orderData')
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-123" />)
 
@@ -935,7 +935,7 @@ describe('OrderDetailClient', () => {
 
     it('shows payment method in paid read-only view', async (): Promise<void> => {
       const { fetchOrderSummary } = await import('./orderData')
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'cash' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'cash', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-123" />)
 
@@ -947,7 +947,7 @@ describe('OrderDetailClient', () => {
 
     it('does not show Close Order or Add Items in paid read-only view', async (): Promise<void> => {
       const { fetchOrderSummary } = await import('./orderData')
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-123" />)
 
@@ -961,7 +961,7 @@ describe('OrderDetailClient', () => {
 
     it('shows order total in paid read-only view', async (): Promise<void> => {
       const { fetchOrderSummary } = await import('./orderData')
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-123" />)
 
@@ -974,7 +974,7 @@ describe('OrderDetailClient', () => {
 
     it('Back to tables link has minimum 48px touch target in paid view', async (): Promise<void> => {
       const { fetchOrderSummary } = await import('./orderData')
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-123" />)
 
@@ -1024,7 +1024,7 @@ describe('OrderDetailClient', () => {
       const { fetchOrderSummary } = await import('./orderData')
       const { fetchOrderItems } = await import('./orderData')
 
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
       // fetchOrderItems never resolves — items remain in loading state
       vi.mocked(fetchOrderItems).mockReturnValue(new Promise<never>(() => {}))
 
@@ -1041,7 +1041,7 @@ describe('OrderDetailClient', () => {
       const { fetchOrderSummary } = await import('./orderData')
       const { fetchOrderItems } = await import('./orderData')
 
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
       vi.mocked(fetchOrderItems).mockRejectedValue(new Error('Items load failed'))
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-err" />)
@@ -1059,7 +1059,7 @@ describe('OrderDetailClient', () => {
       const { fetchOrderSummary } = await import('./orderData')
       const { fetchOrderItems } = await import('./orderData')
 
-      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card' })
+      vi.mocked(fetchOrderSummary).mockResolvedValue({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
       vi.mocked(fetchOrderItems).mockResolvedValue([])
 
       render(<OrderDetailClient tableId="5" orderId="order-paid-empty" />)

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -76,6 +76,15 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [orderType, setOrderType] = useState<'dine_in' | 'takeaway' | 'delivery'>('dine_in')
   const [orderCustomerName, setOrderCustomerName] = useState<string | null>(null)
   const [orderDeliveryNote, setOrderDeliveryNote] = useState<string | null>(null)
+  // Enhanced bill fields (issue #261)
+  const [orderCustomerMobile, setOrderCustomerMobile] = useState<string | null>(null)
+  const [orderBillNumber, setOrderBillNumber] = useState<string | null>(null)
+
+  // Restaurant config for enhanced bill (issue #261)
+  const [restaurantName, setRestaurantName] = useState<string>('Lahore by iKitchen')
+  const [restaurantAddress, setRestaurantAddress] = useState<string>('Lahore by iKitchen, Dhaka')
+  const [binNumber, setBinNumber] = useState<string | undefined>(undefined)
+  const [registerName, setRegisterName] = useState<string | undefined>(undefined)
 
   // Void item state
   const [voidingItem, setVoidingItem] = useState<OrderItem | null>(null)
@@ -205,6 +214,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         setOrderType(summary.order_type)
         setOrderCustomerName(summary.customer_name)
         setOrderDeliveryNote(summary.delivery_note)
+        setOrderCustomerMobile(summary.customer_mobile)
+        setOrderBillNumber(summary.bill_number)
       })
       .catch(() => {
         // Non-fatal: fall back to normal order view if status check fails
@@ -228,12 +239,34 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         Promise.all([
           fetchVatConfig(supabaseUrl, supabaseKey, restaurantId, menuId),
           fetchServiceChargePercent(supabaseUrl, supabaseKey, restaurantId),
+          // Fetch restaurant name
+          fetch(
+            `${supabaseUrl}/rest/v1/restaurants?id=eq.${restaurantId}&select=name&limit=1`,
+            { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } },
+          ).then((r) => r.ok ? r.json() as Promise<Array<{ name: string }>> : Promise.resolve([])),
+          // Fetch enhanced bill config keys in a single request
+          fetch(
+            `${supabaseUrl}/rest/v1/config?restaurant_id=eq.${restaurantId}&key=in.(bin_number,register_name,restaurant_address)&select=key,value`,
+            { headers: { apikey: supabaseKey, Authorization: `Bearer ${supabaseKey}` } },
+          ).then((r) => r.ok ? r.json() as Promise<Array<{ key: string; value: string }>> : Promise.resolve([])),
         ]),
       )
-      .then(([config, scPercent]) => {
+      .then(([config, scPercent, restaurantRows, configRows]) => {
         setVatPercent(config.vatPercent)
         setTaxInclusive(config.taxInclusive)
         setServiceChargePercent(scPercent)
+        // Restaurant name
+        if (Array.isArray(restaurantRows) && restaurantRows.length > 0) {
+          setRestaurantName((restaurantRows as Array<{ name: string }>)[0].name)
+        }
+        // Enhanced bill config
+        const cfgMap = new Map<string, string>()
+        for (const row of (configRows as Array<{ key: string; value: string }>)) {
+          cfgMap.set(row.key, row.value)
+        }
+        if (cfgMap.has('bin_number')) setBinNumber(cfgMap.get('bin_number'))
+        if (cfgMap.has('register_name')) setRegisterName(cfgMap.get('register_name'))
+        if (cfgMap.has('restaurant_address')) setRestaurantAddress(cfgMap.get('restaurant_address') ?? '')
       })
       .catch(() => {
         // Non-fatal: fall back to 0% VAT / 0% service charge (safe — no overcharging)
@@ -1363,6 +1396,12 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             orderType={orderType}
             customerName={orderCustomerName}
             deliveryNote={orderDeliveryNote}
+            customerMobile={orderCustomerMobile}
+            restaurantName={restaurantName}
+            restaurantAddress={restaurantAddress}
+            binNumber={binNumber}
+            billNumber={orderBillNumber ?? undefined}
+            registerName={registerName}
           />
         </div>
       )}
@@ -1380,6 +1419,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             timestamp={splitBillTimestamp}
             evenSplit={splitBillPrintMode === 'even'}
             serviceChargePercent={serviceChargePercent}
+            restaurantName={restaurantName}
+            restaurantAddress={restaurantAddress}
+            binNumber={binNumber}
+            billNumber={orderBillNumber ?? undefined}
+            registerName={registerName}
           />
         </div>
       )}

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
@@ -140,19 +140,19 @@ describe('fetchOrderSummary', () => {
   it('returns status open with null payment_method for open orders', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null; customer_mobile: null; bill_number: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null }],
     })
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'open', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null })
+    expect(result).toEqual({ status: 'open', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
   })
 
   it('fetches payment method when order is paid', async (): Promise<void> => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null }],
+        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null; customer_mobile: null; bill_number: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null }],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -161,14 +161,14 @@ describe('fetchOrderSummary', () => {
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null })
+    expect(result).toEqual({ status: 'paid', payment_method: 'card', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
   })
 
   it('returns null payment_method when payment fetch fails for paid order', async (): Promise<void> => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null }],
+        json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null; customer_mobile: null; bill_number: null }>> => [{ status: 'paid', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null }],
       })
       .mockResolvedValueOnce({
         ok: false,
@@ -179,7 +179,7 @@ describe('fetchOrderSummary', () => {
 
     const result = await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-123')
 
-    expect(result).toEqual({ status: 'paid', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null })
+    expect(result).toEqual({ status: 'paid', payment_method: null, order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null })
   })
 
   it('throws when the order fetch fails', async (): Promise<void> => {
@@ -209,7 +209,7 @@ describe('fetchOrderSummary', () => {
   it('passes correct auth headers', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null; customer_mobile: null; bill_number: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null }],
     })
 
     await fetchOrderSummary('https://example.supabase.co', 'my-key', 'order-abc')
@@ -223,7 +223,7 @@ describe('fetchOrderSummary', () => {
   it('queries the correct order endpoint with id filter', async (): Promise<void> => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null }],
+      json: async (): Promise<Array<{ status: string; order_type: string; customer_name: null; delivery_note: null; customer_mobile: null; bill_number: null }>> => [{ status: 'open', order_type: 'dine_in', customer_name: null, delivery_note: null, customer_mobile: null, bill_number: null }],
     })
 
     await fetchOrderSummary('https://example.supabase.co', 'test-key', 'order-xyz')

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
@@ -52,6 +52,10 @@ export interface OrderSummary {
   customer_name: string | null
   /** Delivery address/note for delivery orders */
   delivery_note: string | null
+  /** Customer mobile number for delivery/takeaway orders (issue #261) */
+  customer_mobile: string | null
+  /** Sequential bill reference generated on close_order (issue #261) */
+  bill_number: string | null
 }
 
 interface OrderItemRow {
@@ -193,7 +197,7 @@ export async function fetchOrderSummary(
 
   const orderUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
   orderUrl.searchParams.set('id', `eq.${orderId}`)
-  orderUrl.searchParams.set('select', 'status,order_type,customer_name,delivery_note')
+  orderUrl.searchParams.set('select', 'status,order_type,customer_name,delivery_note,customer_mobile,bill_number')
 
   const orderRes = await fetch(orderUrl.toString(), { headers })
   if (!orderRes.ok) {
@@ -206,6 +210,8 @@ export async function fetchOrderSummary(
     order_type: string | null
     customer_name: string | null
     delivery_note: string | null
+    customer_mobile: string | null
+    bill_number: string | null
   }>
   if (orders.length === 0) {
     throw new Error('Order not found')
@@ -215,6 +221,8 @@ export async function fetchOrderSummary(
   const orderType = (orders[0].order_type ?? 'dine_in') as 'dine_in' | 'takeaway' | 'delivery'
   const customerName = orders[0].customer_name ?? null
   const deliveryNote = orders[0].delivery_note ?? null
+  const customerMobile = orders[0].customer_mobile ?? null
+  const billNumber = orders[0].bill_number ?? null
 
   if (status !== 'paid') {
     return {
@@ -223,6 +231,8 @@ export async function fetchOrderSummary(
       order_type: orderType,
       customer_name: customerName,
       delivery_note: deliveryNote,
+      customer_mobile: customerMobile,
+      bill_number: billNumber,
     }
   }
 
@@ -239,6 +249,8 @@ export async function fetchOrderSummary(
       order_type: orderType,
       customer_name: customerName,
       delivery_note: deliveryNote,
+      customer_mobile: customerMobile,
+      bill_number: billNumber,
     }
   }
 
@@ -249,5 +261,7 @@ export async function fetchOrderSummary(
     order_type: orderType,
     customer_name: customerName,
     delivery_note: deliveryNote,
+    customer_mobile: customerMobile,
+    bill_number: billNumber,
   }
 }

--- a/apps/web/components/BillPrintView.test.tsx
+++ b/apps/web/components/BillPrintView.test.tsx
@@ -63,8 +63,9 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.getByText('Table: Table 3')).toBeInTheDocument()
-    expect(screen.getByText('Order: order-ab')).toBeInTheDocument()
+    // New layout: table and order# are key-value pairs in separate spans
+    expect(screen.getByText('Table 3')).toBeInTheDocument()
+    expect(screen.getByText('order-ab')).toBeInTheDocument()
   })
 
   it('renders the timestamp', () => {
@@ -98,12 +99,15 @@ describe('BillPrintView', () => {
       />,
     )
 
+    // New layout: item name, qty and amount are in separate spans
+    expect(screen.getByText('Chicken Karahi')).toBeInTheDocument()
+    // quantity column: "2"
+    expect(screen.getAllByText('2').length).toBeGreaterThanOrEqual(1)
     // Chicken Karahi: 2 × ৳15.00 = ৳30.00
-    expect(screen.getByText(/2× Chicken Karahi/)).toBeInTheDocument()
     expect(screen.getByText('৳ 30.00')).toBeInTheDocument()
 
+    expect(screen.getByText('Naan')).toBeInTheDocument()
     // Naan: 4 × ৳2.00 = ৳8.00
-    expect(screen.getByText(/4× Naan/)).toBeInTheDocument()
     expect(screen.getByText('৳ 8.00')).toBeInTheDocument()
   })
 
@@ -122,7 +126,7 @@ describe('BillPrintView', () => {
     )
 
     // ৳ 38.00
-    expect(screen.getByText('Subtotal')).toBeInTheDocument()
+    expect(screen.getByText('Sub Total')).toBeInTheDocument()
     expect(screen.getByText('৳ 38.00')).toBeInTheDocument()
   })
 
@@ -140,7 +144,7 @@ describe('BillPrintView', () => {
       />,
     )
 
-    // VAT 15%: 570 cents = ৳ 5.70
+    // VAT 15%: shown as "VAT 15%"
     expect(screen.getByText('VAT 15%')).toBeInTheDocument()
     expect(screen.getByText('৳ 5.70')).toBeInTheDocument()
   })
@@ -159,8 +163,8 @@ describe('BillPrintView', () => {
       />,
     )
 
-    // Total = 4370 cents = ৳ 43.70
-    expect(screen.getByText('Total')).toBeInTheDocument()
+    // New label is "Pay" for the total line
+    expect(screen.getByText('Pay')).toBeInTheDocument()
     expect(screen.getByText('৳ 43.70')).toBeInTheDocument()
   })
 
@@ -178,7 +182,8 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.getByText('Payment')).toBeInTheDocument()
+    // New label: "Tendered by" with method value "card"
+    expect(screen.getByText('Tendered by')).toBeInTheDocument()
     expect(screen.getByText('card')).toBeInTheDocument()
   })
 
@@ -218,11 +223,11 @@ describe('BillPrintView', () => {
     )
 
     // 5000 cents = ৳ 50.00
-    expect(screen.getByText('Tendered')).toBeInTheDocument()
+    expect(screen.getByText('Cash Tendered')).toBeInTheDocument()
     expect(screen.getByText('৳ 50.00')).toBeInTheDocument()
 
     // 630 cents = ৳ 6.30
-    expect(screen.getByText('Change due')).toBeInTheDocument()
+    expect(screen.getByText('Change Due')).toBeInTheDocument()
     expect(screen.getByText('৳ 6.30')).toBeInTheDocument()
   })
 
@@ -240,8 +245,8 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.queryByText('Tendered')).not.toBeInTheDocument()
-    expect(screen.queryByText('Change due')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cash Tendered')).not.toBeInTheDocument()
+    expect(screen.queryByText('Change Due')).not.toBeInTheDocument()
   })
 
   it('does not render tendered/change rows when not provided for cash payment', () => {
@@ -258,8 +263,8 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.queryByText('Tendered')).not.toBeInTheDocument()
-    expect(screen.queryByText('Change due')).not.toBeInTheDocument()
+    expect(screen.queryByText('Cash Tendered')).not.toBeInTheDocument()
+    expect(screen.queryByText('Change Due')).not.toBeInTheDocument()
   })
 
   it('renders the thank-you footer', () => {
@@ -276,7 +281,7 @@ describe('BillPrintView', () => {
       />,
     )
 
-    expect(screen.getByText('Thank you for dining with us!')).toBeInTheDocument()
+    expect(screen.getByText('Thank You!!!')).toBeInTheDocument()
   })
 
   it('is hidden on screen via aria-hidden', () => {
@@ -314,7 +319,61 @@ describe('BillPrintView', () => {
     )
 
     expect(screen.getByText('Lahore by iKitchen')).toBeInTheDocument()
-    // Subtotal and total should be ৳ 0.00
+    // Sub Total and Pay should be ৳ 0.00
     expect(screen.getAllByText('৳ 0.00').length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('renders BIN number when provided', () => {
+    render(
+      <BillPrintView
+        tableLabel="Table 3"
+        orderId="order-abc-12345678"
+        items={mockItems}
+        subtotalCents={SUBTOTAL}
+        vatPercent={VAT_PERCENT}
+        totalCents={TOTAL}
+        paymentMethod="card"
+        timestamp="25/03/2026, 14:00:00"
+        binNumber="003206332-0101 -Musak6.3"
+      />,
+    )
+
+    expect(screen.getByText(/003206332-0101/)).toBeInTheDocument()
+  })
+
+  it('renders bill number when provided', () => {
+    render(
+      <BillPrintView
+        tableLabel="Table 3"
+        orderId="order-abc-12345678"
+        items={mockItems}
+        subtotalCents={SUBTOTAL}
+        vatPercent={VAT_PERCENT}
+        totalCents={TOTAL}
+        paymentMethod="card"
+        timestamp="25/03/2026, 14:00:00"
+        billNumber="RN0001234"
+      />,
+    )
+
+    expect(screen.getByText('RN0001234')).toBeInTheDocument()
+  })
+
+  it('renders register name when provided', () => {
+    render(
+      <BillPrintView
+        tableLabel="Table 3"
+        orderId="order-abc-12345678"
+        items={mockItems}
+        subtotalCents={SUBTOTAL}
+        vatPercent={VAT_PERCENT}
+        totalCents={TOTAL}
+        paymentMethod="card"
+        timestamp="25/03/2026, 14:00:00"
+        registerName="Cashier 1"
+      />,
+    )
+
+    expect(screen.getByText('Cashier 1')).toBeInTheDocument()
   })
 })

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -31,10 +31,34 @@ export interface BillPrintViewProps {
   vatCents?: number
   /** Order type — shown on bill for non-dine-in orders. */
   orderType?: 'dine_in' | 'takeaway' | 'delivery'
-  /** Customer name for delivery orders. */
+  /** Customer name for delivery/takeaway orders. */
   customerName?: string | null
-  /** Delivery note for delivery orders. */
+  /** Delivery note / address for delivery orders. */
   deliveryNote?: string | null
+  /** Customer mobile number for delivery/takeaway orders. */
+  customerMobile?: string | null
+
+  // --- Enhanced bill header fields (issue #261) ---
+  /** Restaurant name (overrides hard-coded default). */
+  restaurantName?: string
+  /** Restaurant address shown below name. */
+  restaurantAddress?: string
+  /** VAT / BIN registration number. */
+  binNumber?: string
+  /** Sequential bill reference e.g. RN0001234. */
+  billNumber?: string
+  /** Location / branch name. */
+  locationName?: string
+  /** Terminal / register name e.g. "Cashier 1". */
+  registerName?: string
+  /** Staff member (server) who handled the order. */
+  staffUser?: string
+  /**
+   * Round-off adjustment in cents (signed).
+   * Positive = upward rounding added; negative = rounding deducted.
+   * Show line only when non-zero.
+   */
+  roundOffCents?: number
 }
 
 export default function BillPrintView({
@@ -58,6 +82,15 @@ export default function BillPrintView({
   orderType = 'dine_in',
   customerName,
   deliveryNote,
+  customerMobile,
+  restaurantName = 'Lahore by iKitchen',
+  restaurantAddress = 'Lahore by iKitchen, Dhaka',
+  binNumber,
+  billNumber,
+  locationName,
+  registerName,
+  staffUser,
+  roundOffCents = 0,
 }: BillPrintViewProps): JSX.Element {
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
@@ -65,35 +98,71 @@ export default function BillPrintView({
 
   const isTakeaway = orderType === 'takeaway'
   const isDelivery = orderType === 'delivery'
+  const isNonDineIn = isTakeaway || isDelivery
+  const orderTypeLabel = isDelivery ? 'Delivery' : isTakeaway ? 'Takeaway' : 'Dine In'
+
+  // Payable amount after round-off
+  const payableCents = totalCents + roundOffCents
 
   return (
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
-      {/* Header */}
-      <div className="text-center mb-2">
-        <p className="text-base font-bold">Lahore by iKitchen</p>
-        <p className="text-xs">Lahore by iKitchen, Dhaka</p>
-        <p className="text-xs">{timestamp}</p>
+      {/* 1. Restaurant name + address */}
+      <div className="text-center mb-1">
+        <p className="text-base font-bold">{restaurantName}</p>
+        <p className="text-xs">{restaurantAddress}</p>
       </div>
 
-      {/* TAKEAWAY / DELIVERY banner on bill */}
-      {(isTakeaway || isDelivery) && (
-        <div className="border border-black py-1 mb-2 text-center">
-          <p className="text-sm font-bold tracking-widest">
-            {isDelivery ? 'DELIVERY' : 'TAKEAWAY'}
-          </p>
-          {isDelivery && customerName && (
-            <p className="text-xs font-bold">{customerName}</p>
-          )}
-          {isDelivery && deliveryNote && (
-            <p className="text-xs">{deliveryNote}</p>
-          )}
+      {/* 2. BIN # */}
+      {binNumber && (
+        <div className="text-center mb-1">
+          <p className="text-xs">BIN: {binNumber}</p>
         </div>
       )}
 
-      {/* Order info */}
-      <div className="border-t border-b border-black py-1 mb-2 text-sm">
-        {!isTakeaway && !isDelivery && <p>Table: {tableLabel}</p>}
-        <p>Order: {orderId.slice(0, 8)}</p>
+      {/* 3. Bill meta */}
+      <div className="border-t border-b border-black py-1 mb-2 text-xs space-y-0.5">
+        {billNumber && (
+          <div className="flex justify-between">
+            <span className="font-semibold">Bill No</span>
+            <span>{billNumber}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span>Date</span>
+          <span>{timestamp}</span>
+        </div>
+        {locationName && (
+          <div className="flex justify-between">
+            <span>Location</span>
+            <span>{locationName}</span>
+          </div>
+        )}
+        {registerName && (
+          <div className="flex justify-between">
+            <span>Register</span>
+            <span>{registerName}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span>Order Type</span>
+          <span>{orderTypeLabel}</span>
+        </div>
+        {!isNonDineIn && (
+          <div className="flex justify-between">
+            <span>Table</span>
+            <span>{tableLabel}</span>
+          </div>
+        )}
+        {staffUser && (
+          <div className="flex justify-between">
+            <span>Staff</span>
+            <span>{staffUser}</span>
+          </div>
+        )}
+        <div className="flex justify-between">
+          <span>Order#</span>
+          <span>{orderId.slice(0, 8)}</span>
+        </div>
       </div>
 
       {/* COMPLIMENTARY banner for whole-order comp */}
@@ -103,50 +172,52 @@ export default function BillPrintView({
         </div>
       )}
 
-      {/* Items */}
-      <ul className="mb-2">
-        {items.map((item) => {
+      {/* 4. Line items: S.No | Item name | Qty | Amount */}
+      <div className="mb-2">
+        {/* Header row */}
+        <div className="flex text-xs font-semibold border-b border-black pb-0.5 mb-0.5">
+          <span className="w-6 shrink-0">#</span>
+          <span className="flex-1">Item</span>
+          <span className="w-8 text-right shrink-0">Qty</span>
+          <span className="w-16 text-right shrink-0">Amt</span>
+        </div>
+        {items.map((item, idx) => {
           const grossCents = item.quantity * item.price_cents
           const isComp = item.comp || orderComp
           const itemDiscountCents = isComp ? 0 : calcItemDiscountCents(item)
           const lineCents = grossCents - itemDiscountCents
           const hasItemDiscount = !isComp && itemDiscountCents > 0
           return (
-            <li key={item.id} className="text-sm mb-0.5">
-              <div className="flex justify-between">
-                <span>
-                  {item.quantity}× {item.name}
-                  {isComp && <span className="ml-1 text-xs">[COMP]</span>}
+            <div key={item.id} className="mb-0.5">
+              <div className="flex text-xs">
+                <span className="w-6 shrink-0 text-zinc-600">{idx + 1}</span>
+                <span className="flex-1 truncate">
+                  {item.name}
+                  {isComp && <span className="ml-1">[COMP]</span>}
                 </span>
-                {isComp ? (
-                  <span className="italic text-xs">Complimentary</span>
-                ) : hasItemDiscount ? (
-                  <span>
-                    <span className="line-through text-xs mr-1">{formatPrice(grossCents, DEFAULT_CURRENCY_SYMBOL)}</span>
-                    {formatPrice(lineCents, DEFAULT_CURRENCY_SYMBOL)}
-                  </span>
-                ) : (
-                  <span>{formatPrice(lineCents, DEFAULT_CURRENCY_SYMBOL)}</span>
-                )}
+                <span className="w-8 text-right shrink-0">{item.quantity}</span>
+                <span className="w-16 text-right shrink-0">
+                  {isComp ? 'Free' : formatPrice(lineCents, DEFAULT_CURRENCY_SYMBOL)}
+                </span>
               </div>
               {hasItemDiscount && (
-                <div className="pl-4 text-xs">
+                <div className="pl-6 text-xs text-zinc-500">
                   {item.item_discount_type === 'percent' && item.item_discount_value != null
-                    ? `Item discount: -${item.item_discount_value / 100}%`
-                    : `Item discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL)}`}
+                    ? `Discount: -${item.item_discount_value / 100}%`
+                    : `Discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL)}`}
                 </div>
               )}
-            </li>
+            </div>
           )
         })}
-      </ul>
+      </div>
 
-      {/* Subtotal, Discount, VAT, Total */}
+      {/* 5. Sub total → Discount → Service Charge → VAT → Round off → Pay */}
       <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
         {!orderComp && (
           <>
             <div className="flex justify-between">
-              <span>Subtotal</span>
+              <span>Sub Total</span>
               <span>{formatPrice(subtotalCents, DEFAULT_CURRENCY_SYMBOL)}</span>
             </div>
             {discountAmountCents > 0 && (
@@ -167,9 +238,15 @@ export default function BillPrintView({
                 <span>{formatPrice(vatCents, DEFAULT_CURRENCY_SYMBOL)}</span>
               </div>
             )}
-            <div className="flex justify-between font-bold">
-              <span>Total</span>
-              <span>{formatPrice(totalCents, DEFAULT_CURRENCY_SYMBOL)}</span>
+            {roundOffCents !== 0 && (
+              <div className="flex justify-between">
+                <span>Round Off</span>
+                <span>{roundOffCents > 0 ? '+' : ''}{formatPrice(Math.abs(roundOffCents), DEFAULT_CURRENCY_SYMBOL)}</span>
+              </div>
+            )}
+            <div className="flex justify-between font-bold border-t border-black pt-0.5 mt-0.5">
+              <span>Pay</span>
+              <span>{formatPrice(payableCents, DEFAULT_CURRENCY_SYMBOL)}</span>
             </div>
           </>
         )}
@@ -181,31 +258,56 @@ export default function BillPrintView({
         )}
       </div>
 
-      {/* Payment info */}
+      {/* 6. Tendered by */}
       {!orderComp && (
         <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
           <div className="flex justify-between">
-            <span>Payment</span>
+            <span>Tendered by</span>
             <span className="capitalize">{paymentMethod}</span>
           </div>
           {paymentMethod === 'cash' && amountTenderedCents !== undefined && (
             <div className="flex justify-between">
-              <span>Tendered</span>
+              <span>Cash Tendered</span>
               <span>{formatPrice(amountTenderedCents, DEFAULT_CURRENCY_SYMBOL)}</span>
             </div>
           )}
           {paymentMethod === 'cash' && changeDueCents !== undefined && (
             <div className="flex justify-between">
-              <span>Change due</span>
+              <span>Change Due</span>
               <span>{formatPrice(changeDueCents, DEFAULT_CURRENCY_SYMBOL)}</span>
             </div>
           )}
         </div>
       )}
 
-      {/* Footer */}
+      {/* 7. Customer details (delivery/takeaway) */}
+      {isNonDineIn && (customerName || customerMobile || deliveryNote) && (
+        <div className="border-t border-black pt-1 mb-2 text-xs space-y-0.5">
+          <p className="font-semibold text-sm">{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
+          {customerName && (
+            <div className="flex justify-between">
+              <span>Name</span>
+              <span>{customerName}</span>
+            </div>
+          )}
+          {customerMobile && (
+            <div className="flex justify-between">
+              <span>Mobile</span>
+              <span>{customerMobile}</span>
+            </div>
+          )}
+          {isDelivery && deliveryNote && (
+            <div className="flex justify-between">
+              <span>Address</span>
+              <span className="text-right max-w-[150px] leading-tight">{deliveryNote}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 8. Footer */}
       <div className="border-t border-black mt-2 pt-1 text-center text-xs">
-        {isDelivery ? 'Thank you for your order!' : 'Thank you for dining with us!'}
+        Thank You!!!
       </div>
     </div>
   )

--- a/apps/web/components/SplitBillPrintView.tsx
+++ b/apps/web/components/SplitBillPrintView.tsx
@@ -15,6 +15,18 @@ export interface SplitBillPrintViewProps {
   evenSplit?: boolean
   /** Service charge rate in percent (e.g. 10 for 10%). 0 = hidden. */
   serviceChargePercent?: number
+
+  // --- Enhanced bill header fields (issue #261) ---
+  /** Restaurant name (overrides hard-coded default). */
+  restaurantName?: string
+  /** Restaurant address shown below name. */
+  restaurantAddress?: string
+  /** VAT / BIN registration number. */
+  binNumber?: string
+  /** Sequential bill reference e.g. RN0001234. */
+  billNumber?: string
+  /** Terminal / register name e.g. "Cashier 1". */
+  registerName?: string
 }
 
 /**
@@ -31,6 +43,11 @@ export default function SplitBillPrintView({
   timestamp,
   evenSplit = false,
   serviceChargePercent = 0,
+  restaurantName = 'Lahore by iKitchen',
+  restaurantAddress = 'Lahore by iKitchen, Dhaka',
+  binNumber,
+  billNumber,
+  registerName,
 }: SplitBillPrintViewProps): JSX.Element {
   // For even split: calculate total then divide
   const totalRawCents = items
@@ -108,17 +125,45 @@ export default function SplitBillPrintView({
             style={{ pageBreakAfter: idx < sections.length - 1 ? 'always' : 'auto' }}
           >
             {/* Header */}
-            <div className="text-center mb-2">
-              <p className="text-base font-bold">Lahore by iKitchen</p>
-              <p className="text-xs">Lahore by iKitchen, Dhaka</p>
-              <p className="text-xs">{timestamp}</p>
+            <div className="text-center mb-1">
+              <p className="text-base font-bold">{restaurantName}</p>
+              <p className="text-xs">{restaurantAddress}</p>
             </div>
 
+            {/* BIN # */}
+            {binNumber && (
+              <div className="text-center mb-1">
+                <p className="text-xs">BIN: {binNumber}</p>
+              </div>
+            )}
+
             {/* Order info */}
-            <div className="border-t border-b border-black py-1 mb-2 text-sm">
-              <p>Table: {tableLabel}</p>
-              <p>Order: {orderId.slice(0, 8)}</p>
-              <p className="font-bold">{section.label}</p>
+            <div className="border-t border-b border-black py-1 mb-2 text-xs space-y-0.5">
+              {billNumber && (
+                <div className="flex justify-between">
+                  <span className="font-semibold">Bill No</span>
+                  <span>{billNumber}</span>
+                </div>
+              )}
+              <div className="flex justify-between">
+                <span>Date</span>
+                <span>{timestamp}</span>
+              </div>
+              {registerName && (
+                <div className="flex justify-between">
+                  <span>Register</span>
+                  <span>{registerName}</span>
+                </div>
+              )}
+              <div className="flex justify-between">
+                <span>Table</span>
+                <span>{tableLabel}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Order#</span>
+                <span>{orderId.slice(0, 8)}</span>
+              </div>
+              <div className="font-bold text-sm">{section.label}</div>
             </div>
 
             {/* Items (only for by-seat split) */}
@@ -191,7 +236,7 @@ export default function SplitBillPrintView({
 
             {/* Footer */}
             <div className="border-t border-black mt-2 pt-1 text-center text-xs">
-              Thank you for dining with us!
+              Thank You!!!
             </div>
           </div>
         ))}

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -185,17 +185,91 @@ export async function handler(
       }
     }
 
-    // 4. Update order status to pending_payment and persist final_total_cents + service_charge_cents
+    // 4. Generate atomic sequential bill number for this restaurant.
+    //    Use an upsert-then-increment pattern: insert row with last_value=1 if not exists,
+    //    otherwise increment. We read the updated value back via return=representation.
+    let billNumber: string | null = null
+    try {
+      // Attempt to increment using a RPC or a read-modify-write via PostgREST.
+      // PostgREST does not support atomic increment directly, so we use a two-step approach:
+      //   a) Upsert to ensure the row exists (last_value stays the same on conflict update if we set it to last_value).
+      //   b) Fetch + increment via a PATCH with arithmetic is not supported in PostgREST.
+      //
+      // Instead, use a DB function (decrement_ingredient_stock style) or fall back to:
+      //   a) fetch current last_value
+      //   b) PATCH with last_value + 1 — non-atomic but acceptable for POS (concurrent closes rare)
+      //
+      // For true atomicity we call a Postgres RPC if available, otherwise best-effort.
+
+      // Try to call an RPC that atomically increments and returns new value
+      const rpcRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/rpc/next_bill_sequence`,
+        {
+          method: 'POST',
+          headers: { ...dbHeaders, Prefer: 'return=representation' },
+          body: JSON.stringify({ p_restaurant_id: restaurantId }),
+        },
+      )
+      if (rpcRes.ok) {
+        const rpcText = await rpcRes.text()
+        const nextVal = rpcText ? parseInt(JSON.parse(rpcText) as string, 10) : NaN
+        if (!isNaN(nextVal)) {
+          billNumber = 'RN' + String(nextVal).padStart(7, '0')
+        }
+      }
+
+      // Fallback: best-effort non-atomic increment
+      if (!billNumber) {
+        // Upsert sequence row
+        await fetchFn(
+          `${supabaseUrl}/rest/v1/bill_sequences?on_conflict=restaurant_id`,
+          {
+            method: 'POST',
+            headers: { ...dbHeaders, Prefer: 'resolution=ignore-duplicates,return=minimal' },
+            body: JSON.stringify({ restaurant_id: restaurantId, last_value: 0 }),
+          },
+        )
+        // Fetch current
+        const seqRes = await fetchFn(
+          `${supabaseUrl}/rest/v1/bill_sequences?restaurant_id=eq.${restaurantId}&select=last_value&limit=1`,
+          { headers: dbHeaders },
+        )
+        if (seqRes.ok) {
+          const seqRows = (await seqRes.json()) as Array<{ last_value: number }>
+          const currentVal = seqRows.length > 0 ? seqRows[0].last_value : 0
+          const nextVal = currentVal + 1
+          await fetchFn(
+            `${supabaseUrl}/rest/v1/bill_sequences?restaurant_id=eq.${restaurantId}`,
+            {
+              method: 'PATCH',
+              headers: { ...dbHeaders, Prefer: 'return=minimal' },
+              body: JSON.stringify({ last_value: nextVal }),
+            },
+          )
+          billNumber = 'RN' + String(nextVal).padStart(7, '0')
+        }
+      }
+    } catch {
+      // Non-fatal: bill number generation must never block order close
+      billNumber = null
+    }
+
+    // 4b. Update order status to pending_payment and persist final_total_cents + service_charge_cents + bill_number
+    const orderUpdatePayload: Record<string, unknown> = {
+      status: 'pending_payment',
+      final_total_cents: finalTotal,
+      service_charge_cents: serviceChargeCents,
+    }
+    if (billNumber) {
+      orderUpdatePayload['bill_number'] = billNumber
+    }
+
     const updateRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
       {
         method: 'PATCH',
         headers: { ...dbHeaders, Prefer: 'return=minimal' },
-        body: JSON.stringify({
-          status: 'pending_payment',
-          final_total_cents: finalTotal,
-          service_charge_cents: serviceChargeCents,
-        }),
+        body: JSON.stringify(orderUpdatePayload),
       },
     )
     if (!updateRes.ok) {
@@ -298,7 +372,7 @@ export async function handler(
           action: 'close_order',
           entity_type: 'orders',
           entity_id: orderId,
-          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents },
+          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, bill_number: billNumber },
         }),
       },
     )
@@ -310,7 +384,7 @@ export async function handler(
     }
 
     return new Response(
-      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents } }),
+      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, bill_number: billNumber } }),
       { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   } catch {

--- a/supabase/migrations/20260401000000_enhanced_bill.sql
+++ b/supabase/migrations/20260401000000_enhanced_bill.sql
@@ -1,0 +1,40 @@
+-- Issue #261: Enhanced bill/receipt format
+--
+-- 1. bill_sequences — atomic sequential bill counter per restaurant.
+-- 2. orders.bill_number — formatted reference generated on close_order (e.g. RN0001234).
+-- 3. orders.customer_mobile — optional mobile number for delivery/takeaway orders.
+--
+-- Config keys added via application upsert (no DDL):
+--   bin_number       — VAT registration number displayed on bill
+--   register_name    — terminal/device identifier displayed on bill
+--   restaurant_address — physical address displayed below restaurant name on bill
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS bill_sequences;
+--   ALTER TABLE orders DROP COLUMN IF EXISTS bill_number;
+--   ALTER TABLE orders DROP COLUMN IF EXISTS customer_mobile;
+
+-- Atomic bill sequence counter per restaurant
+CREATE TABLE IF NOT EXISTS bill_sequences (
+  restaurant_id uuid PRIMARY KEY REFERENCES restaurants(id) ON DELETE CASCADE,
+  last_value    integer NOT NULL DEFAULT 0
+);
+
+ALTER TABLE bill_sequences ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users (server role via service key) can read/update sequences
+CREATE POLICY "allow_all_authenticated" ON bill_sequences
+  FOR ALL TO authenticated USING (true) WITH CHECK (true);
+
+-- Anon access for dev/demo (matches pattern used by config, vat_rates)
+-- HUMAN REVIEW REQUIRED
+CREATE POLICY "allow_anon_all" ON bill_sequences
+  FOR ALL TO anon USING (true) WITH CHECK (true);
+
+-- bill_number stored on order after generation
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS bill_number text,
+  ADD COLUMN IF NOT EXISTS customer_mobile text;
+
+-- Index for fast lookup by bill_number (e.g. reprint)
+CREATE INDEX IF NOT EXISTS idx_orders_bill_number ON orders(bill_number) WHERE bill_number IS NOT NULL;

--- a/supabase/migrations/20260401000100_bill_sequence_rpc.sql
+++ b/supabase/migrations/20260401000100_bill_sequence_rpc.sql
@@ -1,0 +1,27 @@
+-- Issue #261: Atomic bill sequence RPC
+-- next_bill_sequence(p_restaurant_id) — atomically increments and returns the next bill number.
+-- Uses INSERT ... ON CONFLICT DO UPDATE to ensure atomicity without a separate lock.
+--
+-- Rollback:
+--   DROP FUNCTION IF EXISTS next_bill_sequence(uuid);
+
+CREATE OR REPLACE FUNCTION next_bill_sequence(p_restaurant_id uuid)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_next integer;
+BEGIN
+  INSERT INTO bill_sequences (restaurant_id, last_value)
+  VALUES (p_restaurant_id, 1)
+  ON CONFLICT (restaurant_id) DO UPDATE
+    SET last_value = bill_sequences.last_value + 1
+  RETURNING last_value INTO v_next;
+
+  RETURN v_next;
+END;
+$$;
+
+-- Grant execute to anon and authenticated (matches existing pattern)
+GRANT EXECUTE ON FUNCTION next_bill_sequence(uuid) TO anon, authenticated;


### PR DESCRIPTION
## Summary

Upgrades the printed bill/receipt to match professional POS receipt standards.

Closes #261

---

## Database changes

### New table: `bill_sequences`
Atomic sequential bill counter per restaurant.
```sql
bill_sequences (restaurant_id PK, last_value INTEGER)
```

### New RPC: `next_bill_sequence(p_restaurant_id)`
Atomically increments and returns the next bill number using `INSERT ... ON CONFLICT DO UPDATE`.

### `orders` table additions
- `bill_number TEXT` — generated on `close_order` (format: `RN0001234`)
- `customer_mobile TEXT` — optional mobile for delivery/takeaway

### `config` keys (upserted by the new admin page)
- `bin_number` — VAT registration number
- `register_name` — terminal/device identifier (e.g. Cashier 1)
- `restaurant_address` — address line shown on bill

---

## Bill layout (top to bottom)

1. Restaurant name + address
2. BIN # (hidden when not configured)
3. Bill No / Date / Location / Register / Order type / Staff / Order#
4. Line items: S.No | Item name | Qty | Amount (+ per-item discount rows)
5. Sub total → Discount → Service Charge → VAT → Round off → **Pay**
6. Tendered by: [method] · Cash Tendered / Change Due
7. Customer details section (delivery/takeaway: name, mobile, address)
8. Footer: **Thank You!!!**

---

## Frontend changes

- **`BillPrintView.tsx`** — full redesign with new layout; new props: `restaurantName`, `restaurantAddress`, `binNumber`, `billNumber`, `registerName`, `locationName`, `staffUser`, `roundOffCents`, `customerMobile`
- **`SplitBillPrintView.tsx`** — same header props added (`restaurantName`, `restaurantAddress`, `binNumber`, `billNumber`, `registerName`)
- **Admin → Settings → Restaurant** (new page) — dark Tailwind form for BIN number, register name, restaurant address; upsert pattern matching VAT/currency config
- **AdminNav** — adds Restaurant link (Store icon)
- **`OrderDetailClient.tsx`** — fetches restaurant config in `loadVatConfig()` alongside VAT; passes all enhanced props to both print views
- **`orderData.ts`** — `OrderSummary` extended with `customer_mobile` and `bill_number`

---

## Tests

- `BillPrintView.test.tsx` — updated for new layout; added tests for BIN, bill number, register name (18 tests, all pass)
- `orderData.test.ts` — updated mock response shapes to include new fields
- `OrderDetailClient.test.tsx` — updated mock return values
