### PR TITLE
fix: 86/Availability shows empty — wrong auth token passed to fetchMenuAvailability

### DIFF
--- a/apps/web/app/admin/inventory/AvailabilityPanel.tsx
+++ b/apps/web/app/admin/inventory/AvailabilityPanel.tsx
@@ -27,7 +27,6 @@ export default function AvailabilityPanel(): JSX.Element {
   const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
-  const apiKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
 
   function showFeedback(type: FeedbackType, message: string): void {
     if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
@@ -36,8 +35,8 @@ export default function AvailabilityPanel(): JSX.Element {
   }
 
   useEffect(() => {
-    if (!supabaseUrl || !apiKey) {
-      setFetchError('API not configured')
+    if (!supabaseUrl || !accessToken) {
+      setFetchError(!supabaseUrl ? 'API not configured' : 'Not authenticated')
       setLoading(false)
       return
     }
@@ -49,7 +48,7 @@ export default function AvailabilityPanel(): JSX.Element {
       return
     }
     setLoading(true)
-    fetchMenuAvailability(supabaseUrl, apiKey, restaurantId)
+    fetchMenuAvailability(supabaseUrl, accessToken, restaurantId)
       .then((cats) => setCategories(cats))
       .catch((err: unknown) => {
         setFetchError(err instanceof Error ? err.message : 'Failed to load availability data')
@@ -59,7 +58,7 @@ export default function AvailabilityPanel(): JSX.Element {
     return () => {
       if (feedbackTimerRef.current) clearTimeout(feedbackTimerRef.current)
     }
-  }, [supabaseUrl, apiKey, restaurantId, restaurantLoading])
+  }, [supabaseUrl, accessToken, restaurantId, restaurantLoading])
 
   async function handleToggle(categoryId: string, itemId: string, newAvailable: boolean): Promise<void> {
     if (!accessToken) {


### PR DESCRIPTION
## Problem

Admin → Inventory → 86 / Availability showed "No menu categories found" for all users.

## Root cause

`AvailabilityPanel.tsx` was calling:
```ts
fetchMenuAvailability(supabaseUrl, apiKey, restaurantId)
```

The second parameter is `accessToken` (used as `Authorization: Bearer <value>`), but `apiKey` (the Supabase publishable key) was passed instead of the user JWT.

With RLS policies requiring `get_user_restaurant_id()`, a request bearing only the publishable key has no user context → query returns empty → "No menu categories found.".

## Fix

- Pass `accessToken` (user JWT from `useUser()`) instead of `apiKey` to `fetchMenuAvailability`
- Remove now-unused `apiKey` variable from the component
- Update the early guard and `useEffect` dependency array accordingly (`accessToken` replaces `apiKey`)

`availabilityApi.ts` was already correct — it reads `publishableKey` from `process.env` at module level for the `apikey` header; no changes needed there.

## Changes

- `apps/web/app/admin/inventory/AvailabilityPanel.tsx` — one-line call fix + cleanup