### PR TITLE
fix: add missing migration 20260401003000_drop_tables_assigned_server_id

### DIFF
--- a/supabase/migrations/20260401003000_drop_tables_assigned_server_id.sql
+++ b/supabase/migrations/20260401003000_drop_tables_assigned_server_id.sql
@@ -1,4 +1,6 @@
 -- Drop unused tables.assigned_server_id column
 -- Server assignment is tracked on sections (sections.assigned_server_id), not on individual tables.
 -- This column was added in 20260401002000 but is not referenced by any code.
+-- Rollback: ALTER TABLE public.tables ADD COLUMN assigned_server_id UUID REFERENCES public.users(id) ON DELETE SET NULL;
+--   (note: any data in this column prior to drop cannot be recovered)
 ALTER TABLE public.tables DROP COLUMN IF EXISTS assigned_server_id;


### PR DESCRIPTION
Migration `20260401003000_drop_tables_assigned_server_id` was applied to the remote DB but the file wasn't committed to the repo. This caused the Deploy Migrations CI step to fail on main.

This PR adds the missing migration file to restore CI.