### PR TITLE
fix(#314): Critical — Restaurant-scoped RLS policies for all tables

### DIFF
--- a/apps/web/app/admin/menu/MenuItemFormPage.tsx
+++ b/apps/web/app/admin/menu/MenuItemFormPage.tsx
@@ -93,8 +93,9 @@ async function fetchMenuItemById(
   supabaseUrl: string,
   apiKey: string,
   itemId: string,
+  token?: string,
 ): Promise<MenuItemRow | null> {
-  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+  const headers = { apikey: apiKey, Authorization: `Bearer ${token ?? apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/menu_items`)
   url.searchParams.set('select', 'id,name,description,price_cents,image_url,menu_id,available,allergens,dietary_badges,spicy_level,modifiers(id,name,price_delta_cents)')
   url.searchParams.set('id', `eq.${itemId}`)
@@ -135,10 +136,12 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
       setLoading(false)
       return
     }
+    // Wait for the user's JWT before fetching RLS-protected data
+    if (!accessToken) return
     supabaseConfig.current = { url: supabaseUrl, key: supabaseKey }
 
     const fetches: Promise<void>[] = [
-      fetchMenuAdminData(supabaseUrl, supabaseKey).then((data) => {
+      fetchMenuAdminData(supabaseUrl, supabaseKey, accessToken).then((data) => {
         setMenus(data.menus)
         void fetchConfigValue(supabaseUrl, supabaseKey, data.restaurantId, 'currency_symbol', DEFAULT_CURRENCY_SYMBOL)
           .then((sym) => setCurrencySymbol(sym))
@@ -147,7 +150,7 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
 
     if (mode === 'edit' && itemId) {
       fetches.push(
-        fetchMenuItemById(supabaseUrl, supabaseKey, itemId).then((item) => {
+        fetchMenuItemById(supabaseUrl, supabaseKey, itemId, accessToken).then((item) => {
           if (!item) {
             setFetchError('Menu item not found')
             return
@@ -176,7 +179,7 @@ export default function MenuItemFormPage({ mode, itemId }: MenuItemFormPageProps
         setFetchError(err instanceof Error ? err.message : 'Failed to load data')
       })
       .finally(() => setLoading(false))
-  }, [mode, itemId])
+  }, [mode, itemId, accessToken])
 
   const handleFileSelected = useCallback(
     async (file: File): Promise<void> => {

--- a/apps/web/app/admin/menu/MenuManager.tsx
+++ b/apps/web/app/admin/menu/MenuManager.tsx
@@ -62,9 +62,10 @@ export default function MenuManager(): JSX.Element {
       setLoading(false)
       return
     }
+    if (!accessToken) return
     supabaseConfig.current = { url: supabaseUrl, key: supabaseKey }
 
-    fetchMenuAdminData(supabaseUrl, supabaseKey)
+    fetchMenuAdminData(supabaseUrl, supabaseKey, accessToken)
       .then((data) => {
         setRestaurantId(data.restaurantId)
         setMenus(data.menus)
@@ -75,7 +76,7 @@ export default function MenuManager(): JSX.Element {
       .finally(() => {
         setLoading(false)
       })
-  }, [])
+  }, [accessToken])
 
   useEffect(() => {
     return () => {

--- a/apps/web/app/admin/menu/import/ImportMenuClient.tsx
+++ b/apps/web/app/admin/menu/import/ImportMenuClient.tsx
@@ -57,14 +57,14 @@ export default function ImportMenuClient(): JSX.Element {
 
   // Load menu categories for suggestions
   useEffect(() => {
-    if (!supabaseUrl || !supabaseKey) return
-    fetchMenuAdminData(supabaseUrl, supabaseKey)
+    if (!supabaseUrl || !supabaseKey || !accessToken) return
+    fetchMenuAdminData(supabaseUrl, supabaseKey, accessToken)
       .then((data) => {
         setMenus(data.menus)
         setRestaurantId(data.restaurantId)
       })
       .catch(() => {/* ignore, suggestions just won't appear */})
-  }, [supabaseUrl, supabaseKey])
+  }, [supabaseUrl, supabaseKey, accessToken])
 
   const addFiles = useCallback((incoming: File[]) => {
     setFiles((prev) => {

--- a/apps/web/app/admin/menu/menuAdminData.ts
+++ b/apps/web/app/admin/menu/menuAdminData.ts
@@ -53,8 +53,8 @@ interface RestaurantRow {
   id: string
 }
 
-async function fetchRestaurantId(supabaseUrl: string, apiKey: string): Promise<string> {
-  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+async function fetchRestaurantId(supabaseUrl: string, apiKey: string, token?: string): Promise<string> {
+  const headers = { apikey: apiKey, Authorization: `Bearer ${token ?? apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/restaurants`)
   url.searchParams.set('select', 'id')
   url.searchParams.set('limit', '1')
@@ -68,8 +68,8 @@ async function fetchRestaurantId(supabaseUrl: string, apiKey: string): Promise<s
   return rows[0].id
 }
 
-async function fetchMenus(supabaseUrl: string, apiKey: string): Promise<AdminMenu[]> {
-  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+async function fetchMenus(supabaseUrl: string, apiKey: string, token?: string): Promise<AdminMenu[]> {
+  const headers = { apikey: apiKey, Authorization: `Bearer ${token ?? apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/menus`)
   url.searchParams.set(
     'select',
@@ -105,10 +105,11 @@ async function fetchMenus(supabaseUrl: string, apiKey: string): Promise<AdminMen
 export async function fetchMenuAdminData(
   supabaseUrl: string,
   apiKey: string,
+  token?: string,
 ): Promise<MenuAdminData> {
   const [restaurantId, menus] = await Promise.all([
-    fetchRestaurantId(supabaseUrl, apiKey),
-    fetchMenus(supabaseUrl, apiKey),
+    fetchRestaurantId(supabaseUrl, apiKey, token),
+    fetchMenus(supabaseUrl, apiKey, token),
   ])
   return { restaurantId, menus }
 }

--- a/apps/web/app/admin/users/UserManager.tsx
+++ b/apps/web/app/admin/users/UserManager.tsx
@@ -96,14 +96,16 @@ export default function UserManager(): JSX.Element {
       setLoading(false)
       return
     }
+    // Wait for the user's JWT before fetching RLS-protected data
+    if (!accessToken) return
     supabaseConfig.current = { url: supabaseUrl }
 
     // Identify caller's role for role-hierarchy enforcement in the UI
     const supabaseClient = createBrowserClient(supabaseUrl, supabaseKey)
 
     Promise.all([
-      fetchRestaurantId(supabaseUrl, supabaseKey),
-      fetchAdminUsers(supabaseUrl, supabaseKey),
+      fetchRestaurantId(supabaseUrl, supabaseKey, accessToken),
+      fetchAdminUsers(supabaseUrl, supabaseKey, accessToken),
       getUserRole(supabaseClient),
     ])
       .then(([restaurantId, data, role]) => {
@@ -117,7 +119,7 @@ export default function UserManager(): JSX.Element {
       .finally(() => {
         setLoading(false)
       })
-  }, [])
+  }, [accessToken])
 
   useEffect(() => {
     return () => {

--- a/apps/web/app/admin/users/userAdminData.ts
+++ b/apps/web/app/admin/users/userAdminData.ts
@@ -20,8 +20,8 @@ interface RestaurantRow {
   id: string
 }
 
-export async function fetchRestaurantId(supabaseUrl: string, apiKey: string): Promise<string> {
-  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+export async function fetchRestaurantId(supabaseUrl: string, apiKey: string, token?: string): Promise<string> {
+  const headers = { apikey: apiKey, Authorization: `Bearer ${token ?? apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/restaurants`)
   url.searchParams.set('select', 'id')
   url.searchParams.set('limit', '1')
@@ -38,8 +38,9 @@ export async function fetchRestaurantId(supabaseUrl: string, apiKey: string): Pr
 export async function fetchAdminUsers(
   supabaseUrl: string,
   apiKey: string,
+  token?: string,
 ): Promise<AdminUser[]> {
-  const headers = { apikey: apiKey, Authorization: `Bearer ${apiKey}` }
+  const headers = { apikey: apiKey, Authorization: `Bearer ${token ?? apiKey}` }
   const url = new URL(`${supabaseUrl}/rest/v1/users`)
   url.searchParams.set('select', 'id,email,name,role,is_active,created_at')
   url.searchParams.set('order', 'created_at.asc')

--- a/supabase/migrations/20260401001000_rls_restaurant_isolation.sql
+++ b/supabase/migrations/20260401001000_rls_restaurant_isolation.sql
@@ -5,6 +5,31 @@
 --
 -- Tables NOT touched: customers, reservations (already have correct RLS)
 -- Edge functions use service_role key which BYPASSES RLS — unaffected.
+--
+-- =========================================================================
+-- ROLLBACK
+-- =========================================================================
+-- To reverse this migration, run the following steps:
+--
+-- 1. Drop every "restaurant_isolation*" / "read_own_row" / "read_same_restaurant"
+--    / "update_own_row" / "authenticated_read" policy created below, e.g.:
+--      DROP POLICY IF EXISTS "restaurant_isolation" ON public.tables;
+--      DROP POLICY IF EXISTS "restaurant_isolation_select" ON public.audit_log;
+--      DROP POLICY IF EXISTS "restaurant_isolation_insert" ON public.audit_log;
+--      ... (repeat for every table listed in this migration)
+--
+-- 2. Re-create the original permissive policies that existed before, e.g.:
+--      CREATE POLICY "allow_all_authenticated" ON public.tables FOR ALL
+--        USING (auth.role() = 'authenticated')
+--        WITH CHECK (auth.role() = 'authenticated');
+--      ... (repeat for every table)
+--
+-- 3. Restore PUBLIC EXECUTE on the helper function:
+--      GRANT EXECUTE ON FUNCTION public.get_user_restaurant_id() TO PUBLIC;
+--
+-- 4. Optionally drop the helper function:
+--      DROP FUNCTION IF EXISTS public.get_user_restaurant_id();
+-- =========================================================================
 
 BEGIN;
 
@@ -20,6 +45,10 @@ SET search_path = public
 AS $$
   SELECT restaurant_id FROM public.users WHERE id = auth.uid()
 $$;
+
+-- Restrict EXECUTE to authenticated users only (anon should never call this)
+REVOKE EXECUTE ON FUNCTION public.get_user_restaurant_id() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_user_restaurant_id() TO authenticated;
 
 -- =============================================================================
 -- Step 2: Tables with DIRECT restaurant_id column
@@ -149,13 +178,17 @@ CREATE POLICY "restaurant_isolation" ON public.kds_settings
   USING (restaurant_id = public.get_user_restaurant_id())
   WITH CHECK (restaurant_id = public.get_user_restaurant_id());
 
--- ── audit_log ──
+-- ── audit_log (append-only: SELECT + INSERT, no UPDATE/DELETE) ──
 DROP POLICY IF EXISTS "allow_insert_authenticated" ON public.audit_log;
 DROP POLICY IF EXISTS "allow_select_authenticated" ON public.audit_log;
+DROP POLICY IF EXISTS "restaurant_isolation" ON public.audit_log;
 
-CREATE POLICY "restaurant_isolation" ON public.audit_log
-  FOR ALL
-  USING (restaurant_id = public.get_user_restaurant_id())
+CREATE POLICY "restaurant_isolation_select" ON public.audit_log
+  FOR SELECT
+  USING (restaurant_id = public.get_user_restaurant_id());
+
+CREATE POLICY "restaurant_isolation_insert" ON public.audit_log
+  FOR INSERT
   WITH CHECK (restaurant_id = public.get_user_restaurant_id());
 
 -- =============================================================================
@@ -261,7 +294,7 @@ CREATE POLICY "restaurant_isolation" ON public.restaurants
   WITH CHECK (id = public.get_user_restaurant_id());
 
 -- =============================================================================
--- Step 7: Roles table — read-only for authenticated users
+-- Step 6: Roles table — read-only for authenticated users
 -- =============================================================================
 DROP POLICY IF EXISTS "allow_all_authenticated" ON public.roles;
 


### PR DESCRIPTION
## 🔒 Critical Security Fix — Restaurant Data Isolation

**Closes #314**

### Problem
ALL core RLS policies had `qual = true`, meaning **every authenticated user could read/write ALL data from ALL restaurants**. Only `customers` and `reservations` had correct restaurant-scoped policies.

### Solution
This migration replaces all blanket `true` policies with restaurant-scoped RLS:

1. **Helper function** `get_user_restaurant_id()` — `SECURITY DEFINER` function that returns the current user's restaurant_id from the users table

2. **Direct restaurant_id tables** (`tables`, `menus`, `orders`, `config`, `vat_rates`, `bill_sequences`, `shifts`, `api_keys`, `printers`, `printer_configs`, `ingredients`, `stock_adjustments`, `kds_settings`, `audit_log`):
   - `restaurant_id = get_user_restaurant_id()`

3. **Indirect restaurant_id tables** (`menu_items`, `order_items`, `modifiers`, `payments`, `recipe_items`):
   - Join through parent table to verify restaurant ownership

4. **Users table**:
   - SELECT own row (`id = auth.uid()`)
   - SELECT same-restaurant users (for staff lists)
   - UPDATE own row only

5. **Restaurants table**: can only see own restaurant

6. **Roles table**: read-only for all authenticated users (reference/lookup table)

### Not touched
- `customers` and `reservations` — already had correct restaurant-scoped policies
- Edge functions — use `service_role` key which bypasses RLS

### Migration
`supabase/migrations/20260401001000_rls_restaurant_isolation.sql`

⚠️ **Already applied to production DB** — this was urgent.