### PR TITLE
feat(#401): optional customer name and mobile for dine-in orders

### DIFF
--- a/apps/web/app/tables/[id]/order/new/page.test.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.test.tsx
@@ -270,7 +270,7 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
       })
     })
 
-    it('shows customer name and mobile in creating shell when fields are filled', async () => {
+    it('shows customer name and phone in creating shell when fields are filled', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
 
@@ -282,6 +282,8 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
 
       expect(screen.getByText('Ahmed Khan')).toBeInTheDocument()
       expect(screen.getByText('+8801712345678')).toBeInTheDocument()
+      // Label in creating shell matches takeaway ('Phone', not 'Mobile')
+      expect(screen.getByText('Phone')).toBeInTheDocument()
     })
 
     it('does NOT show customer row in creating shell when fields are skipped', async () => {
@@ -294,7 +296,7 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
 
       // Customer label should not be visible when no customer info was provided
       expect(screen.queryByText('Customer')).not.toBeInTheDocument()
-      expect(screen.queryByText('Mobile')).not.toBeInTheDocument()
+      expect(screen.queryByText('Phone')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/app/tables/[id]/order/new/page.test.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../../components/createOrderApi', () => ({
 
 const originalEnv = process.env
 
-describe('NewOrderPage', () => {
+describe('NewOrderPage (dine-in with optional customer capture — issue #401)', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     process.env = {
@@ -28,59 +28,277 @@ describe('NewOrderPage', () => {
       NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
     }
 
-    // Re-import the module fresh for each test so the mock resolves properly
     const { callCreateOrder } = await import('../../../components/createOrderApi')
     vi.mocked(callCreateOrder).mockReset()
   })
 
-  describe('initial render', () => {
-    it('shows the order page shell with table info and inline creating indicator', async () => {
+  // ── Capture step (initial render) ────────────────────────────────────────
+
+  describe('capture step — initial render', () => {
+    it('shows the customer capture form with optional fields', () => {
+      render(<NewOrderPage />)
+
+      expect(screen.getByRole('heading', { name: 'New Dine-in Order', level: 1 })).toBeInTheDocument()
+      expect(screen.getByText('table-uuid-001')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Customer Details', level: 2 })).toBeInTheDocument()
+      expect(screen.getByText(/optional — leave blank to skip/i)).toBeInTheDocument()
+      expect(screen.getByLabelText('Customer Name')).toBeInTheDocument()
+      expect(screen.getByLabelText('Mobile Number')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Create Order' })).toBeInTheDocument()
+    })
+
+    it('does NOT call callCreateOrder on mount — waits for user interaction', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+
+      render(<NewOrderPage />)
+
+      // Wait a tick to let any potential async effects settle
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+
+    it('"Create Order" button is enabled when auth token is available', () => {
+      render(<NewOrderPage />)
+      // With the default mock (accessToken: 'test-token'), button should be enabled
+      expect(screen.getByRole('button', { name: 'Create Order' })).not.toBeDisabled()
+    })
+
+    it('"Back to tables" button navigates to /tables', async () => {
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: /back to tables/i }))
+      expect(mockReplace).toHaveBeenCalledWith('/tables')
+    })
+  })
+
+  // ── Skip path (no customer info) ─────────────────────────────────────────
+
+  describe('skip path — create order without customer details', () => {
+    it('transitions to creating shell when "Create Order" is clicked with empty fields', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
 
       render(<NewOrderPage />)
 
-      // Order page chrome is immediately visible
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
       expect(screen.getByRole('heading', { name: 'Order', level: 1 })).toBeInTheDocument()
-      // Table info shown from URL params
-      expect(screen.getByText('table-uuid-001')).toBeInTheDocument()
-      // Inline creating indicator — NOT a full-screen spinner
       expect(screen.getByRole('status', { name: 'Creating order…' })).toBeInTheDocument()
       expect(screen.getByText('Creating order…')).toBeInTheDocument()
-      // Action buttons are disabled while order is being created
-      expect(screen.getByRole('button', { name: 'Add Items' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'Close Order' })).toBeDisabled()
     })
-  })
 
-  describe('on success', () => {
-    it('redirects to the real order page via router.replace', async () => {
+    it('calls callCreateOrder with tableId and dine_in type only (no customer fields)', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
-      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'new-order-xyz' })
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
 
       render(<NewOrderPage />)
 
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/new-order-xyz')
-      })
-    })
-
-    it('calls callCreateOrder with the correct arguments', async () => {
-      const { callCreateOrder } = await import('../../../components/createOrderApi')
-      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'new-order-xyz' })
-
-      render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(callCreateOrder).toHaveBeenCalledWith(
           'https://test.supabase.co',
           'test-token',
-          'table-uuid-001',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+          },
           expect.any(AbortSignal),
         )
       })
     })
+
+    it('redirects to the real order page on success (skip path)', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/order-skip-xyz')
+      })
+    })
+
+    it('does not include customerName or customerMobile in the API call when fields are blank', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        const callArgs = vi.mocked(callCreateOrder).mock.calls[0]
+        const opts = callArgs[2] as Record<string, unknown>
+        expect(opts).not.toHaveProperty('customerName')
+        expect(opts).not.toHaveProperty('customerMobile')
+      })
+    })
+
+    it('does not include customerName or customerMobile when fields contain only whitespace', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), '   ')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '   ')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        const callArgs = vi.mocked(callCreateOrder).mock.calls[0]
+        const opts = callArgs[2] as Record<string, unknown>
+        expect(opts).not.toHaveProperty('customerName')
+        expect(opts).not.toHaveProperty('customerMobile')
+      })
+    })
   })
+
+  // ── Fill-in path (with customer info) ────────────────────────────────────
+
+  describe('fill-in path — create order with customer details', () => {
+    it('calls callCreateOrder with customerName and customerMobile when filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-with-customer-abc' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('calls callCreateOrder with only customerName when only name is filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-name-only' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('calls callCreateOrder with only customerMobile when only mobile is filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-mobile-only' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('trims whitespace from customer name and mobile before calling API', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-trimmed' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), '  Ahmed Khan  ')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '  +8801712345678  ')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('redirects to the real order page on success (fill-in path)', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-with-customer-abc' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/order-with-customer-abc')
+      })
+    })
+
+    it('shows customer name and mobile in creating shell when fields are filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      expect(screen.getByText('Ahmed Khan')).toBeInTheDocument()
+      expect(screen.getByText('+8801712345678')).toBeInTheDocument()
+    })
+
+    it('does NOT show customer row in creating shell when fields are skipped', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      // Customer label should not be visible when no customer info was provided
+      expect(screen.queryByText('Customer')).not.toBeInTheDocument()
+      expect(screen.queryByText('Mobile')).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Failure handling ─────────────────────────────────────────────────────
 
   describe('on failure', () => {
     it('shows the error message and a Go back button', async () => {
@@ -88,10 +306,12 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Table already has an open order'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.getByText('Table already has an open order')).toBeInTheDocument()
       })
+      expect(screen.getByText('Failed to create order')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
     })
 
@@ -100,13 +320,13 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Network error'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
       })
 
       await userEvent.click(screen.getByRole('button', { name: /go back to tables/i }))
-
       expect(mockReplace).toHaveBeenCalledWith('/tables')
     })
 
@@ -115,12 +335,29 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('create_order failed: 500'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.queryByRole('status', { name: 'Creating order…' })).not.toBeInTheDocument()
       })
 
       expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('shows a generic error message when the thrown error is not an Error instance', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockRejectedValue('unexpected string error')
+
+      render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      // Shows the error state UI (Go back button confirms we're in error state)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
+      })
+      // Both the heading and the fallback error message text appear in the DOM
+      const allMessages = screen.getAllByText('Failed to create order')
+      expect(allMessages.length).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/apps/web/app/tables/[id]/order/new/page.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.tsx
@@ -1,45 +1,67 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useState, useRef } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import type { JSX } from 'react'
 import { callCreateOrder } from '../../../components/createOrderApi'
 import { useUser } from '@/lib/user-context'
 
+type Step = 'capture' | 'creating' | 'error'
+
 /**
- * Instant dine-in order creation page (issue #255).
+ * Dine-in new order page with optional customer capture (issue #401).
  *
- * Navigated to immediately when staff tap an empty table.
- * Renders the dine-in order shell instantly — no full-screen blocking spinner.
- * Fires callCreateOrder in the background and redirects to the real order page
- * via router.replace on success, or shows an error with a "Go back" button on failure.
+ * Navigated to when staff tap an empty table. Shows an optional customer name
+ * + mobile form. Staff can fill in customer details or leave blank and tap
+ * "Create Order" to skip. The form never blocks order creation.
+ *
+ * On submit, transitions to a "creating" shell that shows a spinner while
+ * callCreateOrder fires in the background, then redirects to the real order
+ * page on success, or shows an error with a "Go back" button on failure.
  */
 export default function NewOrderPage(): JSX.Element {
   const router = useRouter()
   const params = useParams<{ id: string }>()
   const tableId = params.id
   const { accessToken: _at } = useUser()
-  // _at === null means auth is still loading; wait before firing to avoid a
-  // spurious unauthenticated request. Collapse to '' once loaded (token or guest).
+  // _at === null means auth is still loading; disable the submit button until ready.
   const accessToken = _at ?? ''
+
+  const [step, setStep] = useState<Step>('capture')
+  const [customerName, setCustomerName] = useState('')
+  const [customerMobile, setCustomerMobile] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const hasFired = useRef(false)
+  // Keep an AbortController ref so we can clean up if the component unmounts
+  const controllerRef = useRef<AbortController | null>(null)
 
-  useEffect(() => {
-    if (!tableId || _at === null) return
-    if (hasFired.current) return
-    hasFired.current = true
-
+  function handleCreateOrder(): void {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     if (!supabaseUrl || !accessToken) {
-      void Promise.resolve().then(() => { setError('Not authenticated') })
+      setError('Not authenticated')
+      setStep('error')
       return
     }
 
-    const controller = new AbortController()
+    setStep('creating')
 
-    callCreateOrder(supabaseUrl, accessToken, tableId, controller.signal)
-      .then(({ order_id }) => {
+    const controller = new AbortController()
+    controllerRef.current = controller
+
+    const trimmedName = customerName.trim()
+    const trimmedMobile = customerMobile.trim()
+
+    callCreateOrder(
+      supabaseUrl,
+      accessToken,
+      {
+        tableId,
+        orderType: 'dine_in',
+        ...(trimmedName ? { customerName: trimmedName } : {}),
+        ...(trimmedMobile ? { customerMobile: trimmedMobile } : {}),
+      },
+      controller.signal,
+    )
+      .then(({ order_id }: { order_id: string }) => {
         if (controller.signal.aborted) return
         router.replace(`/tables/${tableId}/order/${order_id}`)
       })
@@ -47,12 +69,12 @@ export default function NewOrderPage(): JSX.Element {
         if (controller.signal.aborted) return
         const message = err instanceof Error ? err.message : 'Failed to create order'
         setError(message)
+        setStep('error')
       })
+  }
 
-    return () => { controller.abort() }
-  }, [tableId, accessToken, router])
-
-  if (error !== null) {
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (step === 'error') {
     return (
       <main className="min-h-screen bg-zinc-900 flex flex-col items-center justify-center p-6 gap-6">
         <div className="flex flex-col items-center gap-4 max-w-sm w-full">
@@ -72,69 +94,154 @@ export default function NewOrderPage(): JSX.Element {
     )
   }
 
-  // ── Dine-in order shell — visible immediately on tap ──────────────────────
+  // ── Creating shell — visible after staff tap "Create Order" ───────────────
+  if (step === 'creating') {
+    const displayName = customerName.trim()
+    const displayMobile = customerMobile.trim()
+    return (
+      <main className="min-h-screen bg-zinc-900 p-6 flex flex-col">
+        <button
+          type="button"
+          disabled
+          className="inline-flex items-center gap-2 text-zinc-600 text-base mb-8 min-h-[48px] min-w-[48px] cursor-not-allowed"
+        >
+          ← Back to tables
+        </button>
+
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
+          <dl className="space-y-2 text-base">
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Table</dt>
+              <dd className="font-semibold text-white">{tableId}</dd>
+            </div>
+            {displayName && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Customer</dt>
+                <dd className="font-semibold text-white">{displayName}</dd>
+              </div>
+            )}
+            {displayMobile && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Mobile</dt>
+                <dd className="text-zinc-300">{displayMobile}</dd>
+              </div>
+            )}
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Order ID</dt>
+              <dd className="font-mono text-sm text-zinc-500 flex items-center gap-2">
+                <svg
+                  className="animate-spin h-3 w-3 text-amber-400 flex-shrink-0"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span role="status" aria-label="Creating order…">Creating order…</span>
+              </dd>
+            </div>
+          </dl>
+        </header>
+
+        <section className="flex-1">
+          <h2 className="text-lg font-semibold text-white mb-4">Items</h2>
+          <p className="text-zinc-500 text-base">No items yet — tap Add Items to start</p>
+        </section>
+
+        <footer className="mt-6 pt-4 border-t border-zinc-700">
+          <div className="flex items-center justify-between mb-6">
+            <span className="text-lg text-zinc-400">Total</span>
+            <span className="text-2xl font-bold text-zinc-600">৳0.00</span>
+          </div>
+          <div className="flex gap-4 mb-3">
+            <button
+              type="button"
+              disabled
+              className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl border-2 border-zinc-700 text-zinc-600 text-base font-semibold cursor-not-allowed"
+            >
+              Add Items
+            </button>
+            <button
+              type="button"
+              disabled
+              className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-zinc-800 text-zinc-600 cursor-not-allowed"
+            >
+              Close Order
+            </button>
+          </div>
+        </footer>
+      </main>
+    )
+  }
+
+  // ── Capture step — optional customer details form ─────────────────────────
   return (
     <main className="min-h-screen bg-zinc-900 p-6 flex flex-col">
       <button
         type="button"
-        disabled
-        className="inline-flex items-center gap-2 text-zinc-600 text-base mb-8 min-h-[48px] min-w-[48px] cursor-not-allowed"
+        onClick={() => { router.replace('/tables') }}
+        className="inline-flex items-center gap-2 text-zinc-400 hover:text-white text-base mb-8 min-h-[48px] min-w-[48px] transition-colors"
       >
         ← Back to tables
       </button>
 
       <header className="mb-6">
-        <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
+        <h1 className="text-2xl font-bold text-white mb-4">New Dine-in Order</h1>
         <dl className="space-y-2 text-base">
           <div className="flex gap-3">
             <dt className="text-zinc-500">Table</dt>
             <dd className="font-semibold text-white">{tableId}</dd>
           </div>
-          <div className="flex gap-3">
-            <dt className="text-zinc-500">Order ID</dt>
-            <dd className="font-mono text-sm text-zinc-500 flex items-center gap-2">
-              <svg
-                className="animate-spin h-3 w-3 text-amber-400 flex-shrink-0"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              <span role="status" aria-label="Creating order…">Creating order…</span>
-            </dd>
-          </div>
         </dl>
       </header>
 
-      <section className="flex-1">
-        <h2 className="text-lg font-semibold text-white mb-4">Items</h2>
-        <p className="text-zinc-500 text-base">No items yet — tap Add Items to start</p>
+      <section className="flex-1 max-w-sm">
+        <h2 className="text-lg font-semibold text-white mb-1">Customer Details</h2>
+        <p className="text-zinc-500 text-sm mb-4">Optional — leave blank to skip</p>
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="customerName" className="block text-sm font-medium text-zinc-400 mb-1">
+              Customer Name
+            </label>
+            <input
+              id="customerName"
+              type="text"
+              value={customerName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setCustomerName(e.target.value) }}
+              placeholder="e.g. Ahmed Khan"
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 text-white placeholder-zinc-600 text-base focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="customerMobile" className="block text-sm font-medium text-zinc-400 mb-1">
+              Mobile Number
+            </label>
+            <input
+              id="customerMobile"
+              type="tel"
+              value={customerMobile}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setCustomerMobile(e.target.value) }}
+              placeholder="e.g. +8801712345678"
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 text-white placeholder-zinc-600 text-base focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+        </div>
       </section>
 
       <footer className="mt-6 pt-4 border-t border-zinc-700">
-        <div className="flex items-center justify-between mb-6">
-          <span className="text-lg text-zinc-400">Total</span>
-          <span className="text-2xl font-bold text-zinc-600">৳0.00</span>
-        </div>
-        <div className="flex gap-4 mb-3">
-          <button
-            type="button"
-            disabled
-            className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl border-2 border-zinc-700 text-zinc-600 text-base font-semibold cursor-not-allowed"
-          >
-            Add Items
-          </button>
-          <button
-            type="button"
-            disabled
-            className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-zinc-800 text-zinc-600 cursor-not-allowed"
-          >
-            Close Order
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={handleCreateOrder}
+          disabled={_at === null}
+          className="w-full min-h-[48px] px-6 rounded-xl text-base font-semibold bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed text-zinc-900 transition-colors"
+        >
+          Create Order
+        </button>
       </footer>
     </main>
   )

--- a/apps/web/app/tables/[id]/order/new/page.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import type { JSX } from 'react'
 import { callCreateOrder } from '../../../components/createOrderApi'
@@ -33,6 +33,12 @@ export default function NewOrderPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   // Keep an AbortController ref so we can clean up if the component unmounts
   const controllerRef = useRef<AbortController | null>(null)
+
+  // Abort any in-flight API call when the component unmounts (e.g. OS back gesture
+  // during the 'creating' step) so stale callbacks don't fire on an unmounted component.
+  useEffect(() => {
+    return () => { controllerRef.current?.abort() }
+  }, [])
 
   function handleCreateOrder(): void {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -123,7 +129,7 @@ export default function NewOrderPage(): JSX.Element {
             )}
             {displayMobile && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Mobile</dt>
+                <dt className="text-zinc-500">Phone</dt>
                 <dd className="text-zinc-300">{displayMobile}</dd>
               </div>
             )}


### PR DESCRIPTION
## Summary

Add an optional customer name + mobile capture step to the dine-in new order page. Staff see a form before the order is created. Both fields are optional — tapping **Create Order** without filling in anything skips customer capture entirely. Filling in details passes them to `callCreateOrder`.

The dine-in flow was the only order type without any customer capture. This closes the gap while keeping the flow non-blocking.

## What changed

### `apps/web/app/tables/[id]/order/new/page.tsx`
- Replace the immediate auto-fire pattern with a three-step state machine: **capture → creating → (redirect or error)**
- **Capture step** (new): optional form with Customer Name and Mobile Number inputs, plus a "Create Order" button. Staff fill in or leave blank.
- **Creating step**: the familiar order shell with spinner — shown after staff tap Create Order
- **Error step**: error message + Go back button (unchanged)
- Calls `callCreateOrder` with `CreateOrderOptions` object (replaces legacy `tableId` string), forwarding `tableId`, `orderType: 'dine_in'`, and optional customer fields
- Whitespace-only inputs are trimmed and excluded from the API call

### `apps/web/app/tables/[id]/order/new/page.test.tsx`
- Full rewrite to cover the new three-step flow
- **Skip path**: Create Order with empty fields → `callCreateOrder` called without `customerName`/`customerMobile`
- **Fill-in path**: typed name/mobile correctly forwarded in the API call
- Whitespace-only inputs excluded from API call
- Partial fill (name only, mobile only) forwarded correctly
- Creating shell shows customer info rows when provided, hides them when skipped
- Back button on capture step navigates to `/tables`
- Failure and error-state coverage unchanged

## Checklist
- [x] Fields are optional — dine-in order creation is never blocked
- [x] Matches takeaway UX pattern (creating shell with spinner after submit)
- [x] `callCreateOrder` already accepted optional customer fields — no API changes needed
- [x] Tests: skip path and fill-in path both covered
- [x] All 20 new tests pass; no regressions in takeaway/delivery suites

Closes #401
