### PR TITLE
fix: use users table for ownership check in update_table_position

### DIFF
--- a/supabase/functions/update_table_position/index.test.ts
+++ b/supabase/functions/update_table_position/index.test.ts
@@ -35,9 +35,9 @@ function makePatchFetch(
         : []
       return Promise.resolve(new Response(JSON.stringify(rows), { status: 200 }))
     }
-    // Ownership check — GET /rest/v1/user_restaurants?user_id=...&restaurant_id=...
-    if ((url as string).includes('/user_restaurants?')) {
-      const rows = ownershipGranted ? [{ user_id: mockAuth.actorId }] : []
+    // Ownership check — GET /rest/v1/users?id=eq.{actorId}&restaurant_id=eq.{restaurantId}
+    if ((url as string).includes('/users?id=eq.')) {
+      const rows = ownershipGranted ? [{ id: mockAuth.actorId }] : []
       return Promise.resolve(new Response(JSON.stringify(rows), { status: 200 }))
     }
     return Promise.resolve(new Response('[]', { status: 200 }))

--- a/supabase/functions/update_table_position/index.ts
+++ b/supabase/functions/update_table_position/index.ts
@@ -150,10 +150,12 @@ export async function handler(
     )
   }
 
-  // Verify caller belongs to that restaurant
+  // Verify caller belongs to that restaurant via the users table
+  // (users.restaurant_id is the primary user-restaurant link; user_restaurants
+  //  is the multi-location junction table which is not yet populated for MVP)
   try {
     const ownerRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/user_restaurants?user_id=eq.${caller.actorId}&restaurant_id=eq.${restaurantId}&select=user_id`,
+      `${supabaseUrl}/rest/v1/users?id=eq.${encodeURIComponent(caller.actorId)}&restaurant_id=eq.${encodeURIComponent(restaurantId)}&select=id&limit=1`,
       { headers: baseHeaders },
     )
     if (!ownerRes.ok) {


### PR DESCRIPTION
## Problem

After merging #304 (floor plan builder), dragging tables in the admin gives a **403 Forbidden** error.

## Root cause

`update_table_position` was checking the `user_restaurants` junction table (added in the multi-location migration #179) to verify the caller belongs to the restaurant. That table is **empty for the MVP** — user-restaurant membership is carried by `users.restaurant_id`, not `user_restaurants`.

So every admin drag hit the ownership check, found 0 rows, and returned 403.

## Fix

Replace:
```
GET /rest/v1/user_restaurants?user_id=eq.{actorId}&restaurant_id=eq.{restaurantId}
```
With:
```
GET /rest/v1/users?id=eq.{actorId}&restaurant_id=eq.{restaurantId}
```

Also updates the unit test mock to match the new URL pattern.

## Testing

- Unit tests updated ✅
- Manually: admin drag-and-drop should now succeed (no more 403)