### PR TITLE
feat(#394): allow adding items to dine-in order after bill has been generated

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -2054,6 +2054,36 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
       })
     })
 
+    it('does NOT show "Add More Items" button for takeaway orders', async (): Promise<void> => {
+      const { fetchOrderSummary } = await import('./orderData')
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'open',
+        payment_method: null,
+        order_type: 'takeaway',
+        customer_name: null, delivery_note: null, customer_mobile: null,
+        bill_number: null, reservation_id: null, customer_id: null,
+        order_number: null, scheduled_time: null, delivery_zone_name: null,
+        delivery_zone_id: null, delivery_charge: 0, merge_label: null,
+        payment_lines: [],
+      })
+      const { callCloseOrder } = await import('./closeOrderApi')
+      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+
+      render(<OrderDetailClient tableId="takeaway" orderId="order-takeaway" />)
+
+      await waitFor((): void => {
+        expect(screen.queryByText('Loading items…')).not.toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /Close Order/i }))
+      await waitFor((): void => { expect(screen.getByText('Bill Preview')).toBeInTheDocument() })
+      fireEvent.click(screen.getByRole('button', { name: /Proceed to Payment/i }))
+      await waitFor((): void => { expect(screen.getByText('Record Payment')).toBeInTheDocument() })
+
+      // Add More Items button should NOT appear for takeaway
+      expect(screen.queryByRole('button', { name: /Add More Items/i })).not.toBeInTheDocument()
+    })
+
     it('shows error message when reopen fails', async (): Promise<void> => {
       const { callCloseOrder } = await import('./closeOrderApi')
       vi.mocked(callCloseOrder).mockResolvedValue(undefined)

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -74,6 +74,10 @@ vi.mock('./updateQuantityApi', () => ({
   updateOrderItemQuantity: vi.fn().mockResolvedValue(undefined),
 }))
 
+vi.mock('./reopenOrderForItemsApi', () => ({
+  callReopenOrderForItems: vi.fn(),
+}))
+
 vi.mock('@/lib/fetchVatConfig', () => ({
   fetchOrderVatContext: vi.fn().mockResolvedValue({ restaurantId: 'rest-1', menuId: null }),
   fetchVatConfig: vi.fn().mockResolvedValue({ vatPercent: 15, taxInclusive: false }),
@@ -1964,6 +1968,114 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
     // Success screen shows payment breakdown and change given
     expect(screen.getByText('Payment breakdown')).toBeInTheDocument()
     expect(screen.getByText('Change given')).toBeInTheDocument()
+  })
+
+  describe('Add More Items after billing (issue #394)', () => {
+    it('shows "Add More Items" button in payment step for dine-in orders', async (): Promise<void> => {
+      const { callCloseOrder } = await import('./closeOrderApi')
+      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+
+      render(<OrderDetailClient tableId="5" orderId="order-billed" />)
+
+      await waitFor((): void => {
+        expect(screen.queryByText('Loading items…')).not.toBeInTheDocument()
+      })
+
+      // Go to bill preview
+      fireEvent.click(screen.getByRole('button', { name: /Close Order/i }))
+      await waitFor((): void => {
+        expect(screen.getByText('Bill Preview')).toBeInTheDocument()
+      })
+
+      // Proceed to payment (transitions order to pending_payment)
+      fireEvent.click(screen.getByRole('button', { name: /Proceed to Payment/i }))
+      await waitFor((): void => {
+        expect(screen.getByText('Record Payment')).toBeInTheDocument()
+      })
+
+      // "Add More Items" button should be visible for dine-in
+      expect(screen.getByRole('button', { name: /Add More Items/i })).toBeInTheDocument()
+    })
+
+    it('calls callReopenOrderForItems and transitions back to order step when "Add More Items" clicked', async (): Promise<void> => {
+      const { useUser } = await import('@/lib/user-context')
+      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'server', loading: false })
+      const { callCloseOrder } = await import('./closeOrderApi')
+      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
+      vi.mocked(callReopenOrderForItems).mockResolvedValue(undefined)
+
+      render(<OrderDetailClient tableId="5" orderId="order-billed-2" />)
+
+      await waitFor((): void => {
+        expect(screen.queryByText('Loading items…')).not.toBeInTheDocument()
+      })
+
+      // Go to bill preview and payment
+      fireEvent.click(screen.getByRole('button', { name: /Close Order/i }))
+      await waitFor((): void => { expect(screen.getByText('Bill Preview')).toBeInTheDocument() })
+      fireEvent.click(screen.getByRole('button', { name: /Proceed to Payment/i }))
+      await waitFor((): void => { expect(screen.getByText('Record Payment')).toBeInTheDocument() })
+
+      // Click "Add More Items"
+      fireEvent.click(screen.getByRole('button', { name: /Add More Items/i }))
+      await waitFor((): void => {
+        expect(vi.mocked(callReopenOrderForItems)).toHaveBeenCalledWith(
+          'https://example.supabase.co',
+          'test-token',
+          'order-billed-2',
+        )
+      })
+
+      // Should return to order step
+      await waitFor((): void => {
+        expect(screen.getByRole('link', { name: /Add Items/i })).toBeInTheDocument()
+      })
+    })
+
+    it('shows post-bill mode banner after reopening order', async (): Promise<void> => {
+      const { fetchOrderSummary } = await import('./orderData')
+      vi.mocked(fetchOrderSummary).mockResolvedValue({
+        status: 'open',
+        payment_method: null,
+        order_type: 'dine_in',
+        customer_name: null, delivery_note: null, customer_mobile: null,
+        bill_number: null, reservation_id: null, customer_id: null,
+        order_number: null, scheduled_time: null, delivery_zone_name: null,
+        delivery_zone_id: null, delivery_charge: 0, merge_label: null,
+        payment_lines: [],
+        post_bill_mode: true,
+      })
+
+      render(<OrderDetailClient tableId="5" orderId="order-postbill" />)
+
+      await waitFor((): void => {
+        expect(screen.getByText(/Post-bill addition/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows error message when reopen fails', async (): Promise<void> => {
+      const { callCloseOrder } = await import('./closeOrderApi')
+      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
+      vi.mocked(callReopenOrderForItems).mockRejectedValue(new Error('Insufficient permissions'))
+
+      render(<OrderDetailClient tableId="5" orderId="order-reopen-fail" />)
+
+      await waitFor((): void => {
+        expect(screen.queryByText('Loading items…')).not.toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByRole('button', { name: /Close Order/i }))
+      await waitFor((): void => { expect(screen.getByText('Bill Preview')).toBeInTheDocument() })
+      fireEvent.click(screen.getByRole('button', { name: /Proceed to Payment/i }))
+      await waitFor((): void => { expect(screen.getByText('Record Payment')).toBeInTheDocument() })
+
+      fireEvent.click(screen.getByRole('button', { name: /Add More Items/i }))
+      await waitFor((): void => {
+        expect(screen.getByText('Insufficient permissions')).toBeInTheDocument()
+      })
+    })
   })
 
   it('paid order header shows per-method breakdown when paidPaymentLines are populated (issue #391)', async (): Promise<void> => {

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -8,6 +8,7 @@ import { fetchOrderItems, fetchOrderSummary, calcItemDiscountCents } from './ord
 import type { OrderItem, CourseType, PaymentLine } from './orderData'
 import { callCloseOrder } from './closeOrderApi'
 import { callMarkOrderDue } from './markOrderDueApi'
+import { callReopenOrderForItems } from './reopenOrderForItemsApi'
 import { callRecordSplitPayment } from './recordPaymentApi'
 import type { SplitPaymentEntry } from './recordPaymentApi'
 import { callVoidItem } from './voidItemApi'
@@ -222,6 +223,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [printingBill, setPrintingBill] = useState(false)
   // Pre-payment bill print state (issue #370) — true while printing a "DUE BILL" before payment
   const [printingPreBill, setPrintingPreBill] = useState(false)
+  // Post-bill mode (issue #394) — true when order was reopened after bill was generated
+  const [postBillMode, setPostBillMode] = useState(false)
+  const [reopeningForItems, setReopeningForItems] = useState(false)
+  const [reopenForItemsError, setReopenForItemsError] = useState<string | null>(null)
   // Mark-as-Due state (issue #370) — dine-in only
   const [orderIsDue, setOrderIsDue] = useState(false)
   const [markingDue, setMarkingDue] = useState(false)
@@ -364,6 +369,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           setSplitEntryError(null)
           setStep('payment')
         }
+        // Track post-bill mode (issue #394) — order was reopened for item additions after billing
+        setPostBillMode(summary.post_bill_mode ?? false)
         setOrderType(summary.order_type)
         setOrderCustomerName(summary.customer_name)
         setOrderDeliveryNote(summary.delivery_note)
@@ -1113,6 +1120,30 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       setMarkDueError(err instanceof Error ? err.message : 'Failed to mark order as due')
     } finally {
       setMarkingDue(false)
+    }
+  }
+
+  /**
+   * Reopen a billed dine-in order so additional items can be added (issue #394).
+   * Transitions pending_payment → open with post_bill_mode = true.
+   * The bill is automatically voided; close_order will regenerate it with the new items.
+   * Access: server+ (enforced by the edge function).
+   */
+  async function handleReopenForItems(): Promise<void> {
+    setReopenForItemsError(null)
+    setReopeningForItems(true)
+    try {
+      const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+      if (!supabaseUrl || !accessToken) throw new Error('Not authenticated')
+      await callReopenOrderForItems(supabaseUrl, accessToken, orderId)
+      setPostBillMode(true)
+      // Reload items (in case any new items were already added in a prior session)
+      loadItems()
+      setStep('order')
+    } catch (err) {
+      setReopenForItemsError(err instanceof Error ? err.message : 'Failed to reopen order for items')
+    } finally {
+      setReopeningForItems(false)
     }
   }
 
@@ -3705,6 +3736,14 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               </div>
             )}
 
+            {/* Post-bill mode banner — visible after order was reopened for item additions (issue #394) */}
+            {postBillMode && orderType === 'dine_in' && (
+              <div className="mb-3 flex items-center gap-2 bg-violet-900/30 border border-violet-600 rounded-xl px-4 py-2">
+                <span className="text-violet-400 font-bold text-sm">+</span>
+                <span className="text-violet-300 text-sm font-medium">Post-bill addition — add items, then close order to regenerate bill</span>
+              </div>
+            )}
+
             <div className="flex gap-4 mb-3">
               <Link
                 href={`/tables/${tableId}/order/${orderId}/menu`}
@@ -4150,6 +4189,28 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             >
               <span className="inline-flex items-center gap-1"><Scissors size={16} aria-hidden="true" />Split Bill</span>
             </button>
+
+            {/* Add More Items — dine-in only (issue #394): void bill, reopen order, add items */}
+            {orderType === 'dine_in' && (
+              <div className="space-y-1">
+                <button
+                  type="button"
+                  onClick={() => { void handleReopenForItems() }}
+                  disabled={reopeningForItems}
+                  className={[
+                    'w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors border-2',
+                    reopeningForItems
+                      ? 'border-zinc-700 text-zinc-500 cursor-wait'
+                      : 'border-violet-700 text-violet-400 hover:border-violet-500 hover:bg-violet-900/20',
+                  ].join(' ')}
+                >
+                  {reopeningForItems ? 'Reopening…' : '+ Add More Items'}
+                </button>
+                {reopenForItemsError !== null && (
+                  <p className="text-xs text-red-400">{reopenForItemsError}</p>
+                )}
+              </div>
+            )}
 
             <button
               type="button"

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.test.ts
@@ -41,6 +41,7 @@ function expectedSummary(overrides: object = {}): object {
     delivery_zone_name: null,
     delivery_charge: 0,
     merge_label: null,
+    post_bill_mode: false,
     ...overrides,
   }
 }

--- a/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/orderData.ts
@@ -96,6 +96,12 @@ export interface OrderSummary {
    * E.g. "Table 3 + Table 4". Null when not merged.
    */
   merge_label: string | null
+  /**
+   * True when the order has been reopened for post-bill item additions (issue #394).
+   * Set by reopen_order_for_items edge function; cleared when order is next closed.
+   * Optional: defaults to false when absent (existing orders without the column or mocks).
+   */
+  post_bill_mode?: boolean
 }
 
 interface OrderItemRow {
@@ -239,7 +245,7 @@ export async function fetchOrderSummary(
 
   const orderUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
   orderUrl.searchParams.set('id', `eq.${orderId}`)
-  orderUrl.searchParams.set('select', 'status,order_type,customer_name,delivery_note,customer_mobile,bill_number,reservation_id,customer_id,order_number,scheduled_time,delivery_zone_id,delivery_charge,merge_label,delivery_zones(name)')
+  orderUrl.searchParams.set('select', 'status,order_type,customer_name,delivery_note,customer_mobile,bill_number,reservation_id,customer_id,order_number,scheduled_time,delivery_zone_id,delivery_charge,merge_label,post_bill_mode,delivery_zones(name)')
 
   const orderRes = await fetch(orderUrl.toString(), { headers })
   if (!orderRes.ok) {
@@ -261,6 +267,7 @@ export async function fetchOrderSummary(
     delivery_zone_id: string | null
     delivery_charge: number | null
     merge_label: string | null
+    post_bill_mode: boolean | null
     delivery_zones: { name: string } | null
   }>
   if (orders.length === 0) {
@@ -281,6 +288,7 @@ export async function fetchOrderSummary(
   const deliveryZoneName = orders[0].delivery_zones?.name ?? null
   const deliveryCharge = orders[0].delivery_charge ?? 0
   const mergeLabel = orders[0].merge_label ?? null
+  const postBillMode = orders[0].post_bill_mode ?? false
 
   if (status !== 'paid') {
     return {
@@ -300,6 +308,7 @@ export async function fetchOrderSummary(
       delivery_zone_name: deliveryZoneName,
       delivery_charge: deliveryCharge,
       merge_label: mergeLabel,
+      post_bill_mode: postBillMode,
     }
   }
 
@@ -328,6 +337,7 @@ export async function fetchOrderSummary(
       delivery_zone_name: deliveryZoneName,
       delivery_charge: deliveryCharge,
       merge_label: mergeLabel,
+      post_bill_mode: postBillMode,
     }
   }
 
@@ -355,5 +365,6 @@ export async function fetchOrderSummary(
     delivery_zone_name: deliveryZoneName,
     delivery_charge: deliveryCharge,
     merge_label: mergeLabel,
+    post_bill_mode: postBillMode,
   }
 }

--- a/apps/web/app/tables/[id]/order/[order_id]/reopenOrderForItemsApi.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/reopenOrderForItemsApi.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { callReopenOrderForItems } from './reopenOrderForItemsApi'
+
+describe('callReopenOrderForItems', () => {
+  beforeEach((): void => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it('calls the reopen_order_for_items endpoint with the correct payload', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean; data: { status: string } }> =>
+        Promise.resolve({ success: true, data: { status: 'open' } }),
+    } as Response)
+
+    await callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.supabase.co/functions/v1/reopen_order_for_items',
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ order_id: 'order-123' }),
+      }),
+    )
+  })
+
+  it('sends the Authorization header with Bearer token', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean }> => Promise.resolve({ success: true }),
+    } as Response)
+
+    await callReopenOrderForItems('https://example.supabase.co', 'my-api-key', 'order-456')
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-api-key',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    )
+  })
+
+  it('throws with the API error message when success is false', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean; error: string }> =>
+        Promise.resolve({ success: false, error: 'Order cannot be reopened: status is \'open\'' }),
+    } as Response)
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('Order cannot be reopened')
+  })
+
+  it('throws a fallback message when success is false and no error field is present', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean }> => Promise.resolve({ success: false }),
+    } as Response)
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('Failed to reopen order for items')
+  })
+
+  it('propagates a network error when fetch itself throws', async (): Promise<void> => {
+    vi.mocked(fetch).mockRejectedValue(new Error('Network request failed'))
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('Network request failed')
+  })
+
+  it('throws on a non-2xx HTTP response with error in body', async (): Promise<void> => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: (): Promise<{ success: boolean; error: string }> =>
+        Promise.resolve({ success: false, error: 'Insufficient permissions' }),
+    } as Response)
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('Insufficient permissions')
+  })
+
+  it('throws HTTP status fallback message on non-2xx with non-JSON body', async (): Promise<void> => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: (): Promise<never> => Promise.reject(new Error('not json')),
+    } as Response)
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('HTTP 500')
+  })
+
+  it('throws HTTP 409 error message for wrong-status orders', async (): Promise<void> => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: (): Promise<{ success: boolean; error: string }> =>
+        Promise.resolve({ success: false, error: 'Order cannot be reopened: status is \'paid\'' }),
+    } as Response)
+
+    await expect(
+      callReopenOrderForItems('https://example.supabase.co', 'test-key', 'order-123'),
+    ).rejects.toThrow('Order cannot be reopened')
+  })
+})

--- a/apps/web/app/tables/[id]/order/[order_id]/reopenOrderForItemsApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/reopenOrderForItemsApi.ts
@@ -1,0 +1,34 @@
+/**
+ * API client for the reopen_order_for_items edge function (issue #394).
+ * Transitions a billed dine-in order from 'pending_payment' → 'open'
+ * so that additional items can be added after the bill has been generated.
+ * Sets post_bill_mode = true on the order so new items are flagged as post-bill additions.
+ * Access: server+ only (viewers cannot perform this action).
+ * Throws if the request fails or the server returns success: false.
+ */
+
+export async function callReopenOrderForItems(
+  supabaseUrl: string,
+  accessToken: string,
+  orderId: string,
+): Promise<void> {
+  const res = await fetch(`${supabaseUrl}/functions/v1/reopen_order_for_items`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ order_id: orderId }),
+  })
+  if (!res.ok) {
+    let errMsg = `HTTP ${res.status}`
+    try {
+      errMsg = ((await res.json()) as { error?: string }).error ?? errMsg
+    } catch { /* ignore non-JSON error bodies */ }
+    throw new Error(errMsg)
+  }
+  const json = (await res.json()) as { success: boolean; error?: string }
+  if (!json.success) {
+    throw new Error(json.error ?? 'Failed to reopen order for items')
+  }
+}

--- a/apps/web/e2e/bill-print.spec.ts
+++ b/apps/web/e2e/bill-print.spec.ts
@@ -185,7 +185,7 @@ test.describe('Print Bill button', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳30.00), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click();
     await page.getByRole('spinbutton').fill('30');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
     await expect(page.getByText('Payment recorded — order closed')).toBeVisible();
 

--- a/apps/web/e2e/payment-completion.spec.ts
+++ b/apps/web/e2e/payment-completion.spec.ts
@@ -159,7 +159,7 @@ test.describe('post-payment completion flow', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳12.00), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click();
     await page.getByRole('spinbutton').fill('12');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     // Success state must appear (no change due screen for exact card payment)
@@ -190,7 +190,7 @@ test.describe('post-payment completion flow', () => {
 
     // Cash is default; enter tendered amount (bill = ৳12.00, pay ৳15.00 for change)
     await page.getByRole('spinbutton').fill('15.00');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     // Change due screen

--- a/apps/web/e2e/payment.spec.ts
+++ b/apps/web/e2e/payment.spec.ts
@@ -175,7 +175,7 @@ test.describe('payment flow', () => {
 
     // Cash is the default method; enter tendered amount (total = ৳350, we pay ৳370)
     await page.getByRole('spinbutton').fill('370');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     // Change due screen (change_due = 2000 cents = ৳20.00)
@@ -211,7 +211,7 @@ test.describe('payment flow', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳350), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click();
     await page.getByRole('spinbutton').fill('350');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     // No change due step — goes directly to success

--- a/apps/web/e2e/print-bill.spec.ts
+++ b/apps/web/e2e/print-bill.spec.ts
@@ -180,7 +180,7 @@ test.describe('Print Bill flow', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳450.00), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click();
     await page.getByRole('spinbutton').fill('450');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     await expect(page.getByText('Payment recorded — order closed')).toBeVisible();
@@ -232,7 +232,7 @@ test.describe('Print Bill flow', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳450.00), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click();
     await page.getByRole('spinbutton').fill('450');
-    await page.getByRole('button', { name: 'Add' }).click();
+    await page.getByRole('button', { name: 'Add', exact: true }).click();
     await page.getByRole('button', { name: /Confirm Payment/ }).click();
 
     await expect(page.getByText('Payment recorded — order closed')).toBeVisible();

--- a/apps/web/e2e/split-payment.spec.ts
+++ b/apps/web/e2e/split-payment.spec.ts
@@ -146,7 +146,7 @@ test.describe('split payment builder', () => {
     await page.getByRole('button', { name: 'Card' }).click();
     const amountInput = page.getByRole('spinbutton');
     await amountInput.fill('800');
-    await page.getByRole('button', { name: /Add/ }).click();
+    await page.getByRole('button', { name: /^Add$/ }).click();
 
     // Confirm should still be disabled (only ৳800 of ৳1300 covered)
     const confirmBtn = page.getByRole('button', { name: /Confirm Payment/ });
@@ -155,7 +155,7 @@ test.describe('split payment builder', () => {
     // Add mobile portion: ৳500 (no cash = no change-due step)
     await page.getByRole('button', { name: 'Mobile' }).click();
     await amountInput.fill('500');
-    await page.getByRole('button', { name: /Add/ }).click();
+    await page.getByRole('button', { name: /^Add$/ }).click();
 
     // Now total = ৳1300 = bill total → confirm enabled
     await expect(confirmBtn).toBeEnabled();
@@ -191,12 +191,12 @@ test.describe('split payment builder', () => {
     await page.getByRole('button', { name: 'Card' }).click();
     const amountInput = page.getByRole('spinbutton');
     await amountInput.fill('800');
-    await page.getByRole('button', { name: /Add/ }).click();
+    await page.getByRole('button', { name: /^Add$/ }).click();
 
     // Add cash: ৳700 (over-tender by ৳200)
     await page.getByRole('button', { name: 'Cash' }).click();
     await amountInput.fill('700');
-    await page.getByRole('button', { name: /Add/ }).click();
+    await page.getByRole('button', { name: /^Add$/ }).click();
 
     // Confirm should be enabled (total ৳1500 >= ৳1300)
     const confirmBtn = page.getByRole('button', { name: /Confirm Payment/ });
@@ -228,7 +228,7 @@ test.describe('split payment builder', () => {
     await page.getByRole('button', { name: 'Card' }).click();
     const amountInput = page.getByRole('spinbutton');
     await amountInput.fill('500');
-    await page.getByRole('button', { name: /Add/ }).click();
+    await page.getByRole('button', { name: /^Add$/ }).click();
 
     // Still disabled — only ৳500 of ৳1300 covered
     await expect(confirmBtn).toBeDisabled();

--- a/apps/web/e2e/void-payment-bill.spec.ts
+++ b/apps/web/e2e/void-payment-bill.spec.ts
@@ -286,7 +286,7 @@ test.describe('void item, payment, and bill print flows', () => {
     // Cash method should be default — enter tendered amount, add, then confirm
     // Total is 35000 cents = ৳350, change_due is 2000 cents = ৳20
     await page.getByRole('spinbutton').fill('370')
-    await page.getByRole('button', { name: 'Add' }).click()
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
     await page.getByRole('button', { name: /Confirm Payment/ }).click()
 
     // Change due screen
@@ -350,7 +350,7 @@ test.describe('void item, payment, and bill print flows', () => {
     // Split payment builder: select Card, enter full amount (bill = ৳350), add, then confirm
     await page.getByRole('button', { name: 'Card' }).click()
     await page.getByRole('spinbutton').fill('350')
-    await page.getByRole('button', { name: 'Add' }).click()
+    await page.getByRole('button', { name: 'Add', exact: true }).click()
     await page.getByRole('button', { name: /Confirm Payment/ }).click()
 
     // Success state

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -491,6 +491,9 @@ verify_jwt = false
 [functions.mark_order_due]
 verify_jwt = false
 
+[functions.reopen_order_for_items]
+verify_jwt = false
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/supabase/functions/add_item_to_order/index.ts
+++ b/supabase/functions/add_item_to_order/index.ts
@@ -2,7 +2,7 @@ import { verifyAndGetCaller } from '../_shared/auth.ts'
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-demo-staff-id',
   'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
 }
 
@@ -234,7 +234,12 @@ export async function handler(
           {
             method: 'PATCH',
             headers: { ...dbHeaders, Prefer: 'return=minimal' },
-            body: JSON.stringify({ quantity: existing.quantity + 1 }),
+            body: JSON.stringify({
+              quantity: existing.quantity + 1,
+              // Preserve post_bill_addition flag: if order is in post_bill_mode and the existing
+              // item was not previously a post-bill addition, mark it now (issue #394)
+              ...(isPostBillAddition ? { post_bill_addition: true } : {}),
+            }),
           },
         )
         if (!patchRes.ok) {
@@ -257,6 +262,7 @@ export async function handler(
               unit_price_cents: priceCents,
               quantity: 1,
               course,
+              post_bill_addition: isPostBillAddition,
             }),
           },
         )

--- a/supabase/functions/add_item_to_order/index.ts
+++ b/supabase/functions/add_item_to_order/index.ts
@@ -142,7 +142,7 @@ export async function handler(
 
     // 2. Verify order exists and is open
     const orderRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?select=status&id=eq.${orderId}`,
+      `${supabaseUrl}/rest/v1/orders?select=status,post_bill_mode&id=eq.${orderId}`,
       { headers: dbHeaders },
     )
     if (!orderRes.ok) {
@@ -151,7 +151,7 @@ export async function handler(
         { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
-    const orders = (await orderRes.json()) as Array<{ status: string }>
+    const orders = (await orderRes.json()) as Array<{ status: string; post_bill_mode: boolean }>
     if (orders.length === 0) {
       return new Response(
         JSON.stringify({ success: false, error: 'Order not found' }),
@@ -164,6 +164,8 @@ export async function handler(
         { status: 409, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
+    // Track whether this item is being added after a bill was already generated (issue #394)
+    const isPostBillAddition = orders[0].post_bill_mode === true
 
     let orderItemId: string
 
@@ -198,6 +200,7 @@ export async function handler(
             quantity: 1,
             modifier_ids: modifierIds,
             course,
+            post_bill_addition: isPostBillAddition,
           }),
         },
       )

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -312,10 +312,12 @@ export async function handler(
     }
 
     // 4b. Update order status to pending_payment and persist final_total_cents + service_charge_cents + bill_number
+    // Also reset post_bill_mode to false (issue #394) — the bill has been regenerated, banner should clear
     const orderUpdatePayload: Record<string, unknown> = {
       status: 'pending_payment',
       final_total_cents: finalTotal,
       service_charge_cents: serviceChargeCents,
+      post_bill_mode: false,
     }
     if (billNumber) {
       orderUpdatePayload['bill_number'] = billNumber

--- a/supabase/functions/reopen_order_for_items/index.test.ts
+++ b/supabase/functions/reopen_order_for_items/index.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handler, corsHeaders } from './index'
+import type { FetchFn, HandlerEnv } from './index'
+
+const TEST_ENV: HandlerEnv = {
+  supabaseUrl: 'http://test-supabase.local',
+  serviceKey: 'test-service-key',
+}
+
+const VALID_ORDER_ID = '11111111-1111-1111-1111-111111111111'
+const RESTAURANT_ID = '22222222-2222-2222-2222-222222222222'
+const ACTOR_ID = '33333333-3333-3333-3333-333333333333'
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/functions/v1/reopen_order_for_items', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-jwt',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function buildMockFetch(orderStatus: string): FetchFn {
+  return vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+    if (url.includes('/auth/v1/user')) {
+      return new Response(JSON.stringify({ id: ACTOR_ID }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/users')) {
+      return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'server' }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/orders') && (!init?.method || init.method === 'GET')) {
+      return new Response(
+        JSON.stringify([{
+          id: VALID_ORDER_ID,
+          restaurant_id: RESTAURANT_ID,
+          status: orderStatus,
+          order_type: 'dine_in',
+        }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+    if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
+      return new Response(null, { status: 204 })
+    }
+    if (url.includes('/rest/v1/audit_log') && init?.method === 'POST') {
+      return new Response(null, { status: 201 })
+    }
+    return new Response(JSON.stringify({}), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as FetchFn
+}
+
+describe('reopen_order_for_items handler', () => {
+  describe('OPTIONS preflight', () => {
+    it('returns 204 with CORS headers', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/reopen_order_for_items', {
+        method: 'OPTIONS',
+      })
+      const res = await handler(req, fetch, TEST_ENV)
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe(corsHeaders['Access-Control-Allow-Origin'])
+    })
+  })
+
+  describe('POST — validation', () => {
+    it('returns 400 when body is malformed JSON', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/reopen_order_for_items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+        body: 'not-json',
+      })
+      const res = await handler(req, buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Invalid request body')
+    })
+
+    it('returns 400 when order_id is missing', async (): Promise<void> => {
+      const res = await handler(makeRequest({}), buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('order_id is required')
+    })
+
+    it('returns 400 when order_id is not a valid UUID', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: 'not-a-uuid' }), buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('order_id must be a valid UUID')
+    })
+
+    it('returns 400 when order_id is an empty string', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: '' }), buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+    })
+  })
+
+  describe('POST — happy path', () => {
+    it('returns 200 with status open for a pending_payment order', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: { status: string } }
+      expect(json.success).toBe(true)
+      expect(json.data.status).toBe('open')
+    })
+
+    it('patches the order with post_bill_mode=true and clears bill fields', async (): Promise<void> => {
+      const mockFetch = buildMockFetch('pending_payment')
+      await handler(makeRequest({ order_id: VALID_ORDER_ID }), mockFetch, TEST_ENV)
+
+      const calls = vi.mocked(mockFetch).mock.calls
+      const patchCall = calls.find(([url, init]) =>
+        url.includes('/rest/v1/orders') && init?.method === 'PATCH',
+      )
+      expect(patchCall).toBeDefined()
+      const patchBody = JSON.parse(patchCall![1]?.body as string) as Record<string, unknown>
+      expect(patchBody.status).toBe('open')
+      expect(patchBody.post_bill_mode).toBe(true)
+      expect(patchBody.final_total_cents).toBeNull()
+      expect(patchBody.service_charge_cents).toBeNull()
+      expect(patchBody.bill_number).toBeNull()
+    })
+
+    it('writes an audit log entry for the reopen action', async (): Promise<void> => {
+      const mockFetch = buildMockFetch('pending_payment')
+      await handler(makeRequest({ order_id: VALID_ORDER_ID }), mockFetch, TEST_ENV)
+
+      const calls = vi.mocked(mockFetch).mock.calls
+      const auditCall = calls.find(([url, init]) =>
+        url.includes('/rest/v1/audit_log') && init?.method === 'POST',
+      )
+      expect(auditCall).toBeDefined()
+      const auditBody = JSON.parse(auditCall![1]?.body as string) as Record<string, unknown>
+      expect(auditBody.action).toBe('reopen_order_for_items')
+      expect(auditBody.entity_id).toBe(VALID_ORDER_ID)
+    })
+
+    it('is idempotent — returns 200 when order is already open', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('open'), TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: { status: string } }
+      expect(json.success).toBe(true)
+      expect(json.data.status).toBe('open')
+    })
+  })
+
+  describe('POST — error cases', () => {
+    it('returns 409 when order is already paid', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('paid'), TEST_ENV)
+      expect(res.status).toBe(409)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toContain('pending_payment')
+    })
+
+    it('returns 409 when order is open but already in normal flow', async (): Promise<void> => {
+      // Already-open is handled as idempotent 200 per the handler logic
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('open'), TEST_ENV)
+      expect(res.status).toBe(200)
+    })
+
+    it('returns 409 when order is cancelled', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('cancelled'), TEST_ENV)
+      expect(res.status).toBe(409)
+    })
+
+    it('returns 500 when env is null', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), fetch, null)
+      expect(res.status).toBe(500)
+    })
+
+    it('returns 401 when no Authorization header is provided', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/reopen_order_for_items', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ order_id: VALID_ORDER_ID }),
+      })
+      const res = await handler(req, buildMockFetch('pending_payment'), TEST_ENV)
+      expect(res.status).toBe(401)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+    })
+  })
+
+  describe('POST — order not found', () => {
+    it('returns 404 when order does not exist', async (): Promise<void> => {
+      const emptyOrderFetch: FetchFn = vi.fn(async (url: string): Promise<Response> => {
+        if (url.includes('/auth/v1/user')) {
+          return new Response(JSON.stringify({ id: ACTOR_ID }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        if (url.includes('/rest/v1/users')) {
+          return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'server' }]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        if (url.includes('/rest/v1/orders')) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          })
+        }
+        return new Response(null, { status: 200 })
+      }) as FetchFn
+
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), emptyOrderFetch, TEST_ENV)
+      expect(res.status).toBe(404)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toBe('Order not found')
+    })
+  })
+})

--- a/supabase/functions/reopen_order_for_items/index.test.ts
+++ b/supabase/functions/reopen_order_for_items/index.test.ts
@@ -22,7 +22,7 @@ function makeRequest(body: unknown): Request {
   })
 }
 
-function buildMockFetch(orderStatus: string): FetchFn {
+function buildMockFetch(orderStatus: string, orderType = 'dine_in'): FetchFn {
   return vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
     if (url.includes('/auth/v1/user')) {
       return new Response(JSON.stringify({ id: ACTOR_ID }), {
@@ -42,7 +42,7 @@ function buildMockFetch(orderStatus: string): FetchFn {
           id: VALID_ORDER_ID,
           restaurant_id: RESTAURANT_ID,
           status: orderStatus,
-          order_type: 'dine_in',
+          order_type: orderType,
         }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       )
@@ -168,7 +168,7 @@ describe('reopen_order_for_items handler', () => {
       expect(json.error).toContain('pending_payment')
     })
 
-    it('returns 409 when order is open but already in normal flow', async (): Promise<void> => {
+    it('returns 409 when order is open but already in normal flow (idempotent 200)', async (): Promise<void> => {
       // Already-open is handled as idempotent 200 per the handler logic
       const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('open'), TEST_ENV)
       expect(res.status).toBe(200)
@@ -176,6 +176,19 @@ describe('reopen_order_for_items handler', () => {
 
     it('returns 409 when order is cancelled', async (): Promise<void> => {
       const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('cancelled'), TEST_ENV)
+      expect(res.status).toBe(409)
+    })
+
+    it('returns 409 when order_type is not dine_in (takeaway)', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('pending_payment', 'takeaway'), TEST_ENV)
+      expect(res.status).toBe(409)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toContain('dine-in')
+    })
+
+    it('returns 409 when order_type is delivery', async (): Promise<void> => {
+      const res = await handler(makeRequest({ order_id: VALID_ORDER_ID }), buildMockFetch('pending_payment', 'delivery'), TEST_ENV)
       expect(res.status).toBe(409)
     })
 

--- a/supabase/functions/reopen_order_for_items/index.ts
+++ b/supabase/functions/reopen_order_for_items/index.ts
@@ -1,0 +1,211 @@
+/**
+ * reopen_order_for_items — transitions a billed dine-in order back to 'open'
+ * so that additional items can be added after the bill has been generated.
+ *
+ * Issue #394 — Allow adding items to a dine-in order after the bill has been generated.
+ *
+ * Flow:
+ *   pending_payment → open (post_bill_mode = true)
+ *
+ * The existing bill data (bill_number, final_total_cents, service_charge_cents) is
+ * cleared so that close_order will regenerate a fresh bill including all new items.
+ *
+ * Access: server+ (viewers cannot perform this action).
+ */
+import { verifyAndGetCaller } from '../_shared/auth.ts'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-demo-staff-id',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+function isValidUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  // Require server+ role — viewers may not add items post-bill
+  const caller = await verifyAndGetCaller(req, env.supabaseUrl, env.serviceKey, 'server', fetchFn)
+  if ('error' in caller) {
+    return new Response(
+      JSON.stringify({ success: false, error: caller.error }),
+      { status: caller.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  if (typeof payload['order_id'] !== 'string' || payload['order_id'] === '') {
+    return new Response(
+      JSON.stringify({ success: false, error: 'order_id is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const orderId = payload['order_id'] as string
+  if (!isValidUuid(orderId)) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'order_id must be a valid UUID' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+    Prefer: 'return=representation',
+  }
+
+  try {
+    // 1. Fetch the order — must be pending_payment
+    const orderRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}&select=id,restaurant_id,status,order_type`,
+      { headers: dbHeaders },
+    )
+    if (!orderRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to fetch order' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    const orders = (await orderRes.json()) as Array<{
+      id: string
+      restaurant_id: string
+      status: string
+      order_type: string | null
+    }>
+
+    if (orders.length === 0) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Order not found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    const order = orders[0]
+
+    // Idempotent: already open and in post_bill_mode — return success
+    if (order.status === 'open') {
+      return new Response(
+        JSON.stringify({ success: true, data: { status: 'open' } }),
+        { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // Only pending_payment orders can be reopened for additions
+    if (order.status !== 'pending_payment') {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          error: `Order cannot be reopened: status is '${order.status}' (expected 'pending_payment')`,
+        }),
+        { status: 409, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 2. Reopen: transition to 'open', set post_bill_mode = true, void the generated bill
+    const updateRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}`,
+      {
+        method: 'PATCH',
+        headers: { ...dbHeaders, Prefer: 'return=minimal' },
+        body: JSON.stringify({
+          status: 'open',
+          post_bill_mode: true,
+          // Clear billed totals so close_order regenerates them with the new items
+          final_total_cents: null,
+          service_charge_cents: null,
+          bill_number: null,
+        }),
+      },
+    )
+    if (!updateRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to reopen order' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    // 3. Audit log (required for destructive / status-change actions — CLAUDE.md section 12)
+    const auditRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/audit_log`,
+      {
+        method: 'POST',
+        headers: { ...dbHeaders, Prefer: 'return=minimal' },
+        body: JSON.stringify({
+          restaurant_id: order.restaurant_id,
+          user_id: caller.actorId,
+          action: 'reopen_order_for_items',
+          entity_type: 'orders',
+          entity_id: orderId,
+          payload: { previous_status: 'pending_payment', new_status: 'open', post_bill_mode: true },
+        }),
+      },
+    )
+    if (!auditRes.ok) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Failed to write audit log' }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data: { status: 'open' } }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+}
+
+if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
+}

--- a/supabase/functions/reopen_order_for_items/index.ts
+++ b/supabase/functions/reopen_order_for_items/index.ts
@@ -128,6 +128,14 @@ export async function handler(
 
     const order = orders[0]
 
+    // Only dine-in orders support post-bill additions
+    if (order.order_type !== 'dine_in') {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Only dine-in orders can be reopened for item additions' }),
+        { status: 409, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+
     // Idempotent: already open and in post_bill_mode — return success
     if (order.status === 'open') {
       return new Response(

--- a/supabase/migrations/20260414000000_add_post_bill_addition.sql
+++ b/supabase/migrations/20260414000000_add_post_bill_addition.sql
@@ -1,0 +1,12 @@
+-- Add post-bill addition tracking (issue #394)
+-- post_bill_addition: marks individual order items added after the bill was generated.
+-- post_bill_mode: flags an order that has been reopened for post-bill additions,
+--   so that add_item_to_order can automatically mark new items as post_bill_addition.
+
+ALTER TABLE order_items ADD COLUMN post_bill_addition boolean NOT NULL DEFAULT false;
+
+ALTER TABLE orders ADD COLUMN post_bill_mode boolean NOT NULL DEFAULT false;
+
+-- Rollback:
+-- ALTER TABLE order_items DROP COLUMN post_bill_addition;
+-- ALTER TABLE orders DROP COLUMN post_bill_mode;


### PR DESCRIPTION
## Summary

Fixes #394 — Allows servers to add items to a dine-in order after the bill has been generated, without voiding the entire order.

## Changes

### Backend (Edge Function)
- **`reopen_order_for_items`** — New Deno edge function that transitions an order from `pending_payment` → `open` with `post_bill_mode = true`. Clears `bill_number`, `final_total_cents`, and `service_charge_cents` so `close_order` regenerates a fresh bill including all new items. Access: server+ (enforced server-side via `verifyAndGetCaller`).
- **`add_item_to_order`** — Already updated (prior session) to automatically set `post_bill_addition = true` on items added when `post_bill_mode` is true.

### Database Migration
- `20260414000000_add_post_bill_addition.sql` — Adds `post_bill_mode boolean` to `orders` and `post_bill_addition boolean` to `order_items`.

### Frontend
- **`reopenOrderForItemsApi.ts`** — API client calling `reopen_order_for_items` edge function.
- **`orderData.ts`** — `fetchOrderSummary` now selects and returns `post_bill_mode`.
- **`OrderDetailClient.tsx`**:
  - When order is in payment step (pending_payment) for dine-in: shows **"+ Add More Items"** button
  - Clicking it calls `reopen_order_for_items`, transitions back to order view
  - Shows a **post-bill mode banner** (violet) when `post_bill_mode` is true so staff know they're adding to a re-opened order
  - After adding items, staff close the order normally → bill is auto-regenerated with new items + KOT sent

## Flow
1. Staff generates bill → order is `pending_payment`, payment step shown
2. Guest requests more items → Staff clicks **"+ Add More Items"**  
3. Edge function transitions order `pending_payment → open` + sets `post_bill_mode = true`
4. Order view shown with purple post-bill banner, new items flagged as `post_bill_addition`
5. Staff adds items via menu, sends KOT normally
6. Staff clicks **"Close Order"** → bill regenerated with all items (old + new)

## Tests
- `reopenOrderForItemsApi.test.ts` — 8 unit tests for the API client
- `reopen_order_for_items/index.test.ts` — 15 unit tests for the edge function (happy path, idempotency, auth, validation, not-found, wrong-status)
- `OrderDetailClient.test.tsx` — 4 new tests: button visibility, happy path, post-bill banner, error handling
- `orderData.test.ts` — Updated `expectedSummary` helper to include `post_bill_mode: false`

## Role Restriction
- **Edge function**: `verifyAndGetCaller(..., 'server')` — blocks unauthenticated requests
- **UI**: Button shown only for `dine_in` orders in the payment step