### PR TITLE
fix(#297): availability panel loading state and restaurant null guard

### DIFF
--- a/apps/web/app/admin/inventory/AvailabilityPanel.tsx
+++ b/apps/web/app/admin/inventory/AvailabilityPanel.tsx
@@ -17,7 +17,7 @@ interface Feedback {
 
 export default function AvailabilityPanel(): JSX.Element {
   const { accessToken } = useUser()
-  const { restaurantId } = useActiveRestaurantContext()
+  const { restaurantId, loading: restaurantLoading } = useActiveRestaurantContext()
   const [categories, setCategories] = useState<AvailabilityCategory[]>([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState<string | null>(null)
@@ -41,7 +41,14 @@ export default function AvailabilityPanel(): JSX.Element {
       setLoading(false)
       return
     }
-    if (!restaurantId) return
+    // Wait for restaurant context to finish loading before concluding no restaurant
+    if (restaurantLoading) return
+    if (!restaurantId) {
+      setFetchError('No restaurant found. Please contact your administrator.')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
     fetchMenuAvailability(supabaseUrl, apiKey, restaurantId)
       .then((cats) => setCategories(cats))
       .catch((err: unknown) => {
@@ -52,7 +59,7 @@ export default function AvailabilityPanel(): JSX.Element {
     return () => {
       if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
     }
-  }, [supabaseUrl, apiKey, restaurantId])
+  }, [supabaseUrl, apiKey, restaurantId, restaurantLoading])
 
   async function handleToggle(categoryId: string, itemId: string, newAvailable: boolean): Promise<void> {
     if (!accessToken) {


### PR DESCRIPTION
## Bug #297
Clicking Inventory → 86/Availability crashes with 'Application error'.

## Root cause (best-effort without browser console)
The `useEffect` that triggers the fetch returned early (`if (!restaurantId) return`) without ever calling `setLoading(false)`, so if `useActiveRestaurant` was still resolving the component stayed stuck in `loading = true` state indefinitely. More critically, the component didn't wait for the restaurant context to finish loading before deciding `restaurantId` was null — causing a premature abort.

## Fix
- Destructure `loading` (as `restaurantLoading`) from `useActiveRestaurant`
- Add `if (restaurantLoading) return` guard — wait for context to finish before acting
- When context has loaded and `restaurantId` is still null: set a proper error message and resolve `loading = false` (no more infinite loading state)
- Add `restaurantLoading` to the effect dependency array so it re-runs when context resolves
- Reset `setLoading(true)` at the start of each actual fetch to avoid stale state on re-runs

Closes #297