### PR TITLE
perf(#273): batch config fetch + in-memory cache for floor plan loading

### DIFF
--- a/apps/web/app/admin/floor-plan/FloorPlanBuilder.tsx
+++ b/apps/web/app/admin/floor-plan/FloorPlanBuilder.tsx
@@ -395,7 +395,7 @@ export default function FloorPlanBuilder(): JSX.Element {
       if (outOfBounds.length > 0) {
         await Promise.all(
           outOfBounds.map((t) =>
-            saveTablePosition(config.url, accessToken, t.id, null, null).catch(() => {
+            saveTablePosition(config.url, config.key, accessToken, t.id, null, null).catch(() => {
               /* non-fatal — table state already updated locally */
             }),
           ),
@@ -455,7 +455,7 @@ export default function FloorPlanBuilder(): JSX.Element {
       if (!config || !accessToken) return
 
       setSavingId(tableId)
-      saveTablePosition(config.url, accessToken, tableId, newX, newY)
+      saveTablePosition(config.url, config.key, accessToken, tableId, newX, newY)
         .then(() => {
           // Update server-known state on success
           serverTables.current = serverTables.current.map((t) =>
@@ -479,7 +479,7 @@ export default function FloorPlanBuilder(): JSX.Element {
     const positioned = serverTables.current.filter((t) => t.grid_x !== null || t.grid_y !== null)
     try {
       await Promise.all(
-        positioned.map((t) => saveTablePosition(config.url, accessToken, t.id, null, null)),
+        positioned.map((t) => saveTablePosition(config.url, config.key, accessToken, t.id, null, null)),
       )
       setTables((prev) => prev.map((t) => ({ ...t, grid_x: null, grid_y: null })))
       serverTables.current = serverTables.current.map((t) => ({ ...t, grid_x: null, grid_y: null }))

--- a/apps/web/app/admin/floor-plan/floorPlanApi.test.ts
+++ b/apps/web/app/admin/floor-plan/floorPlanApi.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchTablePositions, saveTablePosition } from './floorPlanApi'
+import {
+  fetchTablePositions,
+  saveTablePosition,
+  fetchFloorPlanConfig,
+  invalidateTablePositionsCache,
+  invalidateFloorPlanConfigCache,
+} from './floorPlanApi'
 
 const SUPABASE_URL = 'https://test.supabase.co'
 const API_KEY = 'test-api-key'
 const ACCESS_TOKEN = 'test-access-token'
+const RESTAURANT_ID = 'rest-1'
 
 const mockTables = [
   { id: 'table-1', label: 'Table 1', seat_count: 4, grid_x: 2, grid_y: 3 },
@@ -12,6 +19,9 @@ const mockTables = [
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  // Clear caches so tests don't bleed into each other
+  invalidateTablePositionsCache(SUPABASE_URL, API_KEY)
+  invalidateFloorPlanConfigCache(SUPABASE_URL, RESTAURANT_ID)
 })
 
 describe('fetchTablePositions', () => {
@@ -62,6 +72,21 @@ describe('fetchTablePositions', () => {
 
     await expect(fetchTablePositions(SUPABASE_URL, API_KEY)).rejects.toThrow('401')
   })
+
+  it('second call within TTL returns cached value (no second fetch)', async (): Promise<void> => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(mockTables), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', mockFetch)
+
+    // First call — hits network
+    const first = await fetchTablePositions(SUPABASE_URL, API_KEY)
+    // Second call — should use cache, no additional fetch
+    const second = await fetchTablePositions(SUPABASE_URL, API_KEY)
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    expect(second).toStrictEqual(first)
+  })
 })
 
 describe('saveTablePosition', () => {
@@ -71,7 +96,7 @@ describe('saveTablePosition', () => {
     )
     vi.stubGlobal('fetch', mockFetch)
 
-    await saveTablePosition(SUPABASE_URL, ACCESS_TOKEN, 'table-1', 5, 3)
+    await saveTablePosition(SUPABASE_URL, API_KEY, ACCESS_TOKEN, 'table-1', 5, 3)
 
     expect(mockFetch).toHaveBeenCalledOnce()
     const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit]
@@ -95,7 +120,7 @@ describe('saveTablePosition', () => {
     )
     vi.stubGlobal('fetch', mockFetch)
 
-    await saveTablePosition(SUPABASE_URL, ACCESS_TOKEN, 'table-1', null, null)
+    await saveTablePosition(SUPABASE_URL, API_KEY, ACCESS_TOKEN, 'table-1', null, null)
 
     const [, init] = mockFetch.mock.calls[0] as [string, RequestInit]
     const body = JSON.parse(init.body as string) as {
@@ -113,7 +138,7 @@ describe('saveTablePosition', () => {
     ))
 
     await expect(
-      saveTablePosition(SUPABASE_URL, ACCESS_TOKEN, '', null, null),
+      saveTablePosition(SUPABASE_URL, API_KEY, ACCESS_TOKEN, '', null, null),
     ).rejects.toThrow('table_id is required')
   })
 
@@ -123,7 +148,105 @@ describe('saveTablePosition', () => {
     ))
 
     await expect(
-      saveTablePosition(SUPABASE_URL, ACCESS_TOKEN, 'table-1', 0, 0),
+      saveTablePosition(SUPABASE_URL, API_KEY, ACCESS_TOKEN, 'table-1', 0, 0),
     ).rejects.toThrow('500')
+  })
+
+  it('triggers cache invalidation so next fetchTablePositions goes to network again', async (): Promise<void> => {
+    let fetchCount = 0
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
+      fetchCount++
+      if ((url as string).includes('update_table_position')) {
+        return Promise.resolve(new Response('{}', { status: 200 }))
+      }
+      return Promise.resolve(new Response(JSON.stringify(mockTables), { status: 200 }))
+    }))
+
+    // Populate cache
+    await fetchTablePositions(SUPABASE_URL, API_KEY)
+    expect(fetchCount).toBe(1)
+
+    // Verify cache is hot — no additional fetch
+    await fetchTablePositions(SUPABASE_URL, API_KEY)
+    expect(fetchCount).toBe(1)
+
+    // Save should invalidate cache
+    await saveTablePosition(SUPABASE_URL, API_KEY, ACCESS_TOKEN, 'table-1', 1, 2)
+    expect(fetchCount).toBe(2) // save itself
+
+    // Next fetchTablePositions must hit the network again
+    await fetchTablePositions(SUPABASE_URL, API_KEY)
+    expect(fetchCount).toBe(3)
+  })
+})
+
+describe('fetchFloorPlanConfig', () => {
+  it('hits the correct PostgREST URL with in.() params and parses both rows', async (): Promise<void> => {
+    const configRows = [
+      { key: 'floor_plan_cols', value: '12' },
+      { key: 'floor_plan_rows', value: '8' },
+    ]
+    const mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(configRows), { status: 200 }),
+    )
+    vi.stubGlobal('fetch', mockFetch)
+
+    const result = await fetchFloorPlanConfig(SUPABASE_URL, API_KEY, RESTAURANT_ID, { cols: 10, rows: 6 })
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url] = mockFetch.mock.calls[0] as [string]
+    const decodedUrl = decodeURIComponent(url)
+    expect(decodedUrl).toContain('/rest/v1/config')
+    expect(decodedUrl).toContain('in.(floor_plan_cols,floor_plan_rows)')
+    expect(decodedUrl).toContain(`eq.${RESTAURANT_ID}`)
+
+    expect(result).toEqual({ cols: 12, rows: 8 })
+  })
+
+  it('returns defaults on a non-ok response', async (): Promise<void> => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response('Forbidden', { status: 403 }),
+    ))
+
+    const defaults = { cols: 10, rows: 6 }
+    const result = await fetchFloorPlanConfig(SUPABASE_URL, API_KEY, RESTAURANT_ID, defaults)
+    expect(result).toEqual(defaults)
+  })
+
+  it('returns defaults for missing keys (empty rows array)', async (): Promise<void> => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    ))
+
+    const defaults = { cols: 10, rows: 6 }
+    const result = await fetchFloorPlanConfig(SUPABASE_URL, API_KEY, RESTAURANT_ID, defaults)
+    expect(result).toEqual(defaults)
+  })
+
+  it('correctly handles cols=0 (zero is valid, not treated as falsy)', async (): Promise<void> => {
+    // Ensure Number.isNaN check is used: zero should be preserved, not replaced with default
+    const configRows = [
+      { key: 'floor_plan_cols', value: '0' },
+      { key: 'floor_plan_rows', value: '0' },
+    ]
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(configRows), { status: 200 }),
+    ))
+
+    const result = await fetchFloorPlanConfig(SUPABASE_URL, API_KEY, RESTAURANT_ID, { cols: 10, rows: 6 })
+    // 0 is a valid integer (not NaN) — should be kept as-is, not replaced with default
+    expect(result).toEqual({ cols: 0, rows: 0 })
+  })
+})
+
+describe('invalidateTablePositionsCache', () => {
+  it('is exported and callable', () => {
+    expect(() => invalidateTablePositionsCache(SUPABASE_URL, API_KEY)).not.toThrow()
+  })
+})
+
+describe('invalidateFloorPlanConfigCache', () => {
+  it('is exported and callable', () => {
+    expect(() => invalidateFloorPlanConfigCache(SUPABASE_URL, RESTAURANT_ID)).not.toThrow()
   })
 })

--- a/apps/web/app/admin/floor-plan/floorPlanApi.ts
+++ b/apps/web/app/admin/floor-plan/floorPlanApi.ts
@@ -21,7 +21,7 @@ export async function fetchTablePositions(
   supabaseUrl: string,
   apiKey: string,
 ): Promise<TablePosition[]> {
-  const cacheKey = supabaseUrl
+  const cacheKey = `${supabaseUrl}:${apiKey}`
   const cached = tablePositionsCache.get(cacheKey)
   if (cached && Date.now() < cached.expiresAt) {
     return cached.data
@@ -43,12 +43,13 @@ export async function fetchTablePositions(
 }
 
 /** Invalidate the table positions cache (call after a successful save). */
-export function invalidateTablePositionsCache(supabaseUrl: string): void {
-  tablePositionsCache.delete(supabaseUrl)
+export function invalidateTablePositionsCache(supabaseUrl: string, apiKey: string): void {
+  tablePositionsCache.delete(`${supabaseUrl}:${apiKey}`)
 }
 
 export async function saveTablePosition(
   supabaseUrl: string,
+  apiKey: string,
   accessToken: string,
   tableId: string,
   gridX: number | null,
@@ -67,7 +68,7 @@ export async function saveTablePosition(
     throw new Error(json.error ?? `Failed to save table position: ${res.status}`)
   }
   // Invalidate so the next load reflects the new position
-  invalidateTablePositionsCache(supabaseUrl)
+  invalidateTablePositionsCache(supabaseUrl, apiKey)
 }
 
 /** Fetch the restaurant id (first restaurant visible to the current key). */
@@ -117,9 +118,11 @@ export async function fetchFloorPlanConfig(
   if (!res.ok) return defaults
   const rows = (await res.json()) as Array<{ key: string; value: string }>
   const map = Object.fromEntries(rows.map(r => [r.key, r.value]))
+  const parsedCols = parseInt(map['floor_plan_cols'] ?? '', 10)
+  const parsedRows = parseInt(map['floor_plan_rows'] ?? '', 10)
   const config: FloorPlanConfig = {
-    cols: parseInt(map['floor_plan_cols'] ?? String(defaults.cols), 10) || defaults.cols,
-    rows: parseInt(map['floor_plan_rows'] ?? String(defaults.rows), 10) || defaults.rows,
+    cols: Number.isNaN(parsedCols) ? defaults.cols : parsedCols,
+    rows: Number.isNaN(parsedRows) ? defaults.rows : parsedRows,
   }
   floorPlanConfigCache.set(cacheKey, { data: config, expiresAt: Date.now() + CACHE_TTL_MS })
   return config


### PR DESCRIPTION
## Problem

The floor plan page (`/admin/floor-plan`) made 4 network requests in 2 sequential waterfall rounds on every page load with no caching:
- **Round 1** (parallel): `fetchTablePositions` + `fetchRestaurantId`
- **Round 2** (sequential, after Round 1): `fetchConfigValue('floor_plan_cols')` + `fetchConfigValue('floor_plan_rows')` — 2 separate REST calls

## Changes

### 1. Batch config fetch (`floorPlanApi.ts`)
Added `fetchFloorPlanConfig` that fetches both `floor_plan_cols` and `floor_plan_rows` in a **single** REST request using `in.(floor_plan_cols,floor_plan_rows)`. Eliminates the second sequential round and halves the config requests from 2 to 1.

### 2. In-memory cache for table positions
`fetchTablePositions` now uses a module-level Map cache with a 60-second TTL. Navigating back to the floor plan within 60s serves from cache (zero network requests).

### 3. In-memory cache for floor plan config
`fetchFloorPlanConfig` similarly caches with a 60-second TTL.

### 4. Cache invalidation
- `saveTablePosition` automatically calls `invalidateTablePositionsCache` after a successful save — fresh data on the next load after drag-and-drop.
- `handleSaveGridSize` in `FloorPlanBuilder.tsx` calls `invalidateFloorPlanConfigCache` after successfully saving grid dimensions.

## Result
- Page load: **4 requests in 2 waterfall rounds → 2 requests in 1 round** (first visit)
- Repeat visits within 60s: **0 network requests** for floor plan data