### PR TITLE
fix(#315): add onBeforeBrowserPrint delay to multi-printer reprint fallback

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -658,6 +658,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         timestamp: ts,
         printerProfile: profile,
         printerConfig: legacyConfig,
+        onBeforeBrowserPrint: () =>
+          // Give React a tick to flush reprintingKot state so print-area
+          // class is applied to the wrapper before window.print() fires
+          // (handles TCP/IP fallback-to-browser case)
+          new Promise<void>((resolve) => setTimeout(resolve, 50)),
       })
 
       if (result.errorMessage) {


### PR DESCRIPTION
## Follow-up to #338

Claude's review of #338 identified one remaining gap: the multi-printer reprint loop in `handleReprintKot` was missing the 50ms `onBeforeBrowserPrint` delay added to all other KOT print paths.

## The gap

If a TCP/IP printer is configured but unreachable, `printKot` falls back to `window.print()`. Since `setReprintingKot(true)` is called before the loop, `print-area` IS scheduled — but React may not have committed the DOM update before `window.print()` fires.

This is low-risk in practice (requires a network printer to be both configured and fail), but it's inconsistent with all other KOT print paths and was flagged in both Claude reviews of #338.

## Fix

Add the same `onBeforeBrowserPrint: () => new Promise(resolve => setTimeout(resolve, 50))` guard to the multi-printer reprint loop in `handleReprintKot`, bringing all 4 browser print paths into consistency:

| Path | 50ms guard |
|------|-----------|
| `handleBackToTables` main loop | ✅ (#338) |
| `handleReprintKot` single-printer | ✅ (#338) |
| `handleFireCourse` loop | ✅ (#338) |
| `handleReprintKot` multi-printer loop | ✅ (this PR) |

Closes #315 (follow-up)