### PR TITLE
fix: reservations bugs — migration return type + fetchTables auth

### DIFF
--- a/apps/web/app/admin/reservations/ReservationsDashboard.tsx
+++ b/apps/web/app/admin/reservations/ReservationsDashboard.tsx
@@ -464,8 +464,8 @@ export default function ReservationsDashboard(): JSX.Element {
     setLoading(true)
     setError(null)
     Promise.all([
-      fetchReservations(supabaseUrl, accessToken, restaurantId, accessToken ?? undefined),
-      fetchTables(supabaseUrl, accessToken, restaurantId),
+      fetchReservations(supabaseUrl, publishableKey, restaurantId, accessToken),
+      fetchTables(supabaseUrl, publishableKey, restaurantId, accessToken),
     ])
       .then(([res, tbl]) => {
         setReservations(res)
@@ -490,7 +490,7 @@ export default function ReservationsDashboard(): JSX.Element {
 
   async function handleAdd(input: CreateReservationInput): Promise<void> {
     if (!accessToken) throw new Error('Not authenticated')
-    const created = await createReservation(supabaseUrl, accessToken, accessToken, input)
+    const created = await createReservation(supabaseUrl, publishableKey, accessToken, input)
     setReservations((prev) => [created, ...prev].sort((a, b) => {
       if (a.reservation_time && b.reservation_time) {
         return new Date(a.reservation_time).getTime() - new Date(b.reservation_time).getTime()
@@ -507,7 +507,7 @@ export default function ReservationsDashboard(): JSX.Element {
     if (!accessToken) return
     setBusyIds((prev) => new Set(prev).add(id))
     try {
-      await updateReservationStatus(supabaseUrl, accessToken, accessToken, id, status, tableId)
+      await updateReservationStatus(supabaseUrl, publishableKey, accessToken, id, status, tableId)
       setReservations((prev) =>
         prev.map((r) =>
           r.id === id
@@ -748,7 +748,7 @@ export default function ReservationsDashboard(): JSX.Element {
             if (!tableIdToUse) throw new Error('A table must be selected to seat the reservation')
             const orderId = await seatReservation(
               supabaseUrl,
-              accessToken,
+              publishableKey,
               accessToken,
               reservation,
               tableIdToUse,

--- a/apps/web/app/admin/reservations/reservationsApi.ts
+++ b/apps/web/app/admin/reservations/reservationsApi.ts
@@ -122,13 +122,14 @@ export async function fetchTables(
   supabaseUrl: string,
   apiKey: string,
   restaurantId: string,
+  accessToken?: string,
 ): Promise<ReservationTable[]> {
   const url = new URL(`${supabaseUrl}/rest/v1/tables`)
   url.searchParams.set('restaurant_id', `eq.${restaurantId}`)
   url.searchParams.set('select', 'id,label,seat_count')
   url.searchParams.set('order', 'label.asc')
   const res = await fetch(url.toString(), {
-    headers: buildHeaders(apiKey),
+    headers: buildHeaders(apiKey, accessToken),
   })
   if (!res.ok) throw new Error('Failed to fetch tables')
   return res.json() as Promise<ReservationTable[]>

--- a/supabase/migrations/20260403100000_orders_customer_id.sql
+++ b/supabase/migrations/20260403100000_orders_customer_id.sql
@@ -3,7 +3,19 @@
 -- Rollback:
 --   DROP INDEX IF EXISTS idx_orders_customer_id;
 --   ALTER TABLE orders DROP COLUMN IF EXISTS customer_id;
---   Restore upsert_customer_visit to RETURNS VOID.
+--   DROP FUNCTION IF EXISTS upsert_customer_visit(UUID, TEXT, TEXT, BIGINT);
+--   CREATE FUNCTION upsert_customer_visit(
+--     p_restaurant_id UUID, p_mobile TEXT, p_name TEXT DEFAULT NULL, p_spend_cents BIGINT DEFAULT 0
+--   ) RETURNS VOID LANGUAGE plpgsql SECURITY DEFINER AS $$
+--   BEGIN
+--     INSERT INTO customers (restaurant_id, mobile, name, visit_count, total_spend_cents, last_visit_at)
+--     VALUES (p_restaurant_id, p_mobile, p_name, 1, p_spend_cents, now())
+--     ON CONFLICT (restaurant_id, mobile) DO UPDATE
+--       SET visit_count       = customers.visit_count + 1,
+--           total_spend_cents = customers.total_spend_cents + EXCLUDED.total_spend_cents,
+--           last_visit_at     = now(),
+--           name              = COALESCE(EXCLUDED.name, customers.name);
+--   END; $$;
 
 -- Part 1: Add customer_id FK to orders
 ALTER TABLE orders
@@ -13,7 +25,10 @@ CREATE INDEX IF NOT EXISTS idx_orders_customer_id ON orders(customer_id);
 
 -- Part 2: Replace upsert_customer_visit to return the customer's UUID
 -- (so close_order can immediately PATCH orders.customer_id)
-CREATE OR REPLACE FUNCTION upsert_customer_visit(
+-- Must DROP first — PostgreSQL won't allow changing return type via CREATE OR REPLACE
+DROP FUNCTION IF EXISTS upsert_customer_visit(UUID, TEXT, TEXT, BIGINT);
+
+CREATE FUNCTION upsert_customer_visit(
   p_restaurant_id UUID,
   p_mobile TEXT,
   p_name TEXT DEFAULT NULL,


### PR DESCRIPTION
## Summary

Fixes two production bugs in the reservations feature:

### Bug 1 — DB migration failing: cannot change return type of existing function

**File:** `supabase/migrations/20260403100000_orders_customer_id.sql`

PostgreSQL does not allow `CREATE OR REPLACE FUNCTION` to change the return type of an existing function. `upsert_customer_visit` existed as `RETURNS VOID` and the migration tried to change it to `RETURNS UUID` via `CREATE OR REPLACE`, which PostgreSQL rejects with:
> ERROR: cannot change return type of existing function (SQLSTATE 42P13)

**Fix:** Replaced `CREATE OR REPLACE FUNCTION` with `DROP FUNCTION IF EXISTS` + `CREATE FUNCTION`. Also updated the rollback comment to include the full `DROP + CREATE VOID` revert steps.

### Bug 2 — "Failed to fetch tables" on reservations page

**Files:** `apps/web/app/admin/reservations/reservationsApi.ts`, `ReservationsDashboard.tsx`

`fetchTables` was missing the `accessToken` parameter, so when the dashboard called `fetchTables(supabaseUrl, accessToken, restaurantId)`, the JWT was being sent as the `apikey` header instead of the publishable key. With RLS active on the `tables` table, this caused all table fetches to fail.

**Fix:**
- Added `accessToken?: string` to `fetchTables` signature and passed it to `buildHeaders`
- Fixed all API calls in `ReservationsDashboard.tsx` (`fetchReservations`, `fetchTables`, `createReservation`, `updateReservationStatus`, `seatReservation`) to pass `publishableKey` as `apiKey` and `accessToken` as the JWT

## Testing
- TypeScript: `npx tsc --noEmit` — no new errors introduced (pre-existing test file errors unrelated to this PR)
- Manual: fixes confirmed against the described failure modes