### PR TITLE
hotfix(#314): tables page uses accessToken for RLS compat

### DIFF
--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -58,7 +58,7 @@ export default function TablesPage(): JSX.Element {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
 
-    if (!supabaseUrl || !supabaseKey) {
+    if (!supabaseUrl || !supabaseKey || !accessToken) {
       setError('Supabase is not configured')
       setLoading(false)
       return
@@ -67,8 +67,8 @@ export default function TablesPage(): JSX.Element {
     setError(null)
 
     Promise.all([
-      fetchTables(supabaseUrl, supabaseKey),
-      fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey),
+      fetchTables(supabaseUrl, supabaseKey, accessToken),
+      fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey, accessToken),
     ])
       .then(([t, q]) => {
         setTablesCache(t, q)
@@ -99,11 +99,11 @@ export default function TablesPage(): JSX.Element {
     intervalRef.current = setInterval(() => {
       const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
       const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY
-      if (!supabaseUrl || !supabaseKey) return
+      if (!supabaseUrl || !supabaseKey || !accessToken) return
 
       Promise.all([
-        fetchTables(supabaseUrl, supabaseKey),
-        fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey),
+        fetchTables(supabaseUrl, supabaseKey, accessToken),
+        fetchTakeawayDeliveryQueue(supabaseUrl, supabaseKey, accessToken),
       ])
         .then(([t, q]) => {
           setTablesCache(t, q)

--- a/apps/web/app/tables/tablesData.ts
+++ b/apps/web/app/tables/tablesData.ts
@@ -47,10 +47,11 @@ interface TakeawayDeliveryApiRow {
 export async function fetchTables(
   supabaseUrl: string,
   apiKey: string,
+  token?: string,
 ): Promise<TableRow[]> {
   const headers = {
     apikey: apiKey,
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${token ?? apiKey}`,
   }
 
   const tablesUrl = new URL(`${supabaseUrl}/rest/v1/tables`)
@@ -127,10 +128,11 @@ export async function fetchTables(
 export async function fetchTakeawayDeliveryQueue(
   supabaseUrl: string,
   apiKey: string,
+  token?: string,
 ): Promise<TakeawayDeliveryOrder[]> {
   const headers = {
     apikey: apiKey,
-    Authorization: `Bearer ${apiKey}`,
+    Authorization: `Bearer ${token ?? apiKey}`,
   }
 
   const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)


### PR DESCRIPTION
## Problem
After the RLS migration (#323), the tables page still used the publishable key for REST API calls. Since RLS policies now require `auth.uid()`, queries returned empty results — no tables visible.

## Fix
- `fetchTables` and `fetchTakeawayDeliveryQueue` now accept optional `token` param
- `page.tsx` passes `accessToken` from `useUser()`
- Polling interval also uses `accessToken`

**Note:** There are more files with the same issue (`orderData.ts`, `OrderDetailClient.tsx`, `menuData.ts`, etc.) — this PR fixes the most critical one (tables page). A follow-up PR will fix the remaining files.