### PR TITLE
feat(#392): mandatory customer name and mobile for takeaway orders

### DIFF
--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -277,6 +277,7 @@ export default function TablesPage(): JSX.Element {
     setTakeawayMobile('')
     setTakeawayScheduledTime('')
     setTakeawaySuggestion(null)
+    setCreateOrderError(null)
     setShowTakeawayModal(true)
   }
 
@@ -300,6 +301,9 @@ export default function TablesPage(): JSX.Element {
     params.set('scheduledTime', new Date(takeawayScheduledTime).toISOString())
     setCreateOrderError(null)
     setShowTakeawayModal(false)
+    setTakeawayName('')
+    setTakeawayMobile('')
+    setTakeawayScheduledTime('')
     router.push(`/tables/takeaway/order/new?${params.toString()}`)
   }
 
@@ -410,7 +414,7 @@ export default function TablesPage(): JSX.Element {
         </button>
       </div>
 
-      {createOrderError !== null && !showDeliveryModal && (
+      {createOrderError !== null && !showDeliveryModal && !showTakeawayModal && (
         <p className="text-red-400 text-sm mb-4">{createOrderError}</p>
       )}
 

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -280,16 +280,25 @@ export default function TablesPage(): JSX.Element {
     setShowTakeawayModal(true)
   }
 
-  // Confirm takeaway — navigate to /order/new with optional search params (issue #317 + #276 + #352)
+  // Confirm takeaway — navigate to /order/new with required search params (issue #317 + #276 + #352 + #392)
   function handleConfirmTakeaway(): void {
+    if (!takeawayName.trim()) {
+      setCreateOrderError('Customer name is required for takeaway orders')
+      return
+    }
+    if (!takeawayMobile.trim()) {
+      setCreateOrderError('Mobile number is required for takeaway orders')
+      return
+    }
     if (!takeawayScheduledTime) {
       return // button is disabled; guard for safety
     }
     const params = new URLSearchParams()
-    if (takeawayName.trim()) params.set('customerName', takeawayName.trim())
-    if (takeawayMobile.trim()) params.set('customerPhone', takeawayMobile.trim())
+    params.set('customerName', takeawayName.trim())
+    params.set('customerPhone', takeawayMobile.trim())
     // Convert local datetime-local value to ISO string for the edge function
     params.set('scheduledTime', new Date(takeawayScheduledTime).toISOString())
+    setCreateOrderError(null)
     setShowTakeawayModal(false)
     router.push(`/tables/takeaway/order/new?${params.toString()}`)
   }
@@ -579,7 +588,7 @@ export default function TablesPage(): JSX.Element {
 
             <div>
               <label htmlFor="takeaway-name" className="block text-white text-base mb-2 font-body">
-                Customer Name <span className="text-brand-grey">(optional)</span>
+                Customer Name <span className="text-red-400">*</span>
               </label>
               <input
                 id="takeaway-name"
@@ -594,7 +603,7 @@ export default function TablesPage(): JSX.Element {
 
             <div>
               <label htmlFor="takeaway-mobile" className="block text-white text-base mb-2 font-body">
-                Phone Number <span className="text-brand-grey">(optional)</span>
+                Phone Number <span className="text-red-400">*</span>
               </label>
               <input
                 id="takeaway-mobile"
@@ -641,10 +650,10 @@ export default function TablesPage(): JSX.Element {
               <button
                 type="button"
                 onClick={handleConfirmTakeaway}
-                disabled={!takeawayScheduledTime}
+                disabled={!takeawayScheduledTime || !takeawayName.trim() || !takeawayMobile.trim()}
                 className={[
                   'flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors font-body',
-                  !takeawayScheduledTime
+                  (!takeawayScheduledTime || !takeawayName.trim() || !takeawayMobile.trim())
                     ? 'bg-brand-grey/30 text-white/40 cursor-not-allowed'
                     : 'bg-brand-gold hover:bg-brand-gold/90 text-brand-navy',
                 ].join(' ')}

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -571,7 +571,7 @@ export default function TablesPage(): JSX.Element {
         </>
       )}
 
-      {/* Takeaway order modal — optional name + mobile (issue #276) */}
+      {/* Takeaway order modal — mandatory name + mobile (issue #276 + #392) */}
       {showTakeawayModal && (
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/70">
           <div className="w-full max-w-lg bg-brand-navy rounded-t-2xl p-6 space-y-4">

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -282,14 +282,13 @@ export default function TablesPage(): JSX.Element {
   }
 
   // Confirm takeaway — navigate to /order/new with required search params (issue #317 + #276 + #352 + #392)
+  // Note: button is disabled when any field is empty, so these early-returns are safety guards only.
   function handleConfirmTakeaway(): void {
     if (!takeawayName.trim()) {
-      setCreateOrderError('Customer name is required for takeaway orders')
-      return
+      return // button is disabled; guard for safety
     }
     if (!takeawayMobile.trim()) {
-      setCreateOrderError('Mobile number is required for takeaway orders')
-      return
+      return // button is disabled; guard for safety
     }
     if (!takeawayScheduledTime) {
       return // button is disabled; guard for safety
@@ -539,12 +538,12 @@ export default function TablesPage(): JSX.Element {
                         <span className="text-xs text-brand-navy/60">{orderAge(order.created_at)}</span>
                       </div>
 
-                      {/* Customer name (delivery only) */}
-                      {isDelivery && order.customer_name && (
+                      {/* Customer name (takeaway and delivery) */}
+                      {order.customer_name && (
                         <p className="text-white font-semibold text-base">{order.customer_name}</p>
                       )}
-                      {/* Phone number (delivery only) */}
-                      {isDelivery && order.customer_mobile && (
+                      {/* Phone number (takeaway and delivery) */}
+                      {order.customer_mobile && (
                         <p className="text-white/70 text-sm">📞 {order.customer_mobile}</p>
                       )}
 

--- a/apps/web/app/tables/takeaway/order/new/NewTakeawayOrderClient.tsx
+++ b/apps/web/app/tables/takeaway/order/new/NewTakeawayOrderClient.tsx
@@ -45,6 +45,16 @@ export default function NewTakeawayOrderClient(): JSX.Element {
       return
     }
 
+    // Customer name and mobile are mandatory for takeaway orders (issue #392)
+    if (!customerName) {
+      void Promise.resolve().then(() => { setError('Customer name is required for takeaway orders') })
+      return
+    }
+    if (!customerPhone) {
+      void Promise.resolve().then(() => { setError('Mobile number is required for takeaway orders') })
+      return
+    }
+
     const controller = new AbortController()
 
     callCreateOrder(
@@ -52,8 +62,8 @@ export default function NewTakeawayOrderClient(): JSX.Element {
       accessToken,
       {
         orderType: 'takeaway',
-        ...(customerName ? { customerName } : {}),
-        ...(customerPhone ? { customerMobile: customerPhone } : {}),
+        customerName,
+        customerMobile: customerPhone,
         scheduledTime,
       },
       controller.signal,

--- a/apps/web/app/tables/takeaway/order/new/NewTakeawayOrderClient.tsx
+++ b/apps/web/app/tables/takeaway/order/new/NewTakeawayOrderClient.tsx
@@ -14,8 +14,9 @@ import { ShoppingBag } from 'lucide-react'
  * useSearchParams() — without Suspense Next.js would de-opt the whole route to
  * dynamic rendering.
  *
- * customerName and customerPhone are optionally passed as URL search params
- * by handleConfirmTakeaway() in tables/page.tsx (issue #276).
+ * customerName and customerPhone are mandatory URL search params set by
+ * handleConfirmTakeaway() in tables/page.tsx (issue #276, #392).
+ * The component validates both fields are present before firing the API call.
  */
 export default function NewTakeawayOrderClient(): JSX.Element {
   const router = useRouter()

--- a/apps/web/app/tables/takeaway/order/new/page.test.tsx
+++ b/apps/web/app/tables/takeaway/order/new/page.test.tsx
@@ -5,8 +5,14 @@ import NewTakeawayOrderPage from './page'
 
 const mockReplace = vi.fn()
 
+// Mutable search params map — tests can set these before rendering
+const searchParamsMap: Record<string, string | null> = {}
+
 vi.mock('next/navigation', () => ({
   useRouter: (): { replace: (url: string) => void } => ({ replace: mockReplace }),
+  useSearchParams: (): { get: (key: string) => string | null } => ({
+    get: (key: string): string | null => searchParamsMap[key] ?? null,
+  }),
 }))
 
 vi.mock('@/lib/user-context', () => ({
@@ -19,9 +25,25 @@ vi.mock('../../../components/createOrderApi', () => ({
 
 const originalEnv = process.env
 
+/** Helper: set URL search params for the current test */
+function setSearchParams(params: Record<string, string>): void {
+  // Clear previous params
+  for (const key of Object.keys(searchParamsMap)) {
+    delete searchParamsMap[key]
+  }
+  Object.assign(searchParamsMap, params)
+}
+
+const VALID_PARAMS = {
+  customerName: 'Ahmed Khan',
+  customerPhone: '+8801712345678',
+  scheduledTime: new Date(Date.now() + 3600_000).toISOString(),
+}
+
 describe('NewTakeawayOrderPage', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
+    setSearchParams({})
     process.env = {
       ...originalEnv,
       NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
@@ -33,6 +55,7 @@ describe('NewTakeawayOrderPage', () => {
 
   describe('initial render', () => {
     it('shows the order page shell with takeaway badge while waiting for callCreateOrder', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
 
@@ -48,8 +71,89 @@ describe('NewTakeawayOrderPage', () => {
     })
   })
 
+  describe('validation — missing required fields (issue #392)', () => {
+    it('shows error when customerName is missing', async () => {
+      setSearchParams({
+        customerPhone: '+8801712345678',
+        scheduledTime: VALID_PARAMS.scheduledTime,
+      })
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'takeaway-order-abc' })
+
+      render(<NewTakeawayOrderPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Customer name is required for takeaway orders')).toBeInTheDocument()
+      })
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+
+    it('shows error when customerPhone is missing', async () => {
+      setSearchParams({
+        customerName: 'Ahmed Khan',
+        scheduledTime: VALID_PARAMS.scheduledTime,
+      })
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'takeaway-order-abc' })
+
+      render(<NewTakeawayOrderPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Mobile number is required for takeaway orders')).toBeInTheDocument()
+      })
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+
+    it('shows error when scheduledTime is missing', async () => {
+      setSearchParams({
+        customerName: 'Ahmed Khan',
+        customerPhone: '+8801712345678',
+      })
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'takeaway-order-abc' })
+
+      render(<NewTakeawayOrderPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Pickup Time is required for takeaway orders')).toBeInTheDocument()
+      })
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+
+    it('shows "Failed to create order" header alongside the validation error message', async () => {
+      setSearchParams({
+        customerPhone: '+8801712345678',
+        scheduledTime: VALID_PARAMS.scheduledTime,
+      })
+
+      render(<NewTakeawayOrderPage />)
+
+      await waitFor(() => {
+        expect(screen.getByText('Failed to create order')).toBeInTheDocument()
+      })
+      expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
+    })
+
+    it('does not call callCreateOrder when customerName is missing', async () => {
+      setSearchParams({
+        customerPhone: '+8801712345678',
+        scheduledTime: VALID_PARAMS.scheduledTime,
+      })
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+
+      render(<NewTakeawayOrderPage />)
+
+      // Wait a tick to let any async operations settle
+      await waitFor(() => {
+        expect(screen.queryByRole('status', { name: 'Creating order…' })).not.toBeInTheDocument()
+      })
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+  })
+
   describe('on success', () => {
     it('redirects to the real takeaway order page via router.replace', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'takeaway-order-abc' })
 
@@ -60,7 +164,8 @@ describe('NewTakeawayOrderPage', () => {
       })
     })
 
-    it('calls callCreateOrder with orderType takeaway', async () => {
+    it('calls callCreateOrder with orderType takeaway, customerName, and customerMobile', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'takeaway-order-abc' })
 
@@ -70,7 +175,12 @@ describe('NewTakeawayOrderPage', () => {
         expect(callCreateOrder).toHaveBeenCalledWith(
           'https://test.supabase.co',
           'test-token',
-          { orderType: 'takeaway' },
+          {
+            orderType: 'takeaway',
+            customerName: VALID_PARAMS.customerName,
+            customerMobile: VALID_PARAMS.customerPhone,
+            scheduledTime: VALID_PARAMS.scheduledTime,
+          },
           expect.any(AbortSignal),
         )
       })
@@ -79,6 +189,7 @@ describe('NewTakeawayOrderPage', () => {
 
   describe('on failure', () => {
     it('shows the error message and a Go back button', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Failed to create takeaway order'))
 
@@ -91,6 +202,7 @@ describe('NewTakeawayOrderPage', () => {
     })
 
     it('"Go back" button navigates to /tables via router.replace', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Network error'))
 
@@ -105,6 +217,7 @@ describe('NewTakeawayOrderPage', () => {
     })
 
     it('does not redirect to an order page on failure', async () => {
+      setSearchParams(VALID_PARAMS)
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('create_order failed: 500'))
 

--- a/supabase/functions/create_order/index.test.ts
+++ b/supabase/functions/create_order/index.test.ts
@@ -267,6 +267,21 @@ describe('create_order handler', () => {
       expect(json.error).toBe('customer_mobile is required for takeaway orders')
     })
 
+    it('returns 400 when customer_mobile is whitespace-only', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: 'Ahmed Khan',
+        customer_mobile: '   ',
+        scheduled_time: SCHEDULED_TIME,
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('customer_mobile is required for takeaway orders')
+    })
+
     it('returns 200 when both customer_name and customer_mobile are provided', async (): Promise<void> => {
       const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
       const req = makeAuthPost({

--- a/supabase/functions/create_order/index.test.ts
+++ b/supabase/functions/create_order/index.test.ts
@@ -4,21 +4,63 @@ import { handler, corsHeaders, type HandlerEnv } from './index'
 const TEST_TABLE_ID = '00000000-0000-0000-0000-000000000101'
 const TEST_RESTAURANT_ID = '00000000-0000-0000-0000-000000000001'
 const TEST_ORDER_ID = '11111111-1111-1111-1111-111111111111'
+const TEST_USER_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
 
 const mockEnv: HandlerEnv = {
   supabaseUrl: 'https://test.supabase.co',
   serviceKey: 'test-service-key',
 }
 
-function makeMockFetch(tableRows: unknown[], orderRows: unknown[]): (input: string, init?: RequestInit) => Promise<Response> {
+/**
+ * Build a mock fetch that handles all Supabase REST/Auth calls used by the handler.
+ *
+ * Auth flow:
+ *   1. GET /auth/v1/user                       → { id: TEST_USER_ID }
+ *   2. GET /rest/v1/users?id=eq.TEST_USER_ID…  → [{ role: 'server' }]
+ *
+ * Data flows (configurable):
+ *   - GET /rest/v1/tables?…  → tableRows
+ *   - POST /rest/v1/orders   → orderRows
+ *   - GET /rest/v1/users?select=restaurant_id… → [{ restaurant_id: TEST_RESTAURANT_ID }]
+ */
+function makeMockFetch(
+  tableRows: unknown[],
+  orderRows: unknown[],
+): (input: string, init?: RequestInit) => Promise<Response> {
   return vi.fn().mockImplementation((url: string) => {
-    if ((url as string).includes('/tables')) {
+    // Auth: verify JWT
+    if ((url as string).includes('/auth/v1/user')) {
+      return Promise.resolve(new Response(JSON.stringify({ id: TEST_USER_ID }), { status: 200 }))
+    }
+    // Auth: role lookup (contains 'select=role')
+    if ((url as string).includes('select=role')) {
+      return Promise.resolve(new Response(JSON.stringify([{ role: 'server' }]), { status: 200 }))
+    }
+    // Restaurant ID lookup for takeaway/delivery (contains 'select=restaurant_id')
+    if ((url as string).includes('select=restaurant_id')) {
+      return Promise.resolve(new Response(JSON.stringify([{ restaurant_id: TEST_RESTAURANT_ID }]), { status: 200 }))
+    }
+    // Tables
+    if ((url as string).includes('/rest/v1/tables')) {
       return Promise.resolve(new Response(JSON.stringify(tableRows), { status: 200 }))
     }
-    if ((url as string).includes('/orders')) {
+    // Orders insert
+    if ((url as string).includes('/rest/v1/orders')) {
       return Promise.resolve(new Response(JSON.stringify(orderRows), { status: 200 }))
     }
     return Promise.resolve(new Response('[]', { status: 200 }))
+  })
+}
+
+/** Helper: build an authenticated POST request */
+function makeAuthPost(body: unknown): Request {
+  return new Request('http://localhost/functions/v1/create_order', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+    },
+    body: JSON.stringify(body),
   })
 }
 
@@ -35,17 +77,82 @@ describe('create_order handler', () => {
     })
   })
 
-  describe('POST — happy path', () => {
+  describe('POST — missing env', () => {
+    it('returns 500 when env is not configured', async (): Promise<void> => {
+      const req = makeAuthPost({ table_id: TEST_TABLE_ID })
+      const res = await handler(req, fetch, null)
+      expect(res.status).toBe(500)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Server configuration error')
+    })
+  })
+
+  describe('POST — authentication', () => {
+    it('returns 401 when Authorization header is missing', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/create_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ table_id: TEST_TABLE_ID }),
+      })
+      const mockFetch = vi.fn().mockResolvedValue(new Response('[]', { status: 200 }))
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(401)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Unauthorized')
+    })
+  })
+
+  describe('POST — invalid body', () => {
+    it('returns 400 when body is malformed JSON', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [])
+      const req = new Request('http://localhost/functions/v1/create_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: 'not-valid-json',
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Invalid or missing request body')
+    })
+
+    it('returns 400 when body is null', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [])
+      const req = new Request('http://localhost/functions/v1/create_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: 'null',
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Missing request body')
+    })
+
+    it('returns CORS headers even on error responses', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [])
+      const req = new Request('http://localhost/functions/v1/create_order', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+        body: 'bad{json',
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+    })
+  })
+
+  describe('POST — dine_in (happy path)', () => {
     it('returns 200 with order_id and status open', async (): Promise<void> => {
       const mockFetch = makeMockFetch(
         [{ id: TEST_TABLE_ID, restaurant_id: TEST_RESTAURANT_ID }],
         [{ id: TEST_ORDER_ID, status: 'open' }],
       )
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID, staff_id: 'staff-abc' }),
-      })
+      const req = makeAuthPost({ table_id: TEST_TABLE_ID })
       const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(200)
       const json = await res.json() as { success: boolean; data: { order_id: string; status: string } }
@@ -59,24 +166,16 @@ describe('create_order handler', () => {
         [{ id: TEST_TABLE_ID, restaurant_id: TEST_RESTAURANT_ID }],
         [{ id: TEST_ORDER_ID, status: 'open' }],
       )
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID, staff_id: 'staff-xyz' }),
-      })
+      const req = makeAuthPost({ table_id: TEST_TABLE_ID })
       const res = await handler(req, mockFetch, mockEnv)
       expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
     })
   })
 
-  describe('POST — table not found', () => {
+  describe('POST — dine_in (table not found)', () => {
     it('returns 404 when table does not exist', async (): Promise<void> => {
       const mockFetch = makeMockFetch([], [])
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID, staff_id: 'staff-abc' }),
-      })
+      const req = makeAuthPost({ table_id: TEST_TABLE_ID })
       const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(404)
       const json = await res.json() as { success: boolean; error: string }
@@ -85,124 +184,117 @@ describe('create_order handler', () => {
     })
   })
 
-  describe('POST — missing env', () => {
-    it('returns 500 when env is not configured', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID, staff_id: 'staff-abc' }),
-      })
-      const res = await handler(req, fetch, null)
-      expect(res.status).toBe(500)
-      const json = await res.json() as { success: boolean; error: string }
-      expect(json.success).toBe(false)
-      expect(json.error).toBe('Server configuration error')
-    })
-  })
-
-  describe('non-POST / non-OPTIONS methods', () => {
-    it('returns 400 when method is GET (no body to parse)', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'GET',
-      })
-      const res = await handler(req)
-      expect(res.status).toBe(400)
-      const json = await res.json() as { success: boolean; error: string }
-      expect(json.success).toBe(false)
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    })
-  })
-
-  describe('POST — invalid body', () => {
-    it('returns 400 when body is malformed JSON', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: 'not-valid-json',
-      })
-      const res = await handler(req)
-      expect(res.status).toBe(400)
-      const json = await res.json() as { success: boolean; error: string }
-      expect(json.success).toBe(false)
-      expect(json.error).toBe('Invalid or missing request body')
-    })
-
-    it('returns 400 when body is null', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: 'null',
-      })
-      const res = await handler(req)
-      expect(res.status).toBe(400)
-      const json = await res.json() as { success: boolean; error: string }
-      expect(json.success).toBe(false)
-      expect(json.error).toBe('Missing request body')
-    })
-
-    it('returns CORS headers even on error responses', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: 'bad{json',
-      })
-      const res = await handler(req)
-      expect(res.status).toBe(400)
-      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
-    })
-  })
-
-  describe('POST — missing required fields', () => {
+  describe('POST — dine_in (missing required fields)', () => {
     it('returns 400 when table_id is absent', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ staff_id: 'staff-abc' }),
-      })
-      const res = await handler(req)
+      const mockFetch = makeMockFetch([], [])
+      const req = makeAuthPost({})
+      const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(400)
       const json = await res.json() as { success: boolean; error: string }
       expect(json.success).toBe(false)
-      expect(json.error).toBe('table_id is required and must be a non-empty string')
+      expect(json.error).toBe('table_id is required for dine_in orders')
     })
 
-    it('returns 400 when table_id is a number instead of a string', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: 1, staff_id: 'staff-abc' }),
-      })
-      const res = await handler(req)
+    it('returns 400 when table_id is empty string', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [])
+      const req = makeAuthPost({ table_id: '' })
+      const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(400)
       const json = await res.json() as { success: boolean; error: string }
       expect(json.success).toBe(false)
-      expect(json.error).toBe('table_id is required and must be a non-empty string')
+      expect(json.error).toBe('table_id is required for dine_in orders')
+    })
+  })
+
+  describe('POST — takeaway (issue #392)', () => {
+    const SCHEDULED_TIME = new Date(Date.now() + 3600_000).toISOString()
+
+    it('returns 400 when customer_name is missing', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_mobile: '+8801712345678',
+        scheduled_time: SCHEDULED_TIME,
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('customer_name is required for takeaway orders')
     })
 
-    it('returns 400 when staff_id is absent', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID }),
+    it('returns 400 when customer_name is empty string', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: '   ',
+        customer_mobile: '+8801712345678',
+        scheduled_time: SCHEDULED_TIME,
       })
-      const res = await handler(req)
+      const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(400)
       const json = await res.json() as { success: boolean; error: string }
       expect(json.success).toBe(false)
-      expect(json.error).toBe('staff_id is required and must be a non-empty string')
+      expect(json.error).toBe('customer_name is required for takeaway orders')
     })
 
-    it('returns 400 when staff_id is an empty string', async (): Promise<void> => {
-      const req = new Request('http://localhost/functions/v1/create_order', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ table_id: TEST_TABLE_ID, staff_id: '' }),
+    it('returns 400 when customer_mobile is missing', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: 'Ahmed Khan',
+        scheduled_time: SCHEDULED_TIME,
       })
-      const res = await handler(req)
+      const res = await handler(req, mockFetch, mockEnv)
       expect(res.status).toBe(400)
       const json = await res.json() as { success: boolean; error: string }
       expect(json.success).toBe(false)
-      expect(json.error).toBe('staff_id is required and must be a non-empty string')
+      expect(json.error).toBe('customer_mobile is required for takeaway orders')
+    })
+
+    it('returns 400 when customer_mobile is empty string', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: 'Ahmed Khan',
+        customer_mobile: '',
+        scheduled_time: SCHEDULED_TIME,
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('customer_mobile is required for takeaway orders')
+    })
+
+    it('returns 200 when both customer_name and customer_mobile are provided', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: 'Ahmed Khan',
+        customer_mobile: '+8801712345678',
+        scheduled_time: SCHEDULED_TIME,
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: { order_id: string; status: string } }
+      expect(json.success).toBe(true)
+      expect(json.data.order_id).toBe(TEST_ORDER_ID)
+      expect(json.data.status).toBe('open')
+    })
+
+    it('returns 400 when scheduled_time is missing', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
+        customer_name: 'Ahmed Khan',
+        customer_mobile: '+8801712345678',
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('scheduled_time is required for takeaway and delivery orders')
     })
   })
 })

--- a/supabase/functions/create_order/index.test.ts
+++ b/supabase/functions/create_order/index.test.ts
@@ -227,6 +227,21 @@ describe('create_order handler', () => {
       const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
       const req = makeAuthPost({
         order_type: 'takeaway',
+        customer_name: '',
+        customer_mobile: '+8801712345678',
+        scheduled_time: SCHEDULED_TIME,
+      })
+      const res = await handler(req, mockFetch, mockEnv)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('customer_name is required for takeaway orders')
+    })
+
+    it('returns 400 when customer_name is whitespace-only', async (): Promise<void> => {
+      const mockFetch = makeMockFetch([], [{ id: TEST_ORDER_ID, status: 'open' }])
+      const req = makeAuthPost({
+        order_type: 'takeaway',
         customer_name: '   ',
         customer_mobile: '+8801712345678',
         scheduled_time: SCHEDULED_TIME,

--- a/supabase/functions/create_order/index.ts
+++ b/supabase/functions/create_order/index.ts
@@ -118,6 +118,20 @@ export async function handler(
     )
   }
 
+  // Takeaway orders require customer_name and customer_mobile (issue #392)
+  if (orderType === 'takeaway' && (!customerName || customerName.trim() === '')) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'customer_name is required for takeaway orders' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (orderType === 'takeaway' && (!customerMobile || customerMobile.trim() === '')) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'customer_mobile is required for takeaway orders' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
   // Delivery orders require customer_name, customer_mobile, and delivery_note (issue #358)
   if (orderType === 'delivery' && (!customerName || customerName.trim() === '')) {
     return new Response(


### PR DESCRIPTION
## Summary

Implements mandatory validation of `customer_name` and `customer_mobile` for takeaway orders, consistent with the existing delivery order validation.

## Changes

### Backend (`supabase/functions/create_order/index.ts`)
- Added validation block for `order_type === 'takeaway'`: returns 400 if `customer_name` is missing/empty or `customer_mobile` is missing/empty — same pattern already used for delivery orders.

### Frontend (`apps/web/app/tables/takeaway/order/new/NewTakeawayOrderClient.tsx`)
- Added pre-submission validation: shows clear error state if `customerName` or `customerPhone` URL params are absent before the API call fires.
- Updated `callCreateOrder` call to always include both `customerName` and `customerMobile` (previously conditional).

### UI (`apps/web/app/tables/page.tsx`)
- Takeaway modal: changed Customer Name and Phone Number labels from `(optional)` to `*` required.
- Confirm button now disabled until all three fields (name, mobile, pickup time) are filled.
- `handleConfirmTakeaway` validates name and mobile before navigating; shows `createOrderError` on failure.

### Tests
- **Edge function**: Rewrote test suite with proper auth mocking (`/auth/v1/user` + role lookup). Added takeaway validation tests: missing `customer_name` → 400, whitespace-only → 400, missing `customer_mobile` → 400, both present → 200.
- **Frontend**: Fixed `useSearchParams` mock (was missing, causing all tests to crash). Added validation tests: submission blocked when `customerName` or `customerPhone` absent; error state shown; `callCreateOrder` not called.

Closes #392