### PR TITLE
feat(#177): accounting export — CSV/daily summary download

### DIFF
--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import type { JSX } from 'react'
+import { Download } from 'lucide-react'
 import { useUser } from '@/lib/user-context'
 import { callGetReports, callExportOrders } from './reportsApi'
 import type { ReportData, ReportPeriod, CompDetailItem, CompByItem, StaffPerformanceRow } from './reportsApi'
@@ -12,6 +13,8 @@ import {
   exportPaymentBreakdown,
   exportCompDetail,
   exportOrderList,
+  exportAccountingCSV,
+  exportDailySummary,
 } from './csvExport'
 
 const PERIOD_LABELS: { value: ReportPeriod; label: string }[] = [
@@ -42,9 +45,7 @@ function ExportButton({ onClick, loading = false, label = 'Export CSV' }: Export
           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
         </svg>
       ) : (
-        <svg className="w-3.5 h-3.5 shrink-0" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-          <path fillRule="evenodd" d="M3 17a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm3.293-7.707a1 1 0 011.414 0L9 10.586V3a1 1 0 112 0v7.586l1.293-1.293a1 1 0 111.414 1.414l-3 3a1 1 0 01-1.414 0l-3-3a1 1 0 010-1.414z" clipRule="evenodd" />
-        </svg>
+        <Download className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
       )}
       {label}
     </button>
@@ -610,7 +611,44 @@ export default function ReportsDashboard(): JSX.Element {
             <StaffPerformanceTable rows={data.staff_performance ?? []} />
           </div>
 
-          {/* Row 7 — Full Order List Export */}
+          {/* Row 7 — Accounting Export */}
+          <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+              <div>
+                <h2 className="text-base font-semibold text-white">Accounting Export</h2>
+                <p className="text-sm text-zinc-400 mt-0.5">
+                  Download a detailed financial summary for the selected period — daily revenue breakdown by payment
+                  method, or a human-readable summary with top items and payment totals.
+                </p>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 flex-wrap">
+                <button
+                  type="button"
+                  onClick={() =>
+                    exportAccountingCSV(data, period, customFrom || undefined, customTo || undefined)
+                  }
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-600 hover:bg-amber-500 text-white text-xs font-medium transition-colors border border-amber-500"
+                  aria-label="Export accounting CSV"
+                >
+                  <Download className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  Export CSV
+                </button>
+                <button
+                  type="button"
+                  onClick={() =>
+                    exportDailySummary(data, period, customFrom || undefined, customTo || undefined)
+                  }
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-700 hover:bg-zinc-600 text-zinc-200 text-xs font-medium transition-colors border border-zinc-600"
+                  aria-label="Export daily summary text"
+                >
+                  <Download className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+                  Daily Summary
+                </button>
+              </div>
+            </div>
+          </div>
+
+          {/* Row 8 — Full Order List Export */}
           <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
               <div>

--- a/apps/web/app/admin/reports/csvExport.ts
+++ b/apps/web/app/admin/reports/csvExport.ts
@@ -103,6 +103,178 @@ export function exportCompDetail(data: ReportData, period: ReportPeriod, customF
 }
 
 // ---------------------------------------------------------------------------
+// Accounting export — per-day financial summary CSV
+// ---------------------------------------------------------------------------
+
+/**
+ * Exports a per-day accounting CSV with revenue broken down by payment method.
+ * Payment method totals are available only at the aggregate level from the
+ * reports API, so per-day values are proportionally distributed from the
+ * aggregate. Where a single day is selected the values are exact.
+ */
+export function exportAccountingCSV(
+  data: ReportData,
+  period: ReportPeriod,
+  customFrom?: string,
+  customTo?: string,
+): void {
+  const headers = [
+    'date',
+    'total_orders',
+    'total_revenue_cents',
+    'cash_revenue_cents',
+    'card_revenue_cents',
+    'comp_revenue_cents',
+    'vat_collected_cents',
+    'service_charge_cents',
+    'net_revenue_cents',
+  ]
+
+  // Build payment-method lookup from aggregate breakdown
+  const paymentMap: Record<string, number> = {}
+  for (const p of data.payment_breakdown) {
+    paymentMap[p.method.toLowerCase()] = p.revenue_cents
+  }
+
+  const totalRevenueCents = data.summary.total_revenue_cents
+  const totalServiceCharge = data.summary.total_service_charge_cents ?? 0
+  const totalComp = data.comp_detail?.total_comp_value_cents ?? 0
+
+  // Aggregate cash / card (sum everything that is not 'comp')
+  const cashRevenue = paymentMap['cash'] ?? 0
+  const cardRevenue =
+    Object.entries(paymentMap)
+      .filter(([method]) => method !== 'cash' && method !== 'comp')
+      .reduce((sum, [, v]) => sum + v, 0)
+
+  const rows = data.revenue_by_day.map(day => {
+    const proportion = totalRevenueCents > 0 ? day.revenue_cents / totalRevenueCents : 0
+    const dayCash = Math.round(cashRevenue * proportion)
+    const dayCard = Math.round(cardRevenue * proportion)
+    const dayComp = Math.round(totalComp * proportion)
+    const daySvc = Math.round(totalServiceCharge * proportion)
+    // VAT is not tracked in the current data model
+    const dayVat = 0
+    const dayNet = day.revenue_cents - daySvc - dayVat
+
+    return [
+      day.date,
+      (day as { date: string; revenue_cents: number; order_count?: number }).order_count ?? '',
+      day.revenue_cents,
+      dayCash,
+      dayCard,
+      dayComp,
+      dayVat,
+      daySvc,
+      dayNet,
+    ]
+  })
+
+  downloadCSV(buildCSV(headers, rows), makeFilename('accounting', period, customFrom, customTo))
+}
+
+// ---------------------------------------------------------------------------
+// Daily summary — human-readable text export
+// ---------------------------------------------------------------------------
+
+function pad(str: string, len: number): string {
+  return str.length >= len ? str : str + ' '.repeat(len - str.length)
+}
+
+/**
+ * Exports a human-readable financial summary for the selected period as a
+ * plain-text file (.txt). Covers total sales, payment breakdown, top 5 items,
+ * discounts & comps, and average order value.
+ */
+export function exportDailySummary(
+  data: ReportData,
+  period: ReportPeriod,
+  customFrom?: string,
+  customTo?: string,
+): void {
+  const periodLabel =
+    period === 'custom' && customFrom && customTo
+      ? `${customFrom} to ${customTo}`
+      : period.charAt(0).toUpperCase() + period.slice(1)
+
+  const divider = '─'.repeat(44)
+
+  const lines: string[] = [
+    'iKitchen POS — Financial Summary',
+    divider,
+    `Period   : ${periodLabel}`,
+    `Generated: ${new Date().toLocaleString('en-GB', { hour12: false })}`,
+    '',
+    'SALES OVERVIEW',
+    divider,
+    `${pad('Total Revenue:', 22)} ${formatPrice(data.summary.total_revenue_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+    `${pad('Total Orders:', 22)} ${data.summary.order_count}`,
+    `${pad('Avg Order Value:', 22)} ${formatPrice(data.summary.avg_order_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+    `${pad('Total Covers:', 22)} ${data.summary.total_covers}`,
+  ]
+
+  if ((data.summary.total_service_charge_cents ?? 0) > 0) {
+    lines.push(
+      `${pad('Service Charge:', 22)} ${formatPrice(data.summary.total_service_charge_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+    )
+  }
+
+  lines.push('', 'PAYMENT BREAKDOWN', divider)
+  if (data.payment_breakdown.length === 0) {
+    lines.push('  No payment data')
+  } else {
+    for (const p of data.payment_breakdown) {
+      const label = p.method.charAt(0).toUpperCase() + p.method.slice(1)
+      lines.push(
+        `${pad(label + ':', 22)} ${formatPrice(p.revenue_cents, DEFAULT_CURRENCY_SYMBOL).padStart(12)}  (${p.count} orders)`,
+      )
+    }
+  }
+
+  lines.push('', 'TOP 5 ITEMS', divider)
+  const top5 = data.top_items.slice(0, 5)
+  if (top5.length === 0) {
+    lines.push('  No item data')
+  } else {
+    top5.forEach((item, idx) => {
+      const rank = `${idx + 1}.`
+      const name = pad(item.name, 28)
+      lines.push(`  ${rank.padEnd(4)}${name}  ${String(item.quantity_sold).padStart(4)} qty  ${formatPrice(item.revenue_cents, DEFAULT_CURRENCY_SYMBOL)}`)
+    })
+  }
+
+  if (data.comp_detail || data.discount_summary.discount_order_count > 0) {
+    lines.push('', 'COMPS & DISCOUNTS', divider)
+    if (data.comp_detail) {
+      lines.push(
+        `${pad('Total Comp Value:', 22)} ${formatPrice(data.comp_detail.total_comp_value_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+        `${pad('  Item comps:', 22)} ${formatPrice(data.comp_detail.comp_item_value_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+        `${pad('  Order comps:', 22)} ${formatPrice(data.comp_detail.comp_order_value_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+      )
+    }
+    if (data.discount_summary.discount_order_count > 0) {
+      lines.push(
+        `${pad('Discounted Orders:', 22)} ${data.discount_summary.discount_order_count}`,
+        `${pad('Total Discounts:', 22)} ${formatPrice(data.discount_summary.total_discount_cents, DEFAULT_CURRENCY_SYMBOL)}`,
+      )
+    }
+  }
+
+  lines.push('', divider, 'Generated by iKitchen POS')
+
+  const content = lines.join('\n')
+  const blob = new Blob([content], { type: 'text/plain;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = makeFilename('daily-summary', period, customFrom, customTo).replace('.csv', '.txt')
+  document.body.appendChild(anchor)
+  anchor.click()
+  document.body.removeChild(anchor)
+  setTimeout(() => URL.revokeObjectURL(url), 10_000)
+}
+
+// ---------------------------------------------------------------------------
 // Full order list (data comes from export_orders edge function)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #177

Adds an **Accounting Export** card to the  dashboard with two client-side download options — no new API endpoints, no new npm packages.

## What's included

### 1. Accounting CSV (`Export CSV` — amber button)
Generates a per-day CSV with these columns:

| Column | Source |
|---|---|
| `date` | `revenue_by_day.date` |
| `total_orders` | `revenue_by_day.order_count` |
| `total_revenue_cents` | `revenue_by_day.revenue_cents` |
| `cash_revenue_cents` | Proportionally distributed from aggregate |
| `card_revenue_cents` | Proportionally distributed from aggregate |
| `comp_revenue_cents` | Proportionally distributed from `comp_detail` |
| `vat_collected_cents` | 0 (not tracked in current model) |
| `service_charge_cents` | Proportionally distributed from `summary` |
| `net_revenue_cents` | `total - service_charge - vat` |

> Payment method breakdown is available only at aggregate level from the current API; values are distributed by daily revenue proportion (exact for single-day periods).

### 2. Daily Summary text (`Daily Summary` — ghost button)
Human-readable `.txt` file with:
- Period & generation timestamp
- Sales overview (revenue, orders, avg order, covers, service charge)
- Payment breakdown table (method, revenue, order count)
- Top 5 items (rank, name, qty, revenue)
- Comps & discounts section

### Other changes
- `ExportButton` now uses `lucide-react` `<Download />` icon instead of inline SVG (consistent with codebase icon convention)
- Both new exports use `Blob + URL.createObjectURL` — no new packages

## Checklist
- [x] No new npm packages
- [x] lucide-react Download icon
- [x] Dark Tailwind theme consistent
- [x] Client-side generation only
- [x] TypeScript clean (no errors in reports/)
- [x] Restaurant-scoped (uses existing auth context via `useUser`)