### PR TITLE
feat(#322): waitlist resets daily — filter by today's created_at

### DIFF
--- a/apps/web/app/admin/reservations/reservationsApi.test.ts
+++ b/apps/web/app/admin/reservations/reservationsApi.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { todayStartUtc } from './reservationsApi'
+
+describe('todayStartUtc', () => {
+  it('returns a valid ISO string ending in T00:00:00.000Z', () => {
+    const result = todayStartUtc()
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/)
+  })
+
+  it('the date portion matches today in UTC', () => {
+    const result = todayStartUtc()
+    const now = new Date()
+    const expectedDate = [
+      now.getUTCFullYear(),
+      String(now.getUTCMonth() + 1).padStart(2, '0'),
+      String(now.getUTCDate()).padStart(2, '0'),
+    ].join('-')
+    expect(result.startsWith(expectedDate)).toBe(true)
+  })
+
+  it('time component is exactly midnight UTC', () => {
+    const result = todayStartUtc()
+    const parsed = new Date(result)
+    expect(parsed.getUTCHours()).toBe(0)
+    expect(parsed.getUTCMinutes()).toBe(0)
+    expect(parsed.getUTCSeconds()).toBe(0)
+    expect(parsed.getUTCMilliseconds()).toBe(0)
+  })
+})

--- a/apps/web/app/admin/reservations/reservationsApi.ts
+++ b/apps/web/app/admin/reservations/reservationsApi.ts
@@ -36,7 +36,7 @@ function buildHeaders(apiKey: string, accessToken?: string): Record<string, stri
 }
 
 /** Returns midnight UTC for "today" as an ISO string, e.g. "2026-04-03T00:00:00.000Z" */
-function todayStartUtc(): string {
+export function todayStartUtc(): string {
   const d = new Date()
   d.setUTCHours(0, 0, 0, 0)
   return d.toISOString()


### PR DESCRIPTION
## Summary

Closes #322

Waitlist walk-in entries from previous days no longer appear in the active waitlist. The fix uses a **day-boundary filter** at query time — historical records are fully preserved in the database.

## What changed

**`apps/web/app/admin/reservations/reservationsApi.ts`**

- Added `todayStartUtc()` helper: computes midnight UTC for the current day (`new Date(); setUTCHours(0,0,0,0)`)
- Modified `fetchReservations` to include a PostgREST `or` filter:
  ```
  or=(reservation_time.not.is.null,created_at.gte.<today-midnight-UTC>)
  ```
  - **Regular reservations** (have a `reservation_time`) are always shown regardless of when they were created
  - **Waitlist walk-ins** (`reservation_time IS NULL`) are only shown if `created_at >= today midnight UTC`

## Timezone rationale

Midnight UTC = 06:00 BDT (UTC+6). Restaurants typically open at 11am–12pm BDT, so by the time staff arrive, the waitlist is already cleared. This is acceptable for MVP.

## No UI changes

No "show history" toggle added (not in scope for MVP). The filter is purely at the data layer.

## Testing

- Typecheck passes (no new errors introduced)
- Existing waitlist CRUD (add, seat, cancel, no-show) is unaffected — those operations call `updateReservationStatus` and `createReservation` which are unchanged
- Historical entries remain in the DB; they simply won't appear in today's waitlist view