### PR TITLE
fix(#315): KOT printing blank/empty pages

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -509,6 +509,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       setKotTimestamp(ts)
       setKotPrintError(null)
 
+      // Set kotStatus before printing so the wrapper div receives the `print-area`
+      // class — without it, global print CSS hides everything and KOT prints blank.
+      setKotStatus('Sending to kitchen…')
+
       // Group unsent items by their printer type (kitchen vs bar)
       const itemsByPrinterType = new Map<'kitchen' | 'bar', typeof unsentItems>()
       for (const item of unsentItems) {
@@ -534,9 +538,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           timestamp: ts,
           printerProfile: profile,
           printerConfig: legacyConfig,
-          onBeforeBrowserPrint: () => {
-            // KotPrintView is already rendered — nothing extra needed
-          },
+          onBeforeBrowserPrint: () =>
+            // Give React a tick to flush the kotStatus state update so the
+            // print-area class is applied to the wrapper before window.print()
+            new Promise<void>((resolve) => setTimeout(resolve, 50)),
         })
 
         printResults.push(result)
@@ -579,7 +584,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         })
       } else {
         // TCP/IP (network) print path: await DB confirmation before navigating.
-        setKotStatus('Sending to kitchen…')
+        // kotStatus is already set to 'Sending to kitchen…' above.
         try {
           await markItemsSentToKitchen(supabaseUrl, accessToken, orderId, unsentItems.map((i) => i.id))
         } catch {
@@ -621,9 +626,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         orderId,
         timestamp: ts,
         printerConfig,
-        onBeforeBrowserPrint: () => {
-          // KotPrintView showAll is already set above
-        },
+        onBeforeBrowserPrint: () =>
+          // Give React a tick to flush reprintingKot state so print-area
+          // class is applied to the wrapper before window.print()
+          new Promise<void>((resolve) => setTimeout(resolve, 50)),
         onAfterBrowserPrint: () => {
           setKotShowAll(false)
           setReprintingKot(false)
@@ -704,7 +710,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           timestamp: ts,
           printerProfile: profile,
           printerConfig: legacyConfig,
-          onBeforeBrowserPrint: () => { /* KotPrintView already rendered with courseFilter */ },
+          onBeforeBrowserPrint: () =>
+            // Give React a tick to flush firingCourse state so print-area
+            // class is applied to the wrapper before window.print()
+            new Promise<void>((resolve) => setTimeout(resolve, 50)),
         })
 
         if (result.errorMessage) {


### PR DESCRIPTION
## Problem

KOT (kitchen order ticket) prints blank/empty pages when "Send to Kitchen" is triggered. Items, table number, and timestamp should appear on the ticket.

## Root Cause

Two related bugs:

### 1. `kotStatus` not set before browser print (primary bug)

`globals.css` hides **everything** during print except `.print-area` elements:
```css
body * { visibility: hidden; }
.print-area, .print-area * { visibility: visible; }
```

The `KotPrintView` wrapper only gets the `print-area` class when `kotStatus !== null || reprintingKot || firingCourse !== null`.

In `handleBackToTables()` (the main "Send to Kitchen" flow), `setKotStatus('Sending to kitchen…')` was placed **inside the TCP/IP branch only**, and only **after** printing. For the browser print path, `kotStatus` remained `null` throughout — so the wrapper never received `print-area`, `KotPrintView` was invisible during print, and the page came out blank.

### 2. React state flush timing (secondary bug affecting all KOT print paths)

Even where state flags were set before `printKot()` (e.g. `setReprintingKot(true)`, `setFiringCourse(course)`), the `onBeforeBrowserPrint` callback was a no-op. React 18 batches state updates asynchronously — the DOM may not have been updated with the `print-area` class before `window.print()` was called, causing the same blank print under certain timing conditions.

## Fix

- **Move `setKotStatus('Sending to kitchen…')` to before the print loop** in `handleBackToTables()` — wrapper gets `print-area` in both browser and TCP/IP paths
- **Remove the duplicate `setKotStatus()`** in the TCP/IP branch (it's now set above)
- **Add a 50ms `onBeforeBrowserPrint` delay** in `handleBackToTables()`, `handleReprintKot()`, and `handleFireCourse()` to give React time to flush the state update and apply `print-area` to the DOM before `window.print()` fires

## Affected paths

| Path | Before | After |
|------|--------|-------|
| Send to Kitchen (browser) | blank — kotStatus never set | fixed |
| Send to Kitchen (TCP/IP) | worked (status set before DB wait) | still works |
| Reprint KOT (browser) | timing race | 50ms flush guard |
| Fire Course (browser) | timing race | 50ms flush guard |

Closes #315