### PR TITLE
fix(#408): replace emoji icons with Lucide icons in order action buttons

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -63,6 +63,9 @@ import {
   UserCheck,
   UserPlus,
   Search,
+  Banknote,
+  UserCog,
+  Tag,
 } from 'lucide-react'
 
 const COMP_REASONS = ['VIP', 'Complaint resolution', 'Staff meal', 'Event', 'Other'] as const
@@ -3764,7 +3767,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                       : 'bg-red-700 hover:bg-red-600 text-white',
                 ].join(' ')}
               >
-                {closing ? 'Processing…' : orderIsDue ? '💰 Settle Bill' : 'Close Order'}
+                {closing ? 'Processing…' : orderIsDue ? <span className='inline-flex items-center gap-1'><Banknote size={16} aria-hidden='true' />Settle Bill</span> : 'Close Order'}
               </button>
             </div>
 
@@ -3799,7 +3802,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                       : 'bg-zinc-800 hover:bg-zinc-700 text-orange-400 border-2 border-orange-700 hover:border-orange-500',
                   ].join(' ')}
                 >
-                  {markingDue ? 'Marking…' : '⏳ Mark as Due'}
+                  {markingDue ? 'Marking…' : <span className='inline-flex items-center gap-1'><Clock size={16} aria-hidden='true' />Mark as Due</span>}
                 </button>
                 {markDueError !== null && (
                   <p className="text-xs text-red-400">{markDueError}</p>
@@ -3859,7 +3862,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 onClick={() => { void openReassignModal() }}
                 className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-indigo-400 border-2 border-zinc-700 hover:border-indigo-600 transition-colors mb-3"
               >
-                👤 Reassign Server
+                <span className='inline-flex items-center gap-1'><UserCog size={16} aria-hidden='true' />Reassign Server</span>
               </button>
             )}
 
@@ -3911,7 +3914,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                     ? 'Updating…'
                     : deliveryFeeWaived
                       ? '↩ Restore Delivery Fee'
-                      : '🆓 Waive Delivery Fee'}
+                      : <span className='inline-flex items-center gap-1'><Tag size={16} aria-hidden='true' />Waive Delivery Fee</span>}
                 </button>
                 {waiveDeliveryFeeError !== null && (
                   <p className="text-xs text-red-400">{waiveDeliveryFeeError}</p>

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -11,7 +11,7 @@ import type { TableRow, TakeawayDeliveryOrder } from './tablesData'
 import { getTablesCache, setTablesCache } from '@/lib/tablesCache'
 import type { TableStatus } from './tableStatus'
 import { useUser } from '@/lib/user-context'
-import { ShoppingBag, Bike, X, Clock } from 'lucide-react'
+import { ShoppingBag, Bike, X, Clock, User, Tag } from 'lucide-react'
 import { formatDateTimeShort } from '@/lib/dateFormat'
 
 /** Auto-refresh interval in milliseconds (30 seconds) */
@@ -660,7 +660,7 @@ export default function TablesPage(): JSX.Element {
                   onClick={() => { setTakeawayName(takeawaySuggestion.name); setTakeawaySuggestion(null) }}
                   className="mt-2 w-full text-left px-4 py-2 rounded-xl bg-brand-gold/10 border border-brand-gold/40 text-sm text-brand-gold hover:bg-brand-gold/20 transition-colors font-body"
                 >
-                  👤 Returning customer: <span className="font-semibold">{takeawaySuggestion.name}</span> — tap to fill name
+                  <User size={14} className='inline mr-1' aria-hidden='true' />Returning customer: <span className="font-semibold">{takeawaySuggestion.name}</span> — tap to fill name
                 </button>
               )}
             </div>
@@ -765,7 +765,7 @@ export default function TablesPage(): JSX.Element {
                   }}
                   className="mt-2 w-full text-left px-4 py-2 rounded-xl bg-brand-gold/10 border border-brand-gold/40 text-sm text-brand-gold hover:bg-brand-gold/20 transition-colors font-body"
                 >
-                  👤 Returning customer: <span className="font-semibold">{customerSuggestion.name}</span> — tap to fill name
+                  <User size={14} className='inline mr-1' aria-hidden='true' />Returning customer: <span className="font-semibold">{customerSuggestion.name}</span> — tap to fill name
                 </button>
               )}
             </div>
@@ -869,7 +869,7 @@ export default function TablesPage(): JSX.Element {
                         : 'border-emerald-700 text-emerald-400 hover:border-emerald-500 hover:bg-emerald-900/20',
                     ].join(' ')}
                   >
-                    {deliveryFreeShipping ? '↩ Restore charge' : '🆓 Mark as Free'}
+                    {deliveryFreeShipping ? '↩ Restore charge' : <span className='inline-flex items-center gap-1'><Tag size={16} aria-hidden='true' />Mark as Free</span>}
                   </button>
                 </div>
                 {deliveryFreeShipping ? (

--- a/apps/web/app/tables/page.tsx
+++ b/apps/web/app/tables/page.tsx
@@ -660,7 +660,7 @@ export default function TablesPage(): JSX.Element {
                   onClick={() => { setTakeawayName(takeawaySuggestion.name); setTakeawaySuggestion(null) }}
                   className="mt-2 w-full text-left px-4 py-2 rounded-xl bg-brand-gold/10 border border-brand-gold/40 text-sm text-brand-gold hover:bg-brand-gold/20 transition-colors font-body"
                 >
-                  <User size={14} className='inline mr-1' aria-hidden='true' />Returning customer: <span className="font-semibold">{takeawaySuggestion.name}</span> — tap to fill name
+                  <span className='inline-flex items-center gap-1'><User size={16} aria-hidden='true' />Returning customer: <span className="font-semibold">{takeawaySuggestion.name}</span> — tap to fill name</span>
                 </button>
               )}
             </div>
@@ -765,7 +765,7 @@ export default function TablesPage(): JSX.Element {
                   }}
                   className="mt-2 w-full text-left px-4 py-2 rounded-xl bg-brand-gold/10 border border-brand-gold/40 text-sm text-brand-gold hover:bg-brand-gold/20 transition-colors font-body"
                 >
-                  <User size={14} className='inline mr-1' aria-hidden='true' />Returning customer: <span className="font-semibold">{customerSuggestion.name}</span> — tap to fill name
+                  <span className='inline-flex items-center gap-1'><User size={16} aria-hidden='true' />Returning customer: <span className="font-semibold">{customerSuggestion.name}</span> — tap to fill name</span>
                 </button>
               )}
             </div>

--- a/apps/web/e2e/pre-payment-bill.spec.ts
+++ b/apps/web/e2e/pre-payment-bill.spec.ts
@@ -217,7 +217,7 @@ test.describe('Pre-payment bill (due bill) — issue #370', () => {
     await setupRoutes(page, DINE_IN_ORDER_ID, 'dine_in');
     await page.goto(`/tables/${TABLE_ID}/order/${DINE_IN_ORDER_ID}`);
     await expect(page.getByText('Chicken Karahi', { exact: true }).last()).toBeVisible();
-    await expect(page.getByText('⏳ Mark as Due')).toBeVisible();
+    await expect(page.getByText('Mark as Due')).toBeVisible();
   });
 
   test('shows "Print Bill (DUE)" button on takeaway order', async ({ page }) => {
@@ -231,7 +231,7 @@ test.describe('Pre-payment bill (due bill) — issue #370', () => {
     await setupRoutes(page, TAKEAWAY_ORDER_ID, 'takeaway');
     await page.goto(`/tables/${TABLE_ID}/order/${TAKEAWAY_ORDER_ID}`);
     await expect(page.getByText('Chicken Karahi', { exact: true }).last()).toBeVisible();
-    await expect(page.getByText('⏳ Mark as Due')).not.toBeVisible();
+    await expect(page.getByText('Mark as Due')).not.toBeVisible();
   });
 
   test('does NOT show "Print Bill (DUE)" on delivery order', async ({ page }) => {

--- a/apps/web/e2e/pre-payment-bill.spec.ts
+++ b/apps/web/e2e/pre-payment-bill.spec.ts
@@ -247,10 +247,10 @@ test.describe('Pre-payment bill (due bill) — issue #370', () => {
     await expect(page.getByText('Chicken Karahi', { exact: true }).last()).toBeVisible();
 
     // Click Mark as Due
-    await page.getByText('⏳ Mark as Due').click();
+    await page.getByText('Mark as Due').click();
 
     // BILL DUE status badge should appear and Close Order should become Settle Bill
     await expect(page.getByText(/BILL DUE/)).toBeVisible();
-    await expect(page.getByText('💰 Settle Bill')).toBeVisible();
+    await expect(page.getByText('Settle Bill')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Closes #408

Replaces all emoji characters used as UI icons in order action buttons with proper Lucide React SVG icons, consistent with the rest of the app.

## Changes

### `OrderDetailClient.tsx`
| Before | After | Icon |
|--------|-------|------|
| 💰 Settle Bill | Settle Bill | `Banknote` |
| ⏳ Mark as Due | Mark as Due | `Clock` (already imported) |
| 👤 Reassign Server | Reassign Server | `UserCog` |
| 🆓 Waive Delivery Fee | Waive Delivery Fee | `Tag` |

### `tables/page.tsx`
| Before | After | Icon |
|--------|-------|------|
| 👤 Returning customer (takeaway) | Returning customer | `User` |
| 👤 Returning customer (delivery) | Returning customer | `User` |
| 🆓 Mark as Free | Mark as Free | `Tag` |

All icons use the existing `inline-flex items-center gap-1` span pattern with `aria-hidden='true'` (same pattern as the already-correct Reprint KOT and Print Bill buttons).

### `e2e/pre-payment-bill.spec.ts`
- Updated text selectors to match the new button text (without emoji prefix)