### PR TITLE
fix: resolve ambiguous FK embed on orders→tables (PGRST201) — Receipts page crash (#407)

### DIFF
--- a/apps/web/app/kitchen/kdsApi.ts
+++ b/apps/web/app/kitchen/kdsApi.ts
@@ -58,7 +58,7 @@ export async function fetchKdsOrders(
   const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
   ordersUrl.searchParams.set(
     'select',
-    'id,created_at,tables(label)',
+    'id,created_at,tables!orders_table_id_fkey(label)',
   )
   ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
   ordersUrl.searchParams.set('kitchen_done_at', 'is.null')

--- a/apps/web/app/receipts/billHistoryApi.ts
+++ b/apps/web/app/receipts/billHistoryApi.ts
@@ -114,7 +114,7 @@ export async function fetchBillHistory(
   const url = new URL(`${supabaseUrl}/rest/v1/orders`)
   url.searchParams.set(
     'select',
-    'id,bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,server_id,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables(label),delivery_zones(name),payments(method,amount_cents,tendered_amount_cents)',
+    'id,bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,server_id,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables!orders_table_id_fkey(label),delivery_zones(name),payments(method,amount_cents,tendered_amount_cents)',
   )
   url.searchParams.set('status', 'eq.paid')
 
@@ -296,7 +296,7 @@ export async function fetchOrderForReprint(
   // Fetch order details + items + payments in parallel
   const [orderRes, itemsRes, paymentsRes] = await Promise.all([
     fetch(
-      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}&select=bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables(label),delivery_zones(name)`,
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}&select=bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables!orders_table_id_fkey(label),delivery_zones(name)`,
       { headers },
     ),
     fetch(

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -1547,7 +1547,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
       // Fetch all open dine_in orders with their table
       const ordersUrl = new URL(`${supabaseUrl}/rest/v1/orders`)
-      ordersUrl.searchParams.set('select', 'id,table_id,tables(id,label,locked_by_order_id)')
+      ordersUrl.searchParams.set('select', 'id,table_id,tables!orders_table_id_fkey(id,label,locked_by_order_id)')
       ordersUrl.searchParams.set('status', 'in.(open,pending_payment)')
       ordersUrl.searchParams.set('order_type', 'eq.dine_in')
       const ordersRes = await fetch(ordersUrl.toString(), {


### PR DESCRIPTION
## Summary

Fixes #407 — Receipts (Bill History) page crashes with PostgREST 300 error due to ambiguous FK relationship between `orders` and `tables`.

## Root Cause

Two FK relationships exist between `orders` and `tables`:
- `tables_locked_by_order_id_fkey` — `orders.id → tables.locked_by_order_id` (one-to-many)
- `orders_table_id_fkey` — `orders.table_id → tables.id` (many-to-one)

PostgREST returns PGRST201 (300) when both exist and no FK hint is given in the embed syntax.

## Fix

Added explicit FK hint `!orders_table_id_fkey` to all three queries that embed `tables` from the `orders` table:

| File | Change |
|------|--------|
| `apps/web/app/receipts/billHistoryApi.ts` | `tables(label)` → `tables!orders_table_id_fkey(label)` (×2 — fetchBillHistory + fetchOrderForReprint) |
| `apps/web/app/kitchen/kdsApi.ts` | `tables(label)` → `tables!orders_table_id_fkey(label)` |
| `apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx` | `tables(id,label,locked_by_order_id)` → `tables!orders_table_id_fkey(id,label,locked_by_order_id)` |

## Testing

The Receipts page should now load without the 300 ambiguity error. The other two files are proactive fixes to prevent the same error surfacing elsewhere.
