### PR TITLE
fix: AvailabilityPanel crash — useMemo called after conditional return

### DIFF
--- a/apps/web/app/admin/inventory/AvailabilityPanel.tsx
+++ b/apps/web/app/admin/inventory/AvailabilityPanel.tsx
@@ -114,6 +114,24 @@ export default function AvailabilityPanel(): JSX.Element {
     }
   }
 
+  // useMemo must be called before any early returns (Rules of Hooks)
+  const filteredCategories = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return categories
+    return categories
+      .map((cat) => ({
+        ...cat,
+        items: cat.items.filter((item) => item.name.toLowerCase().includes(q)),
+      }))
+      .filter((cat) => cat.items.length > 0)
+  }, [categories, searchQuery])
+
+  const totalItems = categories.reduce((sum, cat) => sum + cat.items.length, 0)
+  const eightySixCount = categories.reduce(
+    (sum, cat) => sum + cat.items.filter((i) => !i.available).length,
+    0,
+  )
+
   if (loading) {
     return (
       <div className="flex flex-col gap-6">
@@ -129,24 +147,6 @@ export default function AvailabilityPanel(): JSX.Element {
       </div>
     )
   }
-
-  const totalItems = categories.reduce((sum, cat) => sum + cat.items.length, 0)
-  const eightySixCount = categories.reduce(
-    (sum, cat) => sum + cat.items.filter((i) => !i.available).length,
-    0,
-  )
-
-  // Filter categories/items by search query
-  const filteredCategories = useMemo(() => {
-    const q = searchQuery.trim().toLowerCase()
-    if (!q) return categories
-    return categories
-      .map((cat) => ({
-        ...cat,
-        items: cat.items.filter((item) => item.name.toLowerCase().includes(q)),
-      }))
-      .filter((cat) => cat.items.length > 0)
-  }, [categories, searchQuery])
 
   return (
     <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Bug

Navigating to Admin → Inventory → 86 / Availability crashes with a client-side exception.

## Root cause

`useMemo` was called **after** two early returns (`if (loading)` and `if (fetchError)`):

```
if (loading) return <Loading />      // ← hook count stops here on first render
if (fetchError) return <Error />
const filteredCategories = useMemo(...)  // ← hook not called on first render
```

This violates the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks). On first render React sees N hooks; on the next render (after data loads) it sees N+1 hooks and throws:

> Rendered more hooks than during the previous render

## Fix

Moved `useMemo` (and the derived `totalItems`/`eightySixCount` values) **before** the conditional early returns. Hook call order is now consistent across all renders.

## Impact

- Fixes the crash on the 86 / Availability tab
- No logic or UI changes — purely hook ordering fix

Closes #