### PR TITLE
fix(#389): fix + button qty increase and improve qty display

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -69,6 +69,10 @@ vi.mock('./orderItemNotesApi', () => ({
   updateOrderItemNotes: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock('./updateQuantityApi', () => ({
+  updateOrderItemQuantity: vi.fn().mockResolvedValue(undefined),
+}))
+
 vi.mock('@/lib/fetchVatConfig', () => ({
   fetchOrderVatContext: vi.fn().mockResolvedValue({ restaurantId: 'rest-1', menuId: null }),
   fetchVatConfig: vi.fn().mockResolvedValue({ vatPercent: 15, taxInclusive: false }),
@@ -115,9 +119,12 @@ describe('OrderDetailClient', () => {
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 
     await screen.findByText('Bruschetta')
-    const spans = screen.getAllByText(/^×\d+$/)
-    expect(spans.length).toBeGreaterThanOrEqual(2)
-    expect(screen.getByText('×1')).toBeInTheDocument()
+    // qty > 1 items show ×N badge (amber highlight, issue #389)
+    const qtyBadges = screen.getAllByText(/^×\d+$/)
+    expect(qtyBadges.length).toBeGreaterThanOrEqual(2) // ×2 for Bruschetta and House Wine
+    // qty = 1 item shows plain number (no × prefix)
+    const qtyOne = screen.getByRole('button', { name: 'Quantity 1, tap to edit' })
+    expect(qtyOne).toHaveTextContent('1')
   })
 
   it('renders per-item prices', async (): Promise<void> => {
@@ -1442,6 +1449,111 @@ describe('OrderDetailClient', () => {
       await waitFor((): void => {
         expect(mockPush).toHaveBeenCalledWith('/tables')
       })
+    })
+  })
+
+  describe('handleQtyButton — + and − quantity controls (issue #389)', () => {
+    beforeEach(async (): Promise<void> => {
+      // Provide a real access token so handleQtyButton doesn't early-return on !accessToken
+      const { useUser } = await import('@/lib/user-context')
+      vi.mocked(useUser).mockReturnValue({
+        accessToken: 'test-token', isAdmin: false, role: 'server', loading: false,
+      })
+    })
+
+    it('tapping + immediately shows incremented quantity (optimistic update)', async (): Promise<void> => {
+      render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+      await screen.findByText('Grilled Salmon') // wait for items to load; Grilled Salmon has qty=1
+
+      // Grilled Salmon is the second item; click its + button
+      const plusButtons = screen.getAllByRole('button', { name: 'Increase quantity' })
+      fireEvent.click(plusButtons[1]) // index 1 = Grilled Salmon
+
+      // Optimistic update: qty=1 → qty=2; badge now shows ×2 (amber, issue #389)
+      await waitFor((): void => {
+        expect(screen.getAllByRole('button', { name: 'Quantity 2, tap to edit' }).length).toBeGreaterThanOrEqual(1)
+      })
+    })
+
+    it('coalesces rapid + taps into a single API call after the debounce delay', async (): Promise<void> => {
+      const { updateOrderItemQuantity } = await import('./updateQuantityApi')
+
+      render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+      await screen.findByText('Bruschetta') // Bruschetta is first item, qty=2
+
+      // Tap Bruschetta's + button three times quickly
+      const plusButtons = screen.getAllByRole('button', { name: 'Increase quantity' })
+      fireEvent.click(plusButtons[0])
+      fireEvent.click(plusButtons[0])
+      fireEvent.click(plusButtons[0])
+
+      // No API call yet — still within debounce window
+      expect(updateOrderItemQuantity).not.toHaveBeenCalled()
+
+      // Advance past the 400 ms debounce window
+      await act(async (): Promise<void> => {
+        vi.advanceTimersByTime(500)
+      })
+
+      // Exactly one API call with the final coalesced qty (2 + 3 taps = 5)
+      expect(updateOrderItemQuantity).toHaveBeenCalledTimes(1)
+      expect(updateOrderItemQuantity).toHaveBeenCalledWith(
+        'https://example.supabase.co',
+        'test-token',
+        '1', // Bruschetta id
+        5,   // started at qty=2, tapped + 3 times → 5
+      )
+    })
+
+    it('rolls back to original quantity when the API call fails', async (): Promise<void> => {
+      const { updateOrderItemQuantity } = await import('./updateQuantityApi')
+      let rejectQty!: (err: Error) => void
+      vi.mocked(updateOrderItemQuantity).mockReturnValueOnce(
+        new Promise<void>((_, reject) => { rejectQty = reject }),
+      )
+
+      render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+      await screen.findByText('Grilled Salmon') // qty=1
+
+      // Click Grilled Salmon's + button (index 1)
+      const plusButtons = screen.getAllByRole('button', { name: 'Increase quantity' })
+      fireEvent.click(plusButtons[1])
+
+      // Advance past debounce — API call fires
+      await act(async (): Promise<void> => {
+        vi.advanceTimersByTime(500)
+      })
+
+      // Reject the API call
+      await act(async (): Promise<void> => {
+        rejectQty(new Error('Network error'))
+        await Promise.resolve()
+      })
+
+      // UI must roll back to the original qty=1 (plain number button, no × prefix)
+      await waitFor((): void => {
+        expect(screen.getByRole('button', { name: 'Quantity 1, tap to edit' })).toBeInTheDocument()
+      })
+    })
+
+    it('rapid − taps to 0 open the void dialog and roll back intermediate optimistic state', async (): Promise<void> => {
+      render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+      await screen.findByText('Bruschetta') // qty=2
+
+      // Tap Bruschetta's − twice:
+      //   Tap 1: qty=2→1 (optimistic), debounce starts, originalItems snapshot captured
+      //   Tap 2: newQty=0 → void path: cancel pending, roll back to snapshot (qty=2), open dialog
+      const minusButtons = screen.getAllByRole('button', { name: 'Decrease quantity' })
+      fireEvent.click(minusButtons[0]) // optimistic: qty 2→1
+      fireEvent.click(minusButtons[0]) // newQty=0 → void dialog + rollback
+
+      // Void dialog should be open
+      await waitFor((): void => {
+        expect(screen.getByText('Void Item')).toBeInTheDocument()
+      })
+
+      // Bruschetta qty badge should have rolled back to ×2 (not show 1 or 0)
+      expect(screen.getAllByRole('button', { name: 'Quantity 2, tap to edit' }).length).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -288,6 +288,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [qtyEditStr, setQtyEditStr] = useState('')
   // Ref-based guard: prevents duplicate commits when Enter unmounts the input and fires onBlur (stale closure problem)
   const qtyCommittingRef = useRef(false)
+  // Per-item debounce state for +/− button taps (issue #389)
+  // Stores { originalItems snapshot for rollback, pending timeout, final target qty } per item id
+  const qtyButtonDebounceRef = useRef<Map<string, { originalItems: OrderItem[]; timeout: ReturnType<typeof setTimeout>; targetQty: number }>>(new Map())
 
   // Guards to prevent duplicate print triggers from rapid double-clicks (issue #372)
   const kotSendGuardRef = useRef(false)
@@ -1796,6 +1799,62 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       .finally(() => { qtyCommittingRef.current = false })
   }
 
+  /**
+   * Handle a +/− button tap on an order item (issue #389).
+   *
+   * Unlike `commitQuantity` (which uses a shared ref guard for the inline
+   * text-input double-commit problem), this function debounces rapid button
+   * taps so that:
+   *   1. Local state updates IMMEDIATELY on every tap (good UX).
+   *   2. A single API call is made after 400 ms of no further taps.
+   *   3. On failure, state rolls back to what it was before the entire
+   *      tap sequence started.
+   */
+  function handleQtyButton(item: OrderItem, delta: number): void {
+    const pending = qtyButtonDebounceRef.current.get(item.id)
+
+    // Compute the target qty based on the currently-displayed value (pending or actual)
+    const baseQty = pending ? pending.targetQty : item.quantity
+    const newQty = baseQty + delta
+
+    // Tapping − to reach 0 → open the void dialog
+    if (newQty <= 0) {
+      if (pending) {
+        clearTimeout(pending.timeout)
+        qtyButtonDebounceRef.current.delete(item.id)
+      }
+      setVoidingItem(item)
+      setVoidReason('')
+      setVoidError(null)
+      return
+    }
+
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+    if (!supabaseUrl || !accessToken) return
+
+    // Snapshot the pre-sequence items list for rollback (only on the first tap in a sequence)
+    const originalItems = pending ? pending.originalItems : items
+
+    // Immediate optimistic update — every tap is reflected in the UI at once
+    setItems((prev) => prev.map((i) => i.id === item.id ? { ...i, quantity: newQty } : i))
+
+    // Cancel the previous debounce timer for this item
+    if (pending) clearTimeout(pending.timeout)
+
+    // Schedule a single API call after 400 ms of inactivity
+    const timeout = setTimeout(() => {
+      qtyButtonDebounceRef.current.delete(item.id)
+      updateOrderItemQuantity(supabaseUrl, accessToken, item.id, newQty)
+        .catch(() => {
+          // Roll back to the state before the entire tap sequence started
+          setItems(originalItems)
+          addToast('Failed to update quantity — please retry', 'error')
+        })
+    }, 400)
+
+    qtyButtonDebounceRef.current.set(item.id, { originalItems, timeout, targetQty: newQty })
+  }
+
   // Display label: merge_label takes precedence over raw table label (issue #274)
   const displayTableLabel = mergeLabel ?? tableLabel
 
@@ -1829,7 +1888,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <button
                 type="button"
                 aria-label="Decrease quantity"
-                onClick={() => { commitQuantity(item, item.quantity - 1) }}
+                onClick={() => { handleQtyButton(item, -1) }}
                 className="min-h-[48px] min-w-[48px] flex items-center justify-center rounded-lg bg-zinc-700 hover:bg-zinc-600 text-white text-xl font-bold transition-colors"
               >
                 −
@@ -1864,15 +1923,20 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                   type="button"
                   aria-label={`Quantity ${item.quantity}, tap to edit`}
                   onClick={() => { setQtyEditingId(item.id); setQtyEditStr(String(item.quantity)) }}
-                  className="w-14 text-center text-white font-bold text-base min-h-[48px] rounded-lg bg-zinc-700 hover:bg-zinc-600 transition-colors border-2 border-transparent hover:border-amber-400/50"
+                  className={[
+                    'w-14 text-center font-bold text-base min-h-[48px] rounded-lg transition-colors border-2',
+                    item.quantity > 1
+                      ? 'bg-amber-500/20 border-amber-400 text-amber-300'
+                      : 'bg-zinc-700 hover:bg-zinc-600 text-white border-transparent hover:border-amber-400/50',
+                  ].join(' ')}
                 >
-                  {item.quantity}
+                  {item.quantity > 1 ? `×${item.quantity}` : item.quantity}
                 </button>
               )}
               <button
                 type="button"
                 aria-label="Increase quantity"
-                onClick={() => { commitQuantity(item, item.quantity + 1) }}
+                onClick={() => { handleQtyButton(item, 1) }}
                 className="min-h-[48px] min-w-[48px] flex items-center justify-center rounded-lg bg-zinc-700 hover:bg-zinc-600 text-white text-xl font-bold transition-colors"
               >
                 +

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -585,6 +585,15 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     return () => { clearTimeout(timer) }
   }, [step, router, printingBill])
 
+  // Clean up any pending qty-button debounce timers when the component unmounts (issue #389)
+  useEffect(() => {
+    const ref = qtyButtonDebounceRef.current
+    return () => {
+      ref.forEach(({ timeout }) => { clearTimeout(timeout) })
+      ref.clear()
+    }
+  }, [])
+
   // Exclude comp'd items from the subtotal.
   // Apply per-item discounts first (issue #254), then order-level discount below.
   const rawItemsTotalCents = items
@@ -1822,6 +1831,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       if (pending) {
         clearTimeout(pending.timeout)
         qtyButtonDebounceRef.current.delete(item.id)
+        // Roll back any intermediate optimistic updates from the tap sequence
+        // so the UI shows the original qty while the void dialog is open.
+        // If the user cancels the void, they see the correct quantity.
+        setItems(pending.originalItems)
       }
       setVoidingItem(item)
       setVoidReason('')

--- a/apps/web/e2e/numeric-quantity-input.spec.ts
+++ b/apps/web/e2e/numeric-quantity-input.spec.ts
@@ -169,9 +169,6 @@ test.describe('numeric quantity input', () => {
   });
 
   test('pressing + increases quantity and calls edge function', async ({ page }) => {
-    let updateCalled = false;
-    let patchBody: unknown;
-
     await page.route('**/rest/v1/order_items**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -180,33 +177,28 @@ test.describe('numeric quantity input', () => {
       });
     });
 
-    await page.route('**/functions/v1/update_order_item_quantity**', async (route) => {
-      updateCalled = true;
-      patchBody = JSON.parse(route.request().postData() ?? '{}');
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true }),
-      });
-    });
-
     await page.goto(`/tables/${TABLE_ID}/order/${ORDER_ID}`);
     await expect(page.getByText('Chicken Biryani', { exact: true }).last()).toBeVisible();
 
     const increaseBtn = page.getByRole('button', { name: /increase quantity/i });
+
+    // Set up request listener before the click so we catch the debounced call
+    // (handleQtyButton fires the API after a 400 ms idle window — issue #389)
+    const updateRequestPromise = page.waitForRequest('**/functions/v1/update_order_item_quantity**');
     await increaseBtn.click();
 
+    // Wait for the debounce to fire and capture the outgoing request
+    const updateRequest = await updateRequestPromise;
+    const patchBody = JSON.parse(updateRequest.postData() ?? '{}') as { order_item_id: string; quantity: number };
+
     // Edge function must have been called with qty 3
-    expect(updateCalled).toBe(true);
     expect(patchBody).toMatchObject({ order_item_id: ORDER_ITEM_ID, quantity: 3 });
 
-    // Optimistic UI: quantity badge shows 3
+    // Optimistic UI: quantity badge already shows 3 (updated immediately on tap)
     await expect(page.getByRole('button', { name: /Quantity 3, tap to edit/i })).toBeVisible();
   });
 
   test('pressing − decreases quantity and calls edge function', async ({ page }) => {
-    let patchBody: unknown;
-
     await page.route('**/rest/v1/order_items**', async (route) => {
       await route.fulfill({
         status: 200,
@@ -215,20 +207,17 @@ test.describe('numeric quantity input', () => {
       });
     });
 
-    await page.route('**/functions/v1/update_order_item_quantity**', async (route) => {
-      patchBody = JSON.parse(route.request().postData() ?? '{}');
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ success: true }),
-      });
-    });
-
     await page.goto(`/tables/${TABLE_ID}/order/${ORDER_ID}`);
     await expect(page.getByText('Chicken Biryani', { exact: true }).last()).toBeVisible();
 
     const decreaseBtn = page.getByRole('button', { name: /decrease quantity/i });
+
+    // Set up request listener before the click (debounce — issue #389)
+    const updateRequestPromise = page.waitForRequest('**/functions/v1/update_order_item_quantity**');
     await decreaseBtn.click();
+
+    const updateRequest = await updateRequestPromise;
+    const patchBody = JSON.parse(updateRequest.postData() ?? '{}') as { order_item_id: string; quantity: number };
 
     expect(patchBody).toMatchObject({ order_item_id: ORDER_ITEM_ID, quantity: 2 });
     await expect(page.getByRole('button', { name: /Quantity 2, tap to edit/i })).toBeVisible();


### PR DESCRIPTION
## Summary

Fixes #389 — two bugs reported by Robiul Islam (Supervisor) and Shakil Hossain.

## Root cause

### Bug 1: + button not responding to rapid taps

The `qtyCommittingRef` guard in `commitQuantity()` was designed to prevent double-commits when the inline quantity text input fires both `onKeyDown(Enter)` and `onBlur` simultaneously (React unmount behaviour). However, the same guard was used for the + and − button clicks too.

Since the guard stays `true` for the entire duration of an async API call (~500ms on a good connection), any subsequent + taps within that window were silently dropped. Staff clicking + rapidly to add 3 or 5 portions only got the first tap registered.

### Bug 2: Quantity not visually clear when qty > 1

The quantity display was a plain unstyled number button. When an item had quantity 3 or 5, there was no visual indicator to distinguish it from qty 1 at a glance.

## Changes

**`OrderDetailClient.tsx`**

1. Added `qtyButtonDebounceRef` — a `Map` keyed by item ID that tracks per-item debounce state: the pre-sequence items snapshot (for clean rollback), the pending timeout handle, and the final target quantity.

2. Added `handleQtyButton(item, delta)` — used by + and − buttons:
   - Updates local state **immediately** on every tap (optimistic UI)
   - Debounces the API call (400 ms idle window) so rapid taps produce one network call
   - Rolls back to the original snapshot (before the tap sequence started) on API failure

3. + and − buttons now call `handleQtyButton(item, ±1)` instead of `commitQuantity`

4. The inline text input still uses `commitQuantity` with its ref guard (unchanged — still needed to prevent Enter+onBlur double-fire)

5. Quantity badge now highlighted in amber when qty > 1, with `×N` prefix (e.g. `×3`) for clear visual distinction

## Test plan

- [x] Existing `updateQuantityApi` unit tests pass
- [x] Pre-existing test failures (`orderData.test.ts`, `OrderDetailClientEmptyState.test.tsx`) are not caused by this PR