### PR TITLE
ux(#393): surface delivery charge field during order creation

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -1296,6 +1296,80 @@ describe('OrderDetailClient', () => {
 
       expect(screen.getByText('No items on this order.')).toBeInTheDocument()
     })
+
+    it('shows Delivery Fee row in paid read-only view for delivery orders (issue #393)', async (): Promise<void> => {
+      // Regression guard: the Delivery Fee row added to the paid-order <dl> in OrderDetailClient.tsx
+      // must render for delivery orders with a non-zero charge. Previously all paid-order tests
+      // used order_type: 'dine_in' + delivery_charge: 0, leaving this render path uncovered.
+      vi.useRealTimers()
+
+      const { fetchOrderSummary } = await import('./orderData')
+      const { fetchOrderItems } = await import('./orderData')
+
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'paid',
+        payment_method: 'cash',
+        order_type: 'delivery',
+        customer_name: 'Ahmed Khan',
+        delivery_note: 'Road 12, House 5',
+        customer_mobile: '+880 1711 123456',
+        bill_number: null,
+        reservation_id: null,
+        customer_id: null,
+        order_number: 99,
+        scheduled_time: null,
+        delivery_zone_name: 'Zone A',
+        delivery_charge: 9900,
+        delivery_zone_id: 'zone-1',
+        merge_label: null,
+      })
+      vi.mocked(fetchOrderItems).mockResolvedValue([])
+
+      render(<OrderDetailClient tableId="delivery" orderId="order-paid-delivery-99" />)
+
+      await waitFor((): void => {
+        expect(screen.getByText('Paid')).toBeInTheDocument()
+      }, { timeout: 10000 })
+
+      // "Delivery Fee" label and the formatted amount should both appear in the paid view
+      expect(screen.getAllByText('Delivery Fee').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('৳ 99.00')).toBeInTheDocument()
+    })
+
+    it('shows Free Delivery in paid read-only view for delivery orders with zero charge (issue #393)', async (): Promise<void> => {
+      vi.useRealTimers()
+
+      const { fetchOrderSummary } = await import('./orderData')
+      const { fetchOrderItems } = await import('./orderData')
+
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'paid',
+        payment_method: 'cash',
+        order_type: 'delivery',
+        customer_name: 'Ahmed Khan',
+        delivery_note: 'Road 12, House 5',
+        customer_mobile: '+880 1711 123456',
+        bill_number: null,
+        reservation_id: null,
+        customer_id: null,
+        order_number: 100,
+        scheduled_time: null,
+        delivery_zone_name: null,
+        delivery_charge: 0,
+        delivery_zone_id: null,
+        merge_label: null,
+      })
+      vi.mocked(fetchOrderItems).mockResolvedValue([])
+
+      render(<OrderDetailClient tableId="delivery" orderId="order-paid-delivery-free" />)
+
+      await waitFor((): void => {
+        expect(screen.getByText('Paid')).toBeInTheDocument()
+      }, { timeout: 10000 })
+
+      expect(screen.getAllByText('Delivery Fee').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('Free Delivery')).toBeInTheDocument()
+    })
   })
 
   describe('reprint KOT', () => {

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -1685,4 +1685,72 @@ describe('OrderDetailClient', () => {
       })
     })
   })
+
+  // ─── Delivery fee visibility — issue #393 ─────────────────────────────────
+  // NOTE: these tests use vi.useRealTimers() locally because vi.useFakeTimers()
+  // (set in beforeEach) prevents waitFor's internal polling from advancing,
+  // causing all async tests to time-out (pre-existing infra issue).
+  describe('delivery fee visibility (issue #393)', () => {
+    it('shows Delivery Fee in the order header for a delivery order', async (): Promise<void> => {
+      vi.useRealTimers()
+
+      const { fetchOrderSummary } = await import('./orderData')
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'open',
+        payment_method: null,
+        order_type: 'delivery',
+        customer_name: 'Ahmed Khan',
+        delivery_note: 'Road 12, House 5',
+        customer_mobile: '+880 1711 123456',
+        bill_number: null,
+        reservation_id: null,
+        customer_id: null,
+        order_number: 42,
+        scheduled_time: '2026-04-06T18:00:00.000Z',
+        delivery_zone_name: 'Zone A',
+        delivery_charge: 9900,
+        delivery_zone_id: 'zone-1',
+        merge_label: null,
+      })
+
+      render(<OrderDetailClient tableId="delivery" orderId="order-delivery-1" />)
+
+      await waitFor((): void => {
+        expect(screen.getAllByText('Delivery Fee').length).toBeGreaterThanOrEqual(1)
+      }, { timeout: 10000 })
+    })
+
+    it('shows Waive Delivery Fee button for non-admin staff on delivery orders (issue #393)', async (): Promise<void> => {
+      vi.useRealTimers()
+
+      const { fetchOrderSummary } = await import('./orderData')
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'open',
+        payment_method: null,
+        order_type: 'delivery',
+        customer_name: 'Ahmed Khan',
+        delivery_note: 'Road 12, House 5',
+        customer_mobile: '+880 1711 123456',
+        bill_number: null,
+        reservation_id: null,
+        customer_id: null,
+        order_number: 42,
+        scheduled_time: '2026-04-06T18:00:00.000Z',
+        delivery_zone_name: 'Zone A',
+        delivery_charge: 9900,
+        delivery_zone_id: 'zone-1',
+        merge_label: null,
+      })
+
+      // Non-admin user — previously this button was admin-only
+      const { useUser } = await import('@/lib/user-context')
+      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'waiter', loading: false })
+
+      render(<OrderDetailClient tableId="delivery" orderId="order-delivery-1" />)
+
+      await waitFor((): void => {
+        expect(screen.getByRole('button', { name: /waive delivery fee/i })).toBeInTheDocument()
+      }, { timeout: 10000 })
+    })
+  })
 })

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -2370,6 +2370,17 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 <dd className="font-semibold text-amber-300">{formatDateTimeShort(orderScheduledTime)}</dd>
               </div>
             )}
+            {/* Delivery fee in paid-order read-only view (issue #393) */}
+            {orderType === 'delivery' && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Delivery Fee</dt>
+                <dd className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-300' : 'font-semibold text-emerald-400'}>
+                  {orderDeliveryChargeCents > 0
+                    ? formatPrice(orderDeliveryChargeCents, currencySymbol)
+                    : 'Free Delivery'}
+                </dd>
+              </div>
+            )}
             {paidPaymentMethod !== null && (
               <div className="flex gap-3">
                 <dt className="text-zinc-500">Payment method</dt>
@@ -3380,6 +3391,20 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <dd className="font-semibold text-amber-300">{formatDateTimeShort(orderScheduledTime)}</dd>
             </div>
           )}
+          {/* ── Delivery fee — always visible in the order header for delivery orders (issue #393) ── */}
+          {orderType === 'delivery' && (
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Delivery Fee</dt>
+              <dd
+                data-testid="delivery-fee-header"
+                className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-300' : 'font-semibold text-emerald-400'}
+              >
+                {orderDeliveryChargeCents > 0
+                  ? formatPrice(orderDeliveryChargeCents, currencySymbol)
+                  : 'Free Delivery'}
+              </dd>
+            </div>
+          )}
         </dl>
         {/* Reservation info block — shown when order was created via Seat action (issue #277) */}
         {orderReservationInfo !== null && (
@@ -3806,8 +3831,9 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               </button>
             )}
 
-            {/* Free delivery toggle — delivery orders only (issue #382) */}
-            {orderType === 'delivery' && isAdmin && (
+            {/* Free delivery toggle — delivery orders only (issues #382, #393) */}
+            {/* Available to all staff (not just admin) so any role can waive on the spot */}
+            {orderType === 'delivery' && (
               <div className="space-y-1">
                 <button
                   type="button"

--- a/apps/web/app/tables/[id]/order/new/page.test.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.test.tsx
@@ -270,7 +270,7 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
       })
     })
 
-    it('shows customer name and mobile in creating shell when fields are filled', async () => {
+    it('shows customer name and phone in creating shell when fields are filled', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
 
@@ -282,6 +282,8 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
 
       expect(screen.getByText('Ahmed Khan')).toBeInTheDocument()
       expect(screen.getByText('+8801712345678')).toBeInTheDocument()
+      // Label in creating shell matches takeaway ('Phone', not 'Mobile')
+      expect(screen.getByText('Phone')).toBeInTheDocument()
     })
 
     it('does NOT show customer row in creating shell when fields are skipped', async () => {
@@ -294,7 +296,7 @@ describe('NewOrderPage (dine-in with optional customer capture — issue #401)',
 
       // Customer label should not be visible when no customer info was provided
       expect(screen.queryByText('Customer')).not.toBeInTheDocument()
-      expect(screen.queryByText('Mobile')).not.toBeInTheDocument()
+      expect(screen.queryByText('Phone')).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/app/tables/[id]/order/new/page.test.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.test.tsx
@@ -20,7 +20,7 @@ vi.mock('../../../components/createOrderApi', () => ({
 
 const originalEnv = process.env
 
-describe('NewOrderPage', () => {
+describe('NewOrderPage (dine-in with optional customer capture — issue #401)', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     process.env = {
@@ -28,59 +28,277 @@ describe('NewOrderPage', () => {
       NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
     }
 
-    // Re-import the module fresh for each test so the mock resolves properly
     const { callCreateOrder } = await import('../../../components/createOrderApi')
     vi.mocked(callCreateOrder).mockReset()
   })
 
-  describe('initial render', () => {
-    it('shows the order page shell with table info and inline creating indicator', async () => {
+  // ── Capture step (initial render) ────────────────────────────────────────
+
+  describe('capture step — initial render', () => {
+    it('shows the customer capture form with optional fields', () => {
+      render(<NewOrderPage />)
+
+      expect(screen.getByRole('heading', { name: 'New Dine-in Order', level: 1 })).toBeInTheDocument()
+      expect(screen.getByText('table-uuid-001')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Customer Details', level: 2 })).toBeInTheDocument()
+      expect(screen.getByText(/optional — leave blank to skip/i)).toBeInTheDocument()
+      expect(screen.getByLabelText('Customer Name')).toBeInTheDocument()
+      expect(screen.getByLabelText('Mobile Number')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Create Order' })).toBeInTheDocument()
+    })
+
+    it('does NOT call callCreateOrder on mount — waits for user interaction', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+
+      render(<NewOrderPage />)
+
+      // Wait a tick to let any potential async effects settle
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(callCreateOrder).not.toHaveBeenCalled()
+    })
+
+    it('"Create Order" button is enabled when auth token is available', () => {
+      render(<NewOrderPage />)
+      // With the default mock (accessToken: 'test-token'), button should be enabled
+      expect(screen.getByRole('button', { name: 'Create Order' })).not.toBeDisabled()
+    })
+
+    it('"Back to tables" button navigates to /tables', async () => {
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: /back to tables/i }))
+      expect(mockReplace).toHaveBeenCalledWith('/tables')
+    })
+  })
+
+  // ── Skip path (no customer info) ─────────────────────────────────────────
+
+  describe('skip path — create order without customer details', () => {
+    it('transitions to creating shell when "Create Order" is clicked with empty fields', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
       vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
 
       render(<NewOrderPage />)
 
-      // Order page chrome is immediately visible
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
       expect(screen.getByRole('heading', { name: 'Order', level: 1 })).toBeInTheDocument()
-      // Table info shown from URL params
-      expect(screen.getByText('table-uuid-001')).toBeInTheDocument()
-      // Inline creating indicator — NOT a full-screen spinner
       expect(screen.getByRole('status', { name: 'Creating order…' })).toBeInTheDocument()
       expect(screen.getByText('Creating order…')).toBeInTheDocument()
-      // Action buttons are disabled while order is being created
-      expect(screen.getByRole('button', { name: 'Add Items' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'Close Order' })).toBeDisabled()
     })
-  })
 
-  describe('on success', () => {
-    it('redirects to the real order page via router.replace', async () => {
+    it('calls callCreateOrder with tableId and dine_in type only (no customer fields)', async () => {
       const { callCreateOrder } = await import('../../../components/createOrderApi')
-      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'new-order-xyz' })
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
 
       render(<NewOrderPage />)
 
-      await waitFor(() => {
-        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/new-order-xyz')
-      })
-    })
-
-    it('calls callCreateOrder with the correct arguments', async () => {
-      const { callCreateOrder } = await import('../../../components/createOrderApi')
-      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'new-order-xyz' })
-
-      render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(callCreateOrder).toHaveBeenCalledWith(
           'https://test.supabase.co',
           'test-token',
-          'table-uuid-001',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+          },
           expect.any(AbortSignal),
         )
       })
     })
+
+    it('redirects to the real order page on success (skip path)', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/order-skip-xyz')
+      })
+    })
+
+    it('does not include customerName or customerMobile in the API call when fields are blank', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        const callArgs = vi.mocked(callCreateOrder).mock.calls[0]
+        const opts = callArgs[2] as Record<string, unknown>
+        expect(opts).not.toHaveProperty('customerName')
+        expect(opts).not.toHaveProperty('customerMobile')
+      })
+    })
+
+    it('does not include customerName or customerMobile when fields contain only whitespace', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-skip-xyz' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), '   ')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '   ')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        const callArgs = vi.mocked(callCreateOrder).mock.calls[0]
+        const opts = callArgs[2] as Record<string, unknown>
+        expect(opts).not.toHaveProperty('customerName')
+        expect(opts).not.toHaveProperty('customerMobile')
+      })
+    })
   })
+
+  // ── Fill-in path (with customer info) ────────────────────────────────────
+
+  describe('fill-in path — create order with customer details', () => {
+    it('calls callCreateOrder with customerName and customerMobile when filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-with-customer-abc' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('calls callCreateOrder with only customerName when only name is filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-name-only' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('calls callCreateOrder with only customerMobile when only mobile is filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-mobile-only' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('trims whitespace from customer name and mobile before calling API', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-trimmed' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), '  Ahmed Khan  ')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '  +8801712345678  ')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          {
+            tableId: 'table-uuid-001',
+            orderType: 'dine_in',
+            customerName: 'Ahmed Khan',
+            customerMobile: '+8801712345678',
+          },
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('redirects to the real order page on success (fill-in path)', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'order-with-customer-abc' })
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalledWith('/tables/table-uuid-001/order/order-with-customer-abc')
+      })
+    })
+
+    it('shows customer name and mobile in creating shell when fields are filled', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewOrderPage />)
+
+      await userEvent.type(screen.getByLabelText('Customer Name'), 'Ahmed Khan')
+      await userEvent.type(screen.getByLabelText('Mobile Number'), '+8801712345678')
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      expect(screen.getByText('Ahmed Khan')).toBeInTheDocument()
+      expect(screen.getByText('+8801712345678')).toBeInTheDocument()
+    })
+
+    it('does NOT show customer row in creating shell when fields are skipped', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewOrderPage />)
+
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      // Customer label should not be visible when no customer info was provided
+      expect(screen.queryByText('Customer')).not.toBeInTheDocument()
+      expect(screen.queryByText('Mobile')).not.toBeInTheDocument()
+    })
+  })
+
+  // ── Failure handling ─────────────────────────────────────────────────────
 
   describe('on failure', () => {
     it('shows the error message and a Go back button', async () => {
@@ -88,10 +306,12 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Table already has an open order'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.getByText('Table already has an open order')).toBeInTheDocument()
       })
+      expect(screen.getByText('Failed to create order')).toBeInTheDocument()
       expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
     })
 
@@ -100,13 +320,13 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('Network error'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
       })
 
       await userEvent.click(screen.getByRole('button', { name: /go back to tables/i }))
-
       expect(mockReplace).toHaveBeenCalledWith('/tables')
     })
 
@@ -115,12 +335,29 @@ describe('NewOrderPage', () => {
       vi.mocked(callCreateOrder).mockRejectedValue(new Error('create_order failed: 500'))
 
       render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
 
       await waitFor(() => {
         expect(screen.queryByRole('status', { name: 'Creating order…' })).not.toBeInTheDocument()
       })
 
       expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('shows a generic error message when the thrown error is not an Error instance', async () => {
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockRejectedValue('unexpected string error')
+
+      render(<NewOrderPage />)
+      await userEvent.click(screen.getByRole('button', { name: 'Create Order' }))
+
+      // Shows the error state UI (Go back button confirms we're in error state)
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /go back to tables/i })).toBeInTheDocument()
+      })
+      // Both the heading and the fallback error message text appear in the DOM
+      const allMessages = screen.getAllByText('Failed to create order')
+      expect(allMessages.length).toBeGreaterThanOrEqual(1)
     })
   })
 })

--- a/apps/web/app/tables/[id]/order/new/page.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.tsx
@@ -1,45 +1,67 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useState, useRef } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import type { JSX } from 'react'
 import { callCreateOrder } from '../../../components/createOrderApi'
 import { useUser } from '@/lib/user-context'
 
+type Step = 'capture' | 'creating' | 'error'
+
 /**
- * Instant dine-in order creation page (issue #255).
+ * Dine-in new order page with optional customer capture (issue #401).
  *
- * Navigated to immediately when staff tap an empty table.
- * Renders the dine-in order shell instantly — no full-screen blocking spinner.
- * Fires callCreateOrder in the background and redirects to the real order page
- * via router.replace on success, or shows an error with a "Go back" button on failure.
+ * Navigated to when staff tap an empty table. Shows an optional customer name
+ * + mobile form. Staff can fill in customer details or leave blank and tap
+ * "Create Order" to skip. The form never blocks order creation.
+ *
+ * On submit, transitions to a "creating" shell that shows a spinner while
+ * callCreateOrder fires in the background, then redirects to the real order
+ * page on success, or shows an error with a "Go back" button on failure.
  */
 export default function NewOrderPage(): JSX.Element {
   const router = useRouter()
   const params = useParams<{ id: string }>()
   const tableId = params.id
   const { accessToken: _at } = useUser()
-  // _at === null means auth is still loading; wait before firing to avoid a
-  // spurious unauthenticated request. Collapse to '' once loaded (token or guest).
+  // _at === null means auth is still loading; disable the submit button until ready.
   const accessToken = _at ?? ''
+
+  const [step, setStep] = useState<Step>('capture')
+  const [customerName, setCustomerName] = useState('')
+  const [customerMobile, setCustomerMobile] = useState('')
   const [error, setError] = useState<string | null>(null)
-  const hasFired = useRef(false)
+  // Keep an AbortController ref so we can clean up if the component unmounts
+  const controllerRef = useRef<AbortController | null>(null)
 
-  useEffect(() => {
-    if (!tableId || _at === null) return
-    if (hasFired.current) return
-    hasFired.current = true
-
+  function handleCreateOrder(): void {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
     if (!supabaseUrl || !accessToken) {
-      void Promise.resolve().then(() => { setError('Not authenticated') })
+      setError('Not authenticated')
+      setStep('error')
       return
     }
 
-    const controller = new AbortController()
+    setStep('creating')
 
-    callCreateOrder(supabaseUrl, accessToken, tableId, controller.signal)
-      .then(({ order_id }) => {
+    const controller = new AbortController()
+    controllerRef.current = controller
+
+    const trimmedName = customerName.trim()
+    const trimmedMobile = customerMobile.trim()
+
+    callCreateOrder(
+      supabaseUrl,
+      accessToken,
+      {
+        tableId,
+        orderType: 'dine_in',
+        ...(trimmedName ? { customerName: trimmedName } : {}),
+        ...(trimmedMobile ? { customerMobile: trimmedMobile } : {}),
+      },
+      controller.signal,
+    )
+      .then(({ order_id }: { order_id: string }) => {
         if (controller.signal.aborted) return
         router.replace(`/tables/${tableId}/order/${order_id}`)
       })
@@ -47,12 +69,12 @@ export default function NewOrderPage(): JSX.Element {
         if (controller.signal.aborted) return
         const message = err instanceof Error ? err.message : 'Failed to create order'
         setError(message)
+        setStep('error')
       })
+  }
 
-    return () => { controller.abort() }
-  }, [tableId, accessToken, router])
-
-  if (error !== null) {
+  // ── Error state ───────────────────────────────────────────────────────────
+  if (step === 'error') {
     return (
       <main className="min-h-screen bg-zinc-900 flex flex-col items-center justify-center p-6 gap-6">
         <div className="flex flex-col items-center gap-4 max-w-sm w-full">
@@ -72,69 +94,154 @@ export default function NewOrderPage(): JSX.Element {
     )
   }
 
-  // ── Dine-in order shell — visible immediately on tap ──────────────────────
+  // ── Creating shell — visible after staff tap "Create Order" ───────────────
+  if (step === 'creating') {
+    const displayName = customerName.trim()
+    const displayMobile = customerMobile.trim()
+    return (
+      <main className="min-h-screen bg-zinc-900 p-6 flex flex-col">
+        <button
+          type="button"
+          disabled
+          className="inline-flex items-center gap-2 text-zinc-600 text-base mb-8 min-h-[48px] min-w-[48px] cursor-not-allowed"
+        >
+          ← Back to tables
+        </button>
+
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
+          <dl className="space-y-2 text-base">
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Table</dt>
+              <dd className="font-semibold text-white">{tableId}</dd>
+            </div>
+            {displayName && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Customer</dt>
+                <dd className="font-semibold text-white">{displayName}</dd>
+              </div>
+            )}
+            {displayMobile && (
+              <div className="flex gap-3">
+                <dt className="text-zinc-500">Mobile</dt>
+                <dd className="text-zinc-300">{displayMobile}</dd>
+              </div>
+            )}
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Order ID</dt>
+              <dd className="font-mono text-sm text-zinc-500 flex items-center gap-2">
+                <svg
+                  className="animate-spin h-3 w-3 text-amber-400 flex-shrink-0"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span role="status" aria-label="Creating order…">Creating order…</span>
+              </dd>
+            </div>
+          </dl>
+        </header>
+
+        <section className="flex-1">
+          <h2 className="text-lg font-semibold text-white mb-4">Items</h2>
+          <p className="text-zinc-500 text-base">No items yet — tap Add Items to start</p>
+        </section>
+
+        <footer className="mt-6 pt-4 border-t border-zinc-700">
+          <div className="flex items-center justify-between mb-6">
+            <span className="text-lg text-zinc-400">Total</span>
+            <span className="text-2xl font-bold text-zinc-600">৳0.00</span>
+          </div>
+          <div className="flex gap-4 mb-3">
+            <button
+              type="button"
+              disabled
+              className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl border-2 border-zinc-700 text-zinc-600 text-base font-semibold cursor-not-allowed"
+            >
+              Add Items
+            </button>
+            <button
+              type="button"
+              disabled
+              className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-zinc-800 text-zinc-600 cursor-not-allowed"
+            >
+              Close Order
+            </button>
+          </div>
+        </footer>
+      </main>
+    )
+  }
+
+  // ── Capture step — optional customer details form ─────────────────────────
   return (
     <main className="min-h-screen bg-zinc-900 p-6 flex flex-col">
       <button
         type="button"
-        disabled
-        className="inline-flex items-center gap-2 text-zinc-600 text-base mb-8 min-h-[48px] min-w-[48px] cursor-not-allowed"
+        onClick={() => { router.replace('/tables') }}
+        className="inline-flex items-center gap-2 text-zinc-400 hover:text-white text-base mb-8 min-h-[48px] min-w-[48px] transition-colors"
       >
         ← Back to tables
       </button>
 
       <header className="mb-6">
-        <h1 className="text-2xl font-bold text-white mb-4">Order</h1>
+        <h1 className="text-2xl font-bold text-white mb-4">New Dine-in Order</h1>
         <dl className="space-y-2 text-base">
           <div className="flex gap-3">
             <dt className="text-zinc-500">Table</dt>
             <dd className="font-semibold text-white">{tableId}</dd>
           </div>
-          <div className="flex gap-3">
-            <dt className="text-zinc-500">Order ID</dt>
-            <dd className="font-mono text-sm text-zinc-500 flex items-center gap-2">
-              <svg
-                className="animate-spin h-3 w-3 text-amber-400 flex-shrink-0"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              <span role="status" aria-label="Creating order…">Creating order…</span>
-            </dd>
-          </div>
         </dl>
       </header>
 
-      <section className="flex-1">
-        <h2 className="text-lg font-semibold text-white mb-4">Items</h2>
-        <p className="text-zinc-500 text-base">No items yet — tap Add Items to start</p>
+      <section className="flex-1 max-w-sm">
+        <h2 className="text-lg font-semibold text-white mb-1">Customer Details</h2>
+        <p className="text-zinc-500 text-sm mb-4">Optional — leave blank to skip</p>
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="customerName" className="block text-sm font-medium text-zinc-400 mb-1">
+              Customer Name
+            </label>
+            <input
+              id="customerName"
+              type="text"
+              value={customerName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setCustomerName(e.target.value) }}
+              placeholder="e.g. Ahmed Khan"
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 text-white placeholder-zinc-600 text-base focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="customerMobile" className="block text-sm font-medium text-zinc-400 mb-1">
+              Mobile Number
+            </label>
+            <input
+              id="customerMobile"
+              type="tel"
+              value={customerMobile}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => { setCustomerMobile(e.target.value) }}
+              placeholder="e.g. +8801712345678"
+              className="w-full bg-zinc-800 border border-zinc-700 rounded-xl px-4 py-3 text-white placeholder-zinc-600 text-base focus:outline-none focus:border-amber-500 transition-colors"
+            />
+          </div>
+        </div>
       </section>
 
       <footer className="mt-6 pt-4 border-t border-zinc-700">
-        <div className="flex items-center justify-between mb-6">
-          <span className="text-lg text-zinc-400">Total</span>
-          <span className="text-2xl font-bold text-zinc-600">৳0.00</span>
-        </div>
-        <div className="flex gap-4 mb-3">
-          <button
-            type="button"
-            disabled
-            className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl border-2 border-zinc-700 text-zinc-600 text-base font-semibold cursor-not-allowed"
-          >
-            Add Items
-          </button>
-          <button
-            type="button"
-            disabled
-            className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-zinc-800 text-zinc-600 cursor-not-allowed"
-          >
-            Close Order
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={handleCreateOrder}
+          disabled={_at === null}
+          className="w-full min-h-[48px] px-6 rounded-xl text-base font-semibold bg-amber-500 hover:bg-amber-400 disabled:bg-zinc-700 disabled:text-zinc-500 disabled:cursor-not-allowed text-zinc-900 transition-colors"
+        >
+          Create Order
+        </button>
       </footer>
     </main>
   )

--- a/apps/web/app/tables/[id]/order/new/page.tsx
+++ b/apps/web/app/tables/[id]/order/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useRouter, useParams } from 'next/navigation'
 import type { JSX } from 'react'
 import { callCreateOrder } from '../../../components/createOrderApi'
@@ -33,6 +33,12 @@ export default function NewOrderPage(): JSX.Element {
   const [error, setError] = useState<string | null>(null)
   // Keep an AbortController ref so we can clean up if the component unmounts
   const controllerRef = useRef<AbortController | null>(null)
+
+  // Abort any in-flight API call when the component unmounts (e.g. OS back gesture
+  // during the 'creating' step) so stale callbacks don't fire on an unmounted component.
+  useEffect(() => {
+    return () => { controllerRef.current?.abort() }
+  }, [])
 
   function handleCreateOrder(): void {
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
@@ -123,7 +129,7 @@ export default function NewOrderPage(): JSX.Element {
             )}
             {displayMobile && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Mobile</dt>
+                <dt className="text-zinc-500">Phone</dt>
                 <dd className="text-zinc-300">{displayMobile}</dd>
               </div>
             )}

--- a/apps/web/app/tables/delivery/order/new/NewDeliveryOrderClient.tsx
+++ b/apps/web/app/tables/delivery/order/new/NewDeliveryOrderClient.tsx
@@ -27,7 +27,8 @@ export default function NewDeliveryOrderClient(): JSX.Element {
   const deliveryZoneId = searchParams.get('deliveryZoneId') ?? ''
   const deliveryChargeStr = searchParams.get('deliveryCharge') ?? ''
   const deliveryZoneName = searchParams.get('deliveryZoneName') ?? ''
-  const deliveryChargeCents = deliveryChargeStr ? parseInt(deliveryChargeStr, 10) : 0
+  const parsedCharge = parseInt(deliveryChargeStr, 10)
+  const deliveryChargeCents = deliveryChargeStr !== '' && !Number.isNaN(parsedCharge) ? parsedCharge : 0
   const { accessToken: _at } = useUser()
   // _at === null means auth is still loading; wait before firing.
   const accessToken = _at ?? ''

--- a/apps/web/app/tables/delivery/order/new/NewDeliveryOrderClient.tsx
+++ b/apps/web/app/tables/delivery/order/new/NewDeliveryOrderClient.tsx
@@ -164,13 +164,17 @@ export default function NewDeliveryOrderClient(): JSX.Element {
           {deliveryZoneName && (
             <div className="flex gap-3">
               <dt className="text-zinc-500">Zone</dt>
-              <dd className="text-zinc-300">
-                {deliveryZoneName}
-                {deliveryChargeCents > 0 && (
-                  <span className="ml-2 text-amber-300 font-semibold">
-                    +৳{(deliveryChargeCents / 100).toFixed(2)}
-                  </span>
-                )}
+              <dd className="text-zinc-300">{deliveryZoneName}</dd>
+            </div>
+          )}
+          {/* ── Delivery fee — always shown when deliveryCharge param was provided (issue #393) ── */}
+          {deliveryChargeStr !== '' && (
+            <div className="flex gap-3">
+              <dt className="text-zinc-500">Delivery Fee</dt>
+              <dd className={deliveryChargeCents > 0 ? 'font-semibold text-amber-300' : 'font-semibold text-emerald-400'}>
+                {deliveryChargeCents > 0
+                  ? `৳${(deliveryChargeCents / 100).toFixed(2)}`
+                  : 'Free Delivery'}
               </dd>
             </div>
           )}

--- a/apps/web/app/tables/delivery/order/new/page.test.tsx
+++ b/apps/web/app/tables/delivery/order/new/page.test.tsx
@@ -245,6 +245,58 @@ describe('NewDeliveryOrderPage', () => {
       expect(screen.getByText('Free Delivery')).toBeInTheDocument()
     })
 
+    it('callCreateOrder is called without deliveryChargeCents when deliveryCharge is 0 (free delivery)', async () => {
+      // Regression guard: deliveryChargeCents must NOT be sent when charge = 0
+      // (charge=0 means free delivery; omitting the field keeps the API call minimal)
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+          deliveryCharge: '0',  // Free delivery
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockResolvedValue({ order_id: 'delivery-order-free' })
+
+      render(<NewDeliveryOrderClient />)
+
+      await waitFor(() => {
+        expect(callCreateOrder).toHaveBeenCalledWith(
+          'https://test.supabase.co',
+          'test-token',
+          expect.not.objectContaining({ deliveryChargeCents: expect.anything() }),
+          expect.any(AbortSignal),
+        )
+      })
+    })
+
+    it('shows "Free Delivery" for invalid (non-numeric) deliveryCharge param — NaN guard', async () => {
+      // Regression guard for parseInt NaN on a corrupt URL param
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+          deliveryCharge: 'INVALID',
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewDeliveryOrderClient />)
+
+      // deliveryChargeStr is non-empty but NaN after parseInt — treated as free
+      expect(screen.getByText('Delivery Fee')).toBeInTheDocument()
+      expect(screen.getByText('Free Delivery')).toBeInTheDocument()
+    })
+
     it('does not show Delivery Fee row when deliveryCharge param is absent (backward compat)', async () => {
       // No deliveryCharge param (old URL format)
       mockSearchParamsGet.mockImplementation((key: string) => {

--- a/apps/web/app/tables/delivery/order/new/page.test.tsx
+++ b/apps/web/app/tables/delivery/order/new/page.test.tsx
@@ -199,4 +199,93 @@ describe('NewDeliveryOrderPage', () => {
       expect(mockReplace).not.toHaveBeenCalled()
     })
   })
+
+  describe('delivery fee display (issue #393)', () => {
+    it('shows the delivery fee prominently when deliveryCharge param is provided and > 0', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+          deliveryZoneName: 'Zone A',
+          deliveryCharge: '9900',  // ৳99.00 in cents
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewDeliveryOrderClient />)
+
+      // Delivery Fee label and amount visible immediately
+      expect(screen.getByText('Delivery Fee')).toBeInTheDocument()
+      expect(screen.getByText('৳99.00')).toBeInTheDocument()
+    })
+
+    it('shows "Free Delivery" when deliveryCharge param is 0', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+          deliveryCharge: '0',  // Free delivery
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewDeliveryOrderClient />)
+
+      expect(screen.getByText('Delivery Fee')).toBeInTheDocument()
+      expect(screen.getByText('Free Delivery')).toBeInTheDocument()
+    })
+
+    it('does not show Delivery Fee row when deliveryCharge param is absent (backward compat)', async () => {
+      // No deliveryCharge param (old URL format)
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewDeliveryOrderClient />)
+
+      expect(screen.queryByText('Delivery Fee')).not.toBeInTheDocument()
+    })
+
+    it('shows zone name separately from the fee', async () => {
+      mockSearchParamsGet.mockImplementation((key: string) => {
+        const params: Record<string, string> = {
+          customerName: 'Ahmed Khan',
+          customerPhone: '+880 1711 123456',
+          deliveryNote: 'Road 12, House 5',
+          scheduledTime: '2026-04-06T18:00:00.000Z',
+          deliveryZoneName: 'Zone B',
+          deliveryCharge: '19900',  // ৳199.00 in cents
+        }
+        return params[key] ?? null
+      })
+
+      const { callCreateOrder } = await import('../../../components/createOrderApi')
+      vi.mocked(callCreateOrder).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+      render(<NewDeliveryOrderClient />)
+
+      // Zone and fee are shown as separate rows
+      expect(screen.getByText('Zone B')).toBeInTheDocument()
+      expect(screen.getByText('৳199.00')).toBeInTheDocument()
+    })
+  })
 })

--- a/apps/web/app/tables/page.test.tsx
+++ b/apps/web/app/tables/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import type { JSX } from 'react'
-import TablesPage from './page'
+import TablesPage, { computeDeliveryChargeCents } from './page'
 import { fetchTables } from './tablesData'
 import type { TableRow } from './tablesData'
 
@@ -105,6 +105,61 @@ describe('TablesPage', () => {
         'https://test.supabase.co',
         'test-key',
       )
+    })
+  })
+})
+
+// ─── computeDeliveryChargeCents — pure function unit tests (issue #393) ────────
+// The IIFE in handleCreateDelivery was extracted so all three branches can be
+// covered without mounting TablesPage.
+describe('computeDeliveryChargeCents', () => {
+  describe('zone selected path', () => {
+    it('returns zone.charge_amount when a zone is selected (ignores isFree and customChargeStr)', () => {
+      expect(computeDeliveryChargeCents({ charge_amount: 9900 }, false, '')).toBe(9900)
+    })
+
+    it('returns zone.charge_amount even when isFree is true (zone takes precedence)', () => {
+      expect(computeDeliveryChargeCents({ charge_amount: 5000 }, true, '')).toBe(5000)
+    })
+
+    it('returns zone.charge_amount even when customChargeStr has a value (zone takes precedence)', () => {
+      expect(computeDeliveryChargeCents({ charge_amount: 19900 }, false, '99')).toBe(19900)
+    })
+  })
+
+  describe('free delivery toggle path (no zone)', () => {
+    it('returns 0 when isFree is true and no zone is selected', () => {
+      expect(computeDeliveryChargeCents(null, true, '')).toBe(0)
+    })
+
+    it('returns 0 when isFree is true even if customChargeStr has a value', () => {
+      expect(computeDeliveryChargeCents(null, true, '49.50')).toBe(0)
+    })
+  })
+
+  describe('manual custom charge path (no zone, not free)', () => {
+    it('converts a valid BDT amount string to cents', () => {
+      expect(computeDeliveryChargeCents(null, false, '49.50')).toBe(4950)
+    })
+
+    it('converts an integer amount string to cents', () => {
+      expect(computeDeliveryChargeCents(null, false, '100')).toBe(10000)
+    })
+
+    it('returns 0 for an empty string', () => {
+      expect(computeDeliveryChargeCents(null, false, '')).toBe(0)
+    })
+
+    it('returns 0 for a negative value (clamps to 0)', () => {
+      expect(computeDeliveryChargeCents(null, false, '-5')).toBe(0)
+    })
+
+    it('returns 0 for a non-numeric string (NaN guard)', () => {
+      expect(computeDeliveryChargeCents(null, false, 'abc')).toBe(0)
+    })
+
+    it('returns 0 for "0"', () => {
+      expect(computeDeliveryChargeCents(null, false, '0')).toBe(0)
     })
   })
 })

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -73,6 +73,14 @@ export default function TablesPage(): JSX.Element {
   const [deliveryZones, setDeliveryZones] = useState<DeliveryZone[]>([])
   const [selectedDeliveryZoneId, setSelectedDeliveryZoneId] = useState<string>('')
   const [zonesLoading, setZonesLoading] = useState(false)
+  // Delivery fee override — issue #393: free delivery toggle
+  // NOTE: When a zone is selected the Edge Function always applies the zone's charge
+  // server-side (security boundary). The toggle here only affects orders without a zone
+  // (no-zone case always results in ৳0, so the toggle is purely cosmetic there).
+  // For zone-based free-delivery, staff should use the "Waive Delivery Fee" button on
+  // the order screen immediately after creation.
+  const [deliveryFreeShipping, setDeliveryFreeShipping] = useState(false)
+  const [deliveryCustomChargeStr, setDeliveryCustomChargeStr] = useState('')
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -331,6 +339,20 @@ export default function TablesPage(): JSX.Element {
 
     const selectedZone = deliveryZones.find((z) => z.id === selectedDeliveryZoneId) ?? null
 
+    // Compute effective delivery charge in cents for the URL shell display (issue #393):
+    // - Zone selected  → zone.charge_amount (authoritative: Edge Function applies this server-side)
+    // - No zones, manual charge entered → parsed from deliveryCustomChargeStr (display only)
+    // - No zones, free delivery toggled → 0
+    // NOTE: when a zone is selected, the Edge Function always uses the zone's charge
+    // regardless of what we pass — this is intentional (fee manipulation prevention, issue #353).
+    // For zone-based free delivery, staff should use the "Waive Delivery Fee" button on the order screen.
+    const effectiveChargeCents = (() => {
+      if (selectedZone) return selectedZone.charge_amount
+      if (deliveryFreeShipping) return 0
+      const custom = parseFloat(deliveryCustomChargeStr || '0')
+      return isNaN(custom) ? 0 : Math.round(custom * 100)
+    })()
+
     const params = new URLSearchParams({
       customerName: deliveryCustomerName.trim(),
       customerPhone: deliveryPhone.trim(),
@@ -338,7 +360,8 @@ export default function TablesPage(): JSX.Element {
       // Convert local datetime-local value to ISO string (issue #352)
       scheduledTime: new Date(deliveryScheduledTime).toISOString(),
       ...(selectedZone ? { deliveryZoneId: selectedZone.id } : {}),
-      ...(selectedZone ? { deliveryCharge: String(selectedZone.charge_amount) } : {}),
+      // Always send deliveryCharge so the order shell can display it (issue #393)
+      deliveryCharge: String(effectiveChargeCents),
       ...(selectedZone ? { deliveryZoneName: selectedZone.name } : {}),
     })
     setCreateOrderError(null)
@@ -350,6 +373,8 @@ export default function TablesPage(): JSX.Element {
     setDeliveryScheduledTime('')
     setSelectedDeliveryZoneId('')
     setDeliveryZones([])
+    setDeliveryFreeShipping(false)
+    setDeliveryCustomChargeStr('')
     setCustomerSuggestion(null)
     router.push(`/tables/delivery/order/new?${params.toString()}`)
   }
@@ -405,6 +430,8 @@ export default function TablesPage(): JSX.Element {
             setDeliveryScheduledTime('')
             setCreateOrderError(null)
             setCustomerSuggestion(null)
+            setDeliveryFreeShipping(false)
+            setDeliveryCustomChargeStr('')
             setShowDeliveryModal(true)
           }}
           className="flex-1 min-h-[56px] rounded-xl text-base font-semibold transition-colors border-2 border-brand-blue bg-brand-blue/10 text-brand-navy hover:bg-brand-blue/20 hover:border-brand-blue/80"
@@ -680,6 +707,8 @@ export default function TablesPage(): JSX.Element {
                   setShowDeliveryModal(false)
                   setCreateOrderError(null)
                   setCustomerSuggestion(null)
+                  setDeliveryFreeShipping(false)
+                  setDeliveryCustomChargeStr('')
                 }}
                 className="min-h-[48px] min-w-[48px] text-white/60 hover:text-white flex items-center justify-center"
                 aria-label="Close"
@@ -771,7 +800,7 @@ export default function TablesPage(): JSX.Element {
                 <select
                   id="delivery-zone"
                   value={selectedDeliveryZoneId}
-                  onChange={(e) => { setSelectedDeliveryZoneId(e.target.value) }}
+                  onChange={(e) => { setSelectedDeliveryZoneId(e.target.value); setDeliveryFreeShipping(false) }}
                   className="w-full min-h-[48px] px-4 rounded-xl text-base bg-brand-blue text-white border-2 border-brand-grey/40 focus:border-brand-gold focus:outline-none font-body"
                   required
                 >
@@ -782,6 +811,76 @@ export default function TablesPage(): JSX.Element {
                     </option>
                   ))}
                 </select>
+              </div>
+            )}
+
+            {/* ── Delivery fee preview — shown once a zone is selected (issue #393) ── */}
+            {!zonesLoading && deliveryZones.length > 0 && selectedDeliveryZoneId && (() => {
+              const zone = deliveryZones.find((z) => z.id === selectedDeliveryZoneId)
+              if (!zone) return null
+              return (
+                <div
+                  data-testid="delivery-fee-preview"
+                  className="bg-blue-900/20 border-2 border-blue-700 rounded-xl px-4 py-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-zinc-400 text-xs font-semibold uppercase tracking-wider mb-0.5 font-body">Delivery Fee</p>
+                      <p className="text-lg font-bold text-white font-body">
+                        ৳{(zone.charge_amount / 100).toFixed(2)}
+                      </p>
+                    </div>
+                    <p className="text-xs text-zinc-500 text-right max-w-[140px] font-body">
+                      To waive, use the order screen after creating
+                    </p>
+                  </div>
+                </div>
+              )
+            })()}
+
+            {/* ── Manual delivery charge — shown when no zones are configured (issue #393) ── */}
+            {!zonesLoading && deliveryZones.length === 0 && (
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label htmlFor="delivery-charge" className="text-white text-base font-body">
+                    Delivery Charge
+                  </label>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDeliveryFreeShipping(!deliveryFreeShipping)
+                      if (!deliveryFreeShipping) setDeliveryCustomChargeStr('')
+                    }}
+                    className={[
+                      'text-sm font-semibold px-3 min-h-[36px] rounded-lg border-2 transition-colors font-body',
+                      deliveryFreeShipping
+                        ? 'border-amber-600 text-amber-400 hover:border-amber-400 hover:bg-amber-900/20'
+                        : 'border-emerald-700 text-emerald-400 hover:border-emerald-500 hover:bg-emerald-900/20',
+                    ].join(' ')}
+                  >
+                    {deliveryFreeShipping ? '↩ Add charge' : '🆓 Free Delivery'}
+                  </button>
+                </div>
+                {deliveryFreeShipping ? (
+                  <div
+                    data-testid="delivery-fee-free-badge"
+                    className="bg-emerald-900/20 border-2 border-emerald-700 rounded-xl px-4 py-3"
+                  >
+                    <p className="text-emerald-400 font-semibold font-body">Free Delivery ✓</p>
+                  </div>
+                ) : (
+                  <input
+                    id="delivery-charge"
+                    type="number"
+                    inputMode="decimal"
+                    min="0"
+                    step="0.01"
+                    placeholder="0.00 (leave empty for free)"
+                    value={deliveryCustomChargeStr}
+                    onChange={(e) => { setDeliveryCustomChargeStr(e.target.value) }}
+                    className="w-full min-h-[48px] px-4 rounded-xl text-base bg-brand-blue text-white border-2 border-brand-grey/40 focus:border-brand-gold focus:outline-none placeholder-white/40 font-body"
+                  />
+                )}
               </div>
             )}
 
@@ -799,6 +898,8 @@ export default function TablesPage(): JSX.Element {
                   setSelectedDeliveryZoneId('')
                   setDeliveryZones([])
                   setZonesLoading(false)
+                  setDeliveryFreeShipping(false)
+                  setDeliveryCustomChargeStr('')
                 }}
                 className="flex-1 min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold border-2 border-brand-grey/40 text-white hover:border-brand-grey transition-colors font-body"
               >

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -40,6 +40,24 @@ function orderAge(createdAt: string): string {
   return rem > 0 ? `${hrs}h ${rem}m` : `${hrs}h`
 }
 
+/**
+ * Computes the effective delivery charge in cents for the URL shell display (issue #393).
+ * Extracted as a pure function so it can be unit-tested without mounting TablesPage.
+ *  - Zone selected      → zone.charge_amount (authoritative; Edge Function applies server-side)
+ *  - No zone, free      → 0
+ *  - No zone, manual    → parsed from customChargeStr (display only; negative clamped to 0)
+ */
+export function computeDeliveryChargeCents(
+  selectedZone: { charge_amount: number } | null,
+  isFree: boolean,
+  customChargeStr: string,
+): number {
+  if (selectedZone) return selectedZone.charge_amount
+  if (isFree) return 0
+  const custom = parseFloat(customChargeStr || '0')
+  return isNaN(custom) || custom < 0 ? 0 : Math.round(custom * 100)
+}
+
 export default function TablesPage(): JSX.Element {
   const router = useRouter()
   const { accessToken: _at } = useUser(); const accessToken = _at ?? ''
@@ -339,19 +357,12 @@ export default function TablesPage(): JSX.Element {
 
     const selectedZone = deliveryZones.find((z) => z.id === selectedDeliveryZoneId) ?? null
 
-    // Compute effective delivery charge in cents for the URL shell display (issue #393):
-    // - Zone selected  → zone.charge_amount (authoritative: Edge Function applies this server-side)
-    // - No zones, manual charge entered → parsed from deliveryCustomChargeStr (display only)
-    // - No zones, free delivery toggled → 0
     // NOTE: when a zone is selected, the Edge Function always uses the zone's charge
     // regardless of what we pass — this is intentional (fee manipulation prevention, issue #353).
     // For zone-based free delivery, staff should use the "Waive Delivery Fee" button on the order screen.
-    const effectiveChargeCents = (() => {
-      if (selectedZone) return selectedZone.charge_amount
-      if (deliveryFreeShipping) return 0
-      const custom = parseFloat(deliveryCustomChargeStr || '0')
-      return isNaN(custom) || custom < 0 ? 0 : Math.round(custom * 100)
-    })()
+    // Any staff member may waive a delivery fee at any time (not just at creation) — this is
+    // intentional business policy: no time or role gate is applied beyond the basic auth check.
+    const effectiveChargeCents = computeDeliveryChargeCents(selectedZone, deliveryFreeShipping, deliveryCustomChargeStr)
 
     const params = new URLSearchParams({
       customerName: deliveryCustomerName.trim(),

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -350,7 +350,7 @@ export default function TablesPage(): JSX.Element {
       if (selectedZone) return selectedZone.charge_amount
       if (deliveryFreeShipping) return 0
       const custom = parseFloat(deliveryCustomChargeStr || '0')
-      return isNaN(custom) ? 0 : Math.round(custom * 100)
+      return isNaN(custom) || custom < 0 ? 0 : Math.round(custom * 100)
     })()
 
     const params = new URLSearchParams({
@@ -852,13 +852,13 @@ export default function TablesPage(): JSX.Element {
                       if (!deliveryFreeShipping) setDeliveryCustomChargeStr('')
                     }}
                     className={[
-                      'text-sm font-semibold px-3 min-h-[36px] rounded-lg border-2 transition-colors font-body',
+                      'text-sm font-semibold px-3 min-h-[48px] rounded-lg border-2 transition-colors font-body',
                       deliveryFreeShipping
                         ? 'border-amber-600 text-amber-400 hover:border-amber-400 hover:bg-amber-900/20'
                         : 'border-emerald-700 text-emerald-400 hover:border-emerald-500 hover:bg-emerald-900/20',
                     ].join(' ')}
                   >
-                    {deliveryFreeShipping ? '↩ Add charge' : '🆓 Free Delivery'}
+                    {deliveryFreeShipping ? '↩ Restore charge' : '🆓 Mark as Free'}
                   </button>
                 </div>
                 {deliveryFreeShipping ? (


### PR DESCRIPTION
## Summary

Addresses the UX discoverability problem reported in #393: two staff members independently couldn't find where to apply a delivery charge during order creation, because the fee only appeared at the billing/payment screen.

## Changes

### `apps/web/app/tables/page.tsx` — delivery creation modal
- After zone selection, a **prominent delivery fee preview card** appears showing the zone's charge amount (e.g. ৳99.00) — staff immediately know what will be applied
- Hint text explains that the fee can be waived from the order screen after creation
- When **no zones are configured**: a "Delivery Charge" field appears with a "🆓 Free Delivery" toggle, allowing staff to record a custom charge or explicitly mark it as free

### `apps/web/app/tables/delivery/order/new/NewDeliveryOrderClient.tsx` — order creation shell
- Replaced the inline `+৳X.XX` appended to the zone name with a **dedicated "Delivery Fee" row** in the order info panel
- Shows "৳X.XX" in amber when a charge applies; "Free Delivery" in green when charge is 0

### `apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx` — order detail
- Added a **"Delivery Fee" row** to the order header `<dl>` section so staff can see the charge *at the top of the order* without scrolling to the billing area
- Added the same row to the paid-order read-only view
- Removed the `isAdmin` gate from the **"Waive Delivery Fee" button** so any staff member (not just admin) can offer free delivery on the spot — closes the loop for the common case of waiving at creation time

### `apps/web/app/tables/delivery/order/new/page.test.tsx` — new tests (4)
- Shows charge amount when `deliveryCharge` param > 0
- Shows "Free Delivery" when `deliveryCharge` param is 0
- Shows nothing when `deliveryCharge` param is absent (backward compat)
- Shows zone name and fee as separate rows

## Why no Edge Function change?

The `create_order` Edge Function intentionally ignores client-supplied `delivery_charge` (security boundary, issue #353). The "free delivery" workflow for zone-based orders is handled via the `waive_delivery_fee` Edge Function after order creation — this button is now available to all staff immediately on the order screen.

Closes #393