### PR TITLE
fix(#409): global UI style audit — contrast, colour consistency, readability across all pages

### DIFF
--- a/apps/web/app/admin/customers/CustomersDashboard.tsx
+++ b/apps/web/app/admin/customers/CustomersDashboard.tsx
@@ -180,7 +180,7 @@ export default function CustomersDashboard(): JSX.Element {
     <div className="p-6 max-w-6xl mx-auto">
       <div className="flex items-center gap-3 mb-6">
         <Users size={24} className="text-indigo-400" aria-hidden="true" />
-        <h1 className="text-2xl font-bold text-white">Customers</h1>
+        <h1 className="text-2xl font-bold text-brand-navy">Customers</h1>
       </div>
 
       {/* Search */}
@@ -247,14 +247,14 @@ export default function CustomersDashboard(): JSX.Element {
                               className="w-full min-h-[36px] px-2 rounded-lg bg-zinc-700 text-white border border-zinc-600 focus:border-indigo-400 focus:outline-none text-sm"
                             />
                           ) : (
-                            <span className="font-medium text-white">
-                              {customer.name ?? <span className="text-zinc-500 italic">—</span>}
+                            <span className="font-medium text-gray-900">
+                              {customer.name ?? <span className="text-gray-400 italic">—</span>}
                             </span>
                           )}
                         </td>
                         <td className="px-4 py-3">
                           <span className="inline-flex items-center gap-1 text-zinc-300">
-                            <Phone size={12} className="text-zinc-500" aria-hidden="true" />
+                            <Phone size={12} className="text-gray-400" aria-hidden="true" />
                             {customer.mobile}
                           </span>
                         </td>

--- a/apps/web/app/admin/customers/CustomersDashboard.tsx
+++ b/apps/web/app/admin/customers/CustomersDashboard.tsx
@@ -253,7 +253,7 @@ export default function CustomersDashboard(): JSX.Element {
                           )}
                         </td>
                         <td className="px-4 py-3">
-                          <span className="inline-flex items-center gap-1 text-zinc-300">
+                          <span className="inline-flex items-center gap-1 text-gray-600">
                             <Phone size={12} className="text-gray-400" aria-hidden="true" />
                             {customer.mobile}
                           </span>

--- a/apps/web/app/admin/floor-plan/UnifiedFloorPlan.tsx
+++ b/apps/web/app/admin/floor-plan/UnifiedFloorPlan.tsx
@@ -207,7 +207,7 @@ export default function UnifiedFloorPlan(): JSX.Element {
   if (loading) {
     return (
       <div className="flex flex-col gap-4">
-        <h1 className="text-2xl font-bold text-white">Floor Plan</h1>
+        <h1 className="text-2xl font-bold text-brand-navy">Floor Plan</h1>
         <p className="text-brand-navy/60">Loading floor plan…</p>
       </div>
     )
@@ -216,7 +216,7 @@ export default function UnifiedFloorPlan(): JSX.Element {
   if (error) {
     return (
       <div className="flex flex-col gap-4">
-        <h1 className="text-2xl font-bold text-white">Floor Plan</h1>
+        <h1 className="text-2xl font-bold text-brand-navy">Floor Plan</h1>
         <p className="text-red-400">{error}</p>
       </div>
     )
@@ -236,12 +236,12 @@ export default function UnifiedFloorPlan(): JSX.Element {
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <h1 className="text-2xl font-bold text-white">Floor Plan</h1>
+          <h1 className="text-2xl font-bold text-brand-navy">Floor Plan</h1>
           {refreshing && (
-            <span className="text-xs text-brand-grey animate-pulse">Refreshing…</span>
+            <span className="text-xs text-gray-500 animate-pulse">Refreshing…</span>
           )}
         </div>
-        <span className="text-sm text-brand-grey">Drag tables to arrange • Click empty cell to add</span>
+        <span className="text-sm text-gray-500">Drag tables to arrange • Click empty cell to add</span>
       </div>
 
       {feedback && (

--- a/apps/web/app/admin/inventory/InventoryManager.tsx
+++ b/apps/web/app/admin/inventory/InventoryManager.tsx
@@ -1259,11 +1259,11 @@ function MarginsTab({ menuItems, recipeItems }: MarginsTabProps): JSX.Element {
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4">
           <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">Total Dishes</p>
-          <p className="text-2xl font-bold text-brand-navy font-heading mt-1">{menuItems.length}</p>
+          <p className="text-2xl font-bold text-white mt-1">{menuItems.length}</p>
         </div>
         <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4">
           <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">With Recipe</p>
-          <p className="text-2xl font-bold text-brand-navy font-heading mt-1">{margins.filter((m) => m.hasRecipe).length}</p>
+          <p className="text-2xl font-bold text-white mt-1">{margins.filter((m) => m.hasRecipe).length}</p>
         </div>
         <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4">
           <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">Avg Margin</p>

--- a/apps/web/app/admin/inventory/InventoryManager.tsx
+++ b/apps/web/app/admin/inventory/InventoryManager.tsx
@@ -497,7 +497,7 @@ interface IngredientFormProps {
 function IngredientForm({ form, setForm, formError, submitting, onSave, onCancel, title, saveLabel }: IngredientFormProps): JSX.Element {
   return (
     <div className="bg-zinc-900 border border-zinc-600 rounded-2xl p-5 flex flex-col gap-4">
-      <h3 className="text-base font-semibold text-brand-navy">{title}</h3>
+      <h3 className="text-base font-semibold text-white">{title}</h3>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="flex flex-col gap-1">
           <label className="text-sm font-medium text-zinc-300">Name <span className="text-red-400">*</span></label>
@@ -795,7 +795,7 @@ function AdjustmentsTab({
     <div className="flex flex-col gap-6">
       {/* Log adjustment form */}
       <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-5 flex flex-col gap-4">
-        <h2 className="text-base font-semibold text-brand-navy">Log Adjustment</h2>
+        <h2 className="text-base font-semibold text-white">Log Adjustment</h2>
         <div className="flex flex-wrap gap-4 items-end">
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium text-zinc-300">Ingredient</label>
@@ -1012,7 +1012,7 @@ function WastageTab({
     <div className="flex flex-col gap-8">
       {/* ── Entry Form ────────────────────────────────── */}
       <div className="bg-zinc-800 border border-zinc-700 rounded-2xl p-5 flex flex-col gap-4">
-        <h2 className="text-base font-semibold text-brand-navy">Log Wastage</h2>
+        <h2 className="text-base font-semibold text-white">Log Wastage</h2>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           <div className="flex flex-col gap-1">
             <label className="text-sm font-medium text-zinc-300">Ingredient <span className="text-red-400">*</span></label>
@@ -1106,15 +1106,15 @@ function WastageTab({
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4">
               <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">Total Events</p>
-              <p className="text-2xl font-bold text-brand-navy font-heading mt-1">{reportRecords.length}</p>
+              <p className="text-2xl font-bold text-white mt-1">{reportRecords.length}</p>
             </div>
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4">
               <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">Ingredients Affected</p>
-              <p className="text-2xl font-bold text-brand-navy font-heading mt-1">{ranked.length}</p>
+              <p className="text-2xl font-bold text-white mt-1">{ranked.length}</p>
             </div>
             <div className="bg-zinc-800 border border-zinc-700 rounded-2xl px-5 py-4 col-span-2">
               <p className="text-xs text-zinc-500 uppercase tracking-wide font-semibold">Est. Total Cost</p>
-              <p className="text-2xl font-bold text-brand-navy font-heading mt-1">
+              <p className="text-2xl font-bold text-white mt-1">
                 {ranked.some((r) => r.hasCost)
                   ? ranked.filter((r) => r.hasCost).reduce((sum, r) => sum + (r.totalCost ?? 0), 0).toFixed(2)
                   : '—'}

--- a/apps/web/app/admin/menu/MenuManager.tsx
+++ b/apps/web/app/admin/menu/MenuManager.tsx
@@ -239,7 +239,7 @@ export default function MenuManager(): JSX.Element {
               setShowAddCategory((v) => !v)
             }}
             disabled={submitting}
-            className="min-h-[48px] px-5 py-2 rounded-xl text-base font-medium bg-brand-offwhite text-white hover:bg-zinc-600 transition-colors disabled:opacity-50"
+            className="min-h-[48px] px-5 py-2 rounded-xl text-base font-medium bg-zinc-200 text-zinc-800 hover:bg-zinc-300 transition-colors disabled:opacity-50"
           >
             + Add Category
           </button>
@@ -308,7 +308,7 @@ export default function MenuManager(): JSX.Element {
                 setCategoryName('')
                 setCategoryNameError('')
               }}
-              className="min-h-[48px] px-5 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors"
+              className="min-h-[48px] px-5 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors"
             >
               Cancel
             </button>
@@ -347,7 +347,7 @@ export default function MenuManager(): JSX.Element {
                 </button>
                 <button
                   onClick={handleCancelEditCategory}
-                  className="min-h-[48px] px-4 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors shrink-0"
+                  className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors shrink-0"
                 >
                   Cancel
                 </button>
@@ -407,7 +407,7 @@ export default function MenuManager(): JSX.Element {
                     <button
                       onClick={() => setDeletingCategoryId(null)}
                       aria-label="Cancel delete category"
-                      className="min-h-[48px] px-4 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors"
+                      className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors"
                     >
                       No
                     </button>
@@ -417,7 +417,7 @@ export default function MenuManager(): JSX.Element {
                     <button
                       onClick={() => handleStartEditCategory(menu)}
                       aria-label={`Edit category ${menu.name}`}
-                      className="min-h-[48px] px-4 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors"
+                      className="min-h-[48px] px-4 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors"
                     >
                       Edit
                     </button>
@@ -466,7 +466,7 @@ export default function MenuManager(): JSX.Element {
                     <Link
                       href={`/admin/menu/${item.id}/edit`}
                       aria-label={`Edit ${item.name}`}
-                      className="min-h-[48px] min-w-[48px] px-4 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors shrink-0 flex items-center justify-center"
+                      className="min-h-[48px] min-w-[48px] px-4 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors shrink-0 flex items-center justify-center"
                     >
                       Edit
                     </Link>
@@ -484,7 +484,7 @@ export default function MenuManager(): JSX.Element {
                         <button
                           onClick={() => setDeletingItemId(null)}
                           aria-label="Cancel delete"
-                          className="min-h-[48px] min-w-[48px] px-4 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors"
+                          className="min-h-[48px] min-w-[48px] px-4 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors"
                         >
                           No
                         </button>

--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -38,7 +38,7 @@ function ExportButton({ onClick, loading = false, label = 'Export CSV' }: Export
       type="button"
       onClick={onClick}
       disabled={loading}
-      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-offwhite hover:bg-zinc-600 text-zinc-200 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-brand-grey"
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-700 text-zinc-700 hover:text-white text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-zinc-300"
       aria-label={label}
     >
       {loading ? (
@@ -58,7 +58,7 @@ function SummaryCard({ label, value }: { label: string; value: string | number }
   return (
     <div className="bg-white border border-brand-grey rounded-2xl p-6 flex flex-col gap-2">
       <span className="text-sm font-medium text-brand-navy/60 uppercase tracking-wide">{label}</span>
-      <span className="text-3xl font-bold text-white">{value}</span>
+      <span className="text-3xl font-bold text-brand-navy">{value}</span>
     </div>
   )
 }
@@ -149,7 +149,7 @@ function CompDetailTable({ items }: CompDetailTableProps): JSX.Element {
               <td className="py-2 pr-3 text-brand-navy/60 whitespace-nowrap">
                 {item.date.slice(0, 10)}
               </td>
-              <td className="py-2 pr-3 text-white font-medium">{item.item_name}</td>
+              <td className="py-2 pr-3 text-gray-900 font-medium">{item.item_name}</td>
               <td className="py-2 pr-3 text-brand-navy/80 text-right">{item.quantity}</td>
               <td className="py-2 pr-3 text-brand-navy/80 text-right">
                 {formatPrice(item.unit_price_cents, DEFAULT_CURRENCY_SYMBOL)}
@@ -252,7 +252,7 @@ function StaffPerformanceTable({ rows }: StaffPerformanceTableProps): JSX.Elemen
             return (
               <tr key={row.server_id} className="border-b border-brand-grey/50">
                 <td className="py-2 pr-3 text-brand-navy/60">{idx + 1}</td>
-                <td className="py-2 pr-3 text-white font-medium">{row.staff_name}</td>
+                <td className="py-2 pr-3 text-gray-900 font-medium">{row.staff_name}</td>
                 <td className="py-2 pr-3">
                   <span className="px-2 py-0.5 rounded-full bg-brand-offwhite text-brand-navy/80 text-xs font-medium capitalize">
                     {row.role}
@@ -387,7 +387,7 @@ export default function ReportsDashboard(): JSX.Element {
               type="date"
               value={customFrom}
               onChange={e => setCustomFrom(e.target.value)}
-              className="bg-brand-offwhite text-white rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
+              className="bg-white text-gray-900 rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
             />
           </div>
           <div className="flex flex-col gap-1">
@@ -396,7 +396,7 @@ export default function ReportsDashboard(): JSX.Element {
               type="date"
               value={customTo}
               onChange={e => setCustomTo(e.target.value)}
-              className="bg-brand-offwhite text-white rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
+              className="bg-white text-gray-900 rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
             />
           </div>
           <button
@@ -476,7 +476,7 @@ export default function ReportsDashboard(): JSX.Element {
                     {data.top_items.map((item, idx) => (
                       <tr key={item.name} className="border-b border-brand-grey/50">
                         <td className="py-2 pr-3 text-brand-navy/60">{idx + 1}</td>
-                        <td className="py-2 pr-3 text-white font-medium">{item.name}</td>
+                        <td className="py-2 pr-3 text-gray-900 font-medium">{item.name}</td>
                         <td className="py-2 pr-3 text-brand-navy/80 text-right">{item.quantity_sold}</td>
                         <td className="py-2 text-amber-400 text-right font-medium">
                           {formatPrice(item.revenue_cents, DEFAULT_CURRENCY_SYMBOL)}
@@ -508,7 +508,7 @@ export default function ReportsDashboard(): JSX.Element {
                     return (
                       <div key={p.method}>
                         <div className="flex justify-between text-sm mb-1">
-                          <span className="text-white font-medium capitalize">{PAYMENT_METHOD_LABELS[p.method as PaymentMethod] ?? p.method}</span>
+                          <span className="text-gray-900 font-medium capitalize">{PAYMENT_METHOD_LABELS[p.method as PaymentMethod] ?? p.method}</span>
                           <span className="text-brand-navy/60">
                             {p.count} orders · {formatPrice(p.revenue_cents, DEFAULT_CURRENCY_SYMBOL)} · {pct}%
                           </span>
@@ -532,23 +532,23 @@ export default function ReportsDashboard(): JSX.Element {
             <h2 className="text-base font-semibold text-brand-navy mb-4">Discounts &amp; Comps</h2>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
               <div className="bg-brand-navy rounded-xl p-4">
-                <div className="text-xs text-brand-navy/60 uppercase tracking-wide mb-1">Discounted Orders</div>
-                <div className="text-2xl font-bold text-brand-navy font-heading">{data.discount_summary.discount_order_count}</div>
-                <div className="text-sm text-brand-navy/60 mt-1">
+                <div className="text-xs text-white/60 uppercase tracking-wide mb-1">Discounted Orders</div>
+                <div className="text-2xl font-bold text-white">{data.discount_summary.discount_order_count}</div>
+                <div className="text-sm text-white/70 mt-1">
                   Total: {formatPrice(data.discount_summary.total_discount_cents, DEFAULT_CURRENCY_SYMBOL)}
                 </div>
               </div>
               <div className="bg-brand-navy rounded-xl p-4">
-                <div className="text-xs text-brand-navy/60 uppercase tracking-wide mb-1">Comped Orders</div>
-                <div className="text-2xl font-bold text-brand-navy font-heading">{data.discount_summary.comp_order_count}</div>
+                <div className="text-xs text-white/60 uppercase tracking-wide mb-1">Comped Orders</div>
+                <div className="text-2xl font-bold text-white">{data.discount_summary.comp_order_count}</div>
               </div>
               {data.comp_detail && (
                 <div className="bg-brand-navy rounded-xl p-4">
-                  <div className="text-xs text-brand-navy/60 uppercase tracking-wide mb-1">Total Comp Value</div>
+                  <div className="text-xs text-white/60 uppercase tracking-wide mb-1">Total Comp Value</div>
                   <div className="text-2xl font-bold text-rose-400">
                     {formatPrice(data.comp_detail.total_comp_value_cents, DEFAULT_CURRENCY_SYMBOL)}
                   </div>
-                  <div className="text-xs text-brand-grey mt-1">
+                  <div className="text-xs text-white/60 mt-1">
                     Item comps: {formatPrice(data.comp_detail.comp_item_value_cents, DEFAULT_CURRENCY_SYMBOL)}
                     {' · '}Order comps: {formatPrice(data.comp_detail.comp_order_value_cents, DEFAULT_CURRENCY_SYMBOL)}
                   </div>
@@ -570,7 +570,7 @@ export default function ReportsDashboard(): JSX.Element {
                       'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
                       compTab === 'breakdown'
                         ? 'bg-rose-600 text-white'
-                        : 'bg-brand-offwhite text-brand-navy/80 hover:bg-zinc-600',
+                        : 'bg-zinc-200 text-zinc-700 hover:bg-zinc-300',
                     ].join(' ')}
                   >
                     By Item
@@ -582,7 +582,7 @@ export default function ReportsDashboard(): JSX.Element {
                       'px-3 py-1.5 rounded-lg text-sm font-medium transition-colors',
                       compTab === 'detail'
                         ? 'bg-rose-600 text-white'
-                        : 'bg-brand-offwhite text-brand-navy/80 hover:bg-zinc-600',
+                        : 'bg-zinc-200 text-zinc-700 hover:bg-zinc-300',
                     ].join(' ')}
                   >
                     Full Log
@@ -640,7 +640,7 @@ export default function ReportsDashboard(): JSX.Element {
                   onClick={() =>
                     exportDailySummary(data, period, customFrom || undefined, customTo || undefined)
                   }
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-offwhite hover:bg-zinc-600 text-zinc-200 text-xs font-medium transition-colors border border-brand-grey"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-700 text-zinc-700 hover:text-white text-xs font-medium transition-colors border border-zinc-300"
                   aria-label="Export daily summary text"
                 >
                   <Download className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />

--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -38,7 +38,7 @@ function ExportButton({ onClick, loading = false, label = 'Export CSV' }: Export
       type="button"
       onClick={onClick}
       disabled={loading}
-      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-700 text-zinc-700 hover:text-white text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-zinc-300"
+      className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-300 text-zinc-700 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed border border-zinc-300"
       aria-label={label}
     >
       {loading ? (
@@ -640,7 +640,7 @@ export default function ReportsDashboard(): JSX.Element {
                   onClick={() =>
                     exportDailySummary(data, period, customFrom || undefined, customTo || undefined)
                   }
-                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-700 text-zinc-700 hover:text-white text-xs font-medium transition-colors border border-zinc-300"
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-zinc-200 hover:bg-zinc-300 text-zinc-700 text-xs font-medium transition-colors border border-zinc-300"
                   aria-label="Export daily summary text"
                 >
                   <Download className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />

--- a/apps/web/app/admin/reservations/ReservationsDashboard.tsx
+++ b/apps/web/app/admin/reservations/ReservationsDashboard.tsx
@@ -536,7 +536,7 @@ export default function ReservationsDashboard(): JSX.Element {
       <div className="flex items-center justify-between gap-4 mb-6 flex-wrap">
         <div className="flex items-center gap-3">
           <CalendarDays size={24} className="text-indigo-400" aria-hidden="true" />
-          <h1 className="text-2xl font-bold text-white">Reservations</h1>
+          <h1 className="text-2xl font-bold text-brand-navy">Reservations</h1>
           {todayCount > 0 && (
             <span className="inline-flex items-center justify-center min-w-[24px] h-6 px-1.5 rounded-full bg-indigo-600 text-white text-xs font-bold">
               {todayCount}
@@ -594,7 +594,7 @@ export default function ReservationsDashboard(): JSX.Element {
       </div>
 
       {loading ? (
-        <p className="text-zinc-400">Loading…</p>
+        <p className="text-gray-600">Loading…</p>
       ) : error !== null ? (
         <p className="text-red-400">{error}</p>
       ) : tab === 'reservations' ? (
@@ -603,7 +603,7 @@ export default function ReservationsDashboard(): JSX.Element {
           {bookings.length === 0 ? (
             <div className="text-center py-16">
               <CalendarDays size={48} className="text-zinc-600 mx-auto mb-4" aria-hidden="true" />
-              <p className="text-zinc-400">No reservations yet.</p>
+              <p className="text-gray-500">No reservations yet.</p>
             </div>
           ) : (
             <table className="w-full text-sm">
@@ -627,24 +627,24 @@ export default function ReservationsDashboard(): JSX.Element {
                 {bookings.map((r) => (
                   <tr key={r.id} className="border-b border-zinc-800 hover:bg-zinc-800/40 transition-colors">
                     <td className="px-4 py-3">
-                      <p className="font-medium text-white">{r.customer_name}</p>
-                      {r.customer_mobile && <p className="text-xs text-zinc-500">{r.customer_mobile}</p>}
-                      {r.notes && <p className="text-xs text-zinc-500 italic mt-0.5">{r.notes}</p>}
+                      <p className="font-medium text-gray-900">{r.customer_name}</p>
+                      {r.customer_mobile && <p className="text-xs text-gray-500">{r.customer_mobile}</p>}
+                      {r.notes && <p className="text-xs text-gray-500 italic mt-0.5">{r.notes}</p>}
                     </td>
                     <td className="px-4 py-3">
-                      <span className="text-white font-semibold">{r.party_size}</span>
+                      <span className="text-gray-900 font-semibold">{r.party_size}</span>
                     </td>
                     <td className="px-4 py-3">
                       {r.reservation_time ? (
                         <div>
-                          <p className={`font-medium ${isToday(r.reservation_time) ? 'text-indigo-300' : 'text-white'}`}>
+                          <p className={`font-medium ${isToday(r.reservation_time) ? 'text-indigo-600' : 'text-gray-900'}`}>
                             {isToday(r.reservation_time) ? 'Today' : formatDateShort(r.reservation_time)}
                           </p>
-                          <p className="text-xs text-zinc-400">{formatTime(r.reservation_time)}</p>
+                          <p className="text-xs text-gray-500">{formatTime(r.reservation_time)}</p>
                         </div>
                       ) : '—'}
                     </td>
-                    <td className="px-4 py-3 text-zinc-300">{getTableLabel(r.table_id)}</td>
+                    <td className="px-4 py-3 text-gray-700">{getTableLabel(r.table_id)}</td>
                     <td className="px-4 py-3"><StatusBadge status={r.status} /></td>
                     <td className="px-4 py-3">
                       <ActionButtons
@@ -667,7 +667,7 @@ export default function ReservationsDashboard(): JSX.Element {
           {waitlist.length === 0 ? (
             <div className="text-center py-16">
               <Clock size={48} className="text-zinc-600 mx-auto mb-4" aria-hidden="true" />
-              <p className="text-zinc-400">Waitlist is empty.</p>
+              <p className="text-gray-500">Waitlist is empty.</p>
             </div>
           ) : (
             <table className="w-full text-sm">
@@ -696,15 +696,15 @@ export default function ReservationsDashboard(): JSX.Element {
                       </span>
                     </td>
                     <td className="px-4 py-3">
-                      <p className="font-medium text-white">{r.customer_name}</p>
-                      {r.customer_mobile && <p className="text-xs text-zinc-500">{r.customer_mobile}</p>}
-                      {r.notes && <p className="text-xs text-zinc-500 italic mt-0.5">{r.notes}</p>}
+                      <p className="font-medium text-gray-900">{r.customer_name}</p>
+                      {r.customer_mobile && <p className="text-xs text-gray-500">{r.customer_mobile}</p>}
+                      {r.notes && <p className="text-xs text-gray-500 italic mt-0.5">{r.notes}</p>}
                     </td>
                     <td className="px-4 py-3">
-                      <span className="text-white font-semibold">{r.party_size}</span>
+                      <span className="text-gray-900 font-semibold">{r.party_size}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <span className="text-amber-400 font-medium">{waitTime(r.created_at)}</span>
+                      <span className="text-amber-600 font-medium">{waitTime(r.created_at)}</span>
                     </td>
                     <td className="px-4 py-3"><StatusBadge status={r.status} /></td>
                     <td className="px-4 py-3">

--- a/apps/web/app/admin/users/UserManager.tsx
+++ b/apps/web/app/admin/users/UserManager.tsx
@@ -325,7 +325,7 @@ export default function UserManager(): JSX.Element {
                 setCreateFormErrors({})
               }}
               disabled={submitting === 'create'}
-              className="min-h-[48px] px-5 py-2 rounded-xl bg-brand-offwhite text-white text-base font-medium hover:bg-zinc-600 transition-colors"
+              className="min-h-[48px] px-5 py-2 rounded-xl bg-zinc-200 text-zinc-800 text-base font-medium hover:bg-zinc-300 transition-colors"
             >
               Cancel
             </button>
@@ -390,7 +390,7 @@ export default function UserManager(): JSX.Element {
                       Active
                     </span>
                   ) : (
-                    <span className="inline-block px-2 py-1 rounded-lg text-sm font-medium bg-brand-offwhite text-brand-navy/80">
+                    <span className="inline-block px-2 py-1 rounded-lg text-sm font-medium bg-zinc-200 text-zinc-700">
                       Inactive
                     </span>
                   )}

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -2387,33 +2387,33 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           <dl className="space-y-2 text-base">
             {orderType === 'dine_in' && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Table</dt>
-                <dd className="font-semibold text-white">{displayTableLabel || tableId}</dd>
+                <dt className="text-gray-600">Table</dt>
+                <dd className="font-semibold text-gray-900">{displayTableLabel || tableId}</dd>
               </div>
             )}
             {orderType === 'delivery' && orderCustomerName && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Customer</dt>
-                <dd className="font-semibold text-white">{orderCustomerName}</dd>
+                <dt className="text-gray-600">Customer</dt>
+                <dd className="font-semibold text-gray-900">{orderCustomerName}</dd>
               </div>
             )}
             {orderType === 'delivery' && orderDeliveryNote && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Note</dt>
-                <dd className="text-zinc-300">{orderDeliveryNote}</dd>
+                <dt className="text-gray-600">Note</dt>
+                <dd className="text-gray-700">{orderDeliveryNote}</dd>
               </div>
             )}
             {(orderType === 'takeaway' || orderType === 'delivery') && orderScheduledTime && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">{orderType === 'takeaway' ? 'Pickup Time' : 'Delivery Time'}</dt>
-                <dd className="font-semibold text-amber-300">{formatDateTimeShort(orderScheduledTime)}</dd>
+                <dt className="text-gray-600">{orderType === 'takeaway' ? 'Pickup Time' : 'Delivery Time'}</dt>
+                <dd className="font-semibold text-amber-700">{formatDateTimeShort(orderScheduledTime)}</dd>
               </div>
             )}
             {/* Delivery fee in paid-order read-only view (issue #393) */}
             {orderType === 'delivery' && (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Delivery Fee</dt>
-                <dd className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-300' : 'font-semibold text-emerald-400'}>
+                <dt className="text-gray-600">Delivery Fee</dt>
+                <dd className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-700' : 'font-semibold text-emerald-700'}>
                   {orderDeliveryChargeCents > 0
                     ? formatPrice(orderDeliveryChargeCents, currencySymbol)
                     : 'Free Delivery'}
@@ -2423,13 +2423,13 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             {/* Payment breakdown (issue #391) — show per-method amounts for audit trail */}
             {paidPaymentLines.length > 0 ? (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Payment</dt>
-                <dd className="font-semibold text-white">
+                <dt className="text-gray-600">Payment</dt>
+                <dd className="font-semibold text-gray-900">
                   <div className="space-y-0.5">
                     {paidPaymentLines.map((pl, idx) => (
                       <div key={idx} className="flex items-center gap-2">
                         <span>{PAYMENT_METHOD_LABELS[pl.method as PaymentMethod] ?? pl.method}</span>
-                        <span className="text-amber-400">{formatPrice(pl.amount_cents, currencySymbol)}</span>
+                        <span className="text-amber-600">{formatPrice(pl.amount_cents, currencySymbol)}</span>
                       </div>
                     ))}
                   </div>
@@ -2437,8 +2437,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               </div>
             ) : paidPaymentMethod !== null ? (
               <div className="flex gap-3">
-                <dt className="text-zinc-500">Payment method</dt>
-                <dd className="font-semibold text-white">{PAYMENT_METHOD_LABELS[paidPaymentMethod as PaymentMethod] ?? paidPaymentMethod}</dd>
+                <dt className="text-gray-600">Payment method</dt>
+                <dd className="font-semibold text-gray-900">{PAYMENT_METHOD_LABELS[paidPaymentMethod as PaymentMethod] ?? paidPaymentMethod}</dd>
               </div>
             ) : null}
           </dl>
@@ -2472,14 +2472,14 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           {renderReadOnlyItems()}
         </section>
 
-        <footer className="mt-6 pt-4 border-t border-zinc-700">
+        <footer className="mt-6 pt-4 border-t border-gray-300">
           <div className="flex items-center justify-between mb-6">
-            <span className="text-lg text-zinc-400">Total</span>
-            <span className="text-2xl font-bold text-white">{totalFormatted}</span>
+            <span className="text-lg text-gray-600">Total</span>
+            <span className="text-2xl font-bold text-gray-900">{totalFormatted}</span>
           </div>
           <Link
             href="/tables"
-            className="w-full inline-flex items-center justify-center min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-zinc-700 hover:bg-zinc-600 text-white transition-colors"
+            className="w-full inline-flex items-center justify-center min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold bg-brand-navy hover:bg-brand-blue text-white transition-colors"
           >
             Back to tables
           </Link>
@@ -3423,35 +3423,35 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         <dl className="space-y-2 text-base">
           {orderType === 'dine_in' && (
             <div className="flex gap-3">
-              <dt className="text-zinc-500">Table</dt>
-              <dd className="font-semibold text-white">{displayTableLabel || tableId}</dd>
+              <dt className="text-gray-600">Table</dt>
+              <dd className="font-semibold text-gray-900">{displayTableLabel || tableId}</dd>
             </div>
           )}
           {orderType === 'delivery' && orderCustomerName && (
             <div className="flex gap-3">
-              <dt className="text-zinc-500">Customer</dt>
-              <dd className="font-semibold text-white">{orderCustomerName}</dd>
+              <dt className="text-gray-600">Customer</dt>
+              <dd className="font-semibold text-gray-900">{orderCustomerName}</dd>
             </div>
           )}
           {orderType === 'delivery' && orderDeliveryNote && (
             <div className="flex gap-3">
-              <dt className="text-zinc-500">Note</dt>
-              <dd className="text-zinc-300">{orderDeliveryNote}</dd>
+              <dt className="text-gray-600">Note</dt>
+              <dd className="text-gray-700">{orderDeliveryNote}</dd>
             </div>
           )}
           {(orderType === 'takeaway' || orderType === 'delivery') && orderScheduledTime && (
             <div className="flex gap-3">
-              <dt className="text-zinc-500">{orderType === 'takeaway' ? 'Pickup Time' : 'Delivery Time'}</dt>
-              <dd className="font-semibold text-amber-300">{formatDateTimeShort(orderScheduledTime)}</dd>
+              <dt className="text-gray-600">{orderType === 'takeaway' ? 'Pickup Time' : 'Delivery Time'}</dt>
+              <dd className="font-semibold text-amber-700">{formatDateTimeShort(orderScheduledTime)}</dd>
             </div>
           )}
           {/* ── Delivery fee — always visible in the order header for delivery orders (issue #393) ── */}
           {orderType === 'delivery' && (
             <div className="flex gap-3">
-              <dt className="text-zinc-500">Delivery Fee</dt>
+              <dt className="text-gray-600">Delivery Fee</dt>
               <dd
                 data-testid="delivery-fee-header"
-                className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-300' : 'font-semibold text-emerald-400'}
+                className={orderDeliveryChargeCents > 0 ? 'font-semibold text-amber-700' : 'font-semibold text-emerald-700'}
               >
                 {orderDeliveryChargeCents > 0
                   ? formatPrice(orderDeliveryChargeCents, currencySymbol)
@@ -3489,7 +3489,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             <button
               type="button"
               onClick={() => { setShowLinkCustomer((v) => !v); setLinkMobileSearch(''); setLinkSearchResults([]); setLinkError(null) }}
-              className="flex items-center gap-2 text-sm text-zinc-400 hover:text-white transition-colors min-h-[36px]"
+              className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 transition-colors min-h-[36px]"
             >
               <UserPlus size={14} aria-hidden="true" />
               {showLinkCustomer ? 'Cancel' : 'Link customer'}
@@ -3536,22 +3536,22 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         {/* Covers field — always visible in order step */}
         {step === 'order' && (
           <div className="flex items-center gap-3 mt-4">
-            <span className="text-zinc-400 text-base">Covers:</span>
+            <span className="text-gray-600 text-base">Covers:</span>
             <button
               type="button"
               onClick={() => { handleCoversChange(covers - 1) }}
               disabled={covers <= 1}
-              className="min-h-[48px] min-w-[48px] rounded-xl bg-zinc-800 text-white text-xl font-bold hover:bg-zinc-700 transition-colors disabled:opacity-40"
+              className="min-h-[48px] min-w-[48px] rounded-xl bg-gray-200 text-gray-900 text-xl font-bold hover:bg-gray-300 border border-gray-300 transition-colors disabled:opacity-40"
               aria-label="Decrease covers"
             >
               −
             </button>
-            <span className="text-white font-bold text-xl w-8 text-center">{covers}</span>
+            <span className="text-gray-900 font-bold text-xl w-8 text-center">{covers}</span>
             <button
               type="button"
               onClick={() => { handleCoversChange(covers + 1) }}
               disabled={covers >= 20}
-              className="min-h-[48px] min-w-[48px] rounded-xl bg-zinc-800 text-white text-xl font-bold hover:bg-zinc-700 transition-colors disabled:opacity-40"
+              className="min-h-[48px] min-w-[48px] rounded-xl bg-gray-200 text-gray-900 text-xl font-bold hover:bg-gray-300 border border-gray-300 transition-colors disabled:opacity-40"
               aria-label="Increase covers"
             >
               +
@@ -3567,19 +3567,19 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
       {/* print:hidden ensures this footer (containing the payment-step subtotal breakdown)
           is never rendered during window.print() — prevents duplicate subtotal on bill (issue #369) */}
-      <footer className="mt-6 pt-4 border-t border-zinc-700 print:hidden">
+      <footer className="mt-6 pt-4 border-t border-gray-300 print:hidden">
         <div className="flex items-center justify-between mb-6">
-          <span className="text-lg text-zinc-400">Total</span>
+          <span className="text-lg text-gray-600">Total</span>
           {orderIsComp ? (
-            <span className="text-2xl font-bold text-emerald-400">COMPLIMENTARY</span>
+            <span className="text-2xl font-bold text-emerald-700">COMPLIMENTARY</span>
           ) : (
-            <span className="text-2xl font-bold text-white">{totalFormatted}</span>
+            <span className="text-2xl font-bold text-gray-900">{totalFormatted}</span>
           )}
         </div>
 
         {step === 'bill_preview' ? (
           <div className="space-y-5">
-            <h2 className="text-xl font-semibold text-white">Bill Preview</h2>
+            <h2 className="text-xl font-semibold text-brand-navy">Bill Preview</h2>
 
             {/* Order meta */}
             <div className="bg-zinc-800 rounded-xl px-4 py-3 text-sm space-y-1.5">
@@ -3780,8 +3780,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 className={[
                   'w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors mb-3',
                   printingPreBill
-                    ? 'bg-zinc-700 text-zinc-400 cursor-wait'
-                    : 'bg-zinc-800 hover:bg-zinc-700 text-amber-400 border-2 border-amber-700 hover:border-amber-500',
+                    ? 'bg-gray-100 text-gray-400 cursor-wait'
+                    : 'bg-transparent border-2 border-amber-500 text-amber-700 hover:bg-amber-50 hover:border-amber-600',
                 ].join(' ')}
               >
                 {printingPreBill ? 'Printing…' : <span className='inline-flex items-center gap-1'><PrinterIcon size={16} aria-hidden='true' />Print Bill (DUE)</span>}
@@ -3798,8 +3798,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                   className={[
                     'w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors',
                     markingDue
-                      ? 'bg-zinc-700 text-zinc-400 cursor-wait'
-                      : 'bg-zinc-800 hover:bg-zinc-700 text-orange-400 border-2 border-orange-700 hover:border-orange-500',
+                      ? 'bg-gray-100 text-gray-400 cursor-wait'
+                      : 'bg-transparent border-2 border-orange-500 text-orange-700 hover:bg-orange-50 hover:border-orange-600',
                   ].join(' ')}
                 >
                   {markingDue ? 'Marking…' : <span className='inline-flex items-center gap-1'><Clock size={16} aria-hidden='true' />Mark as Due</span>}
@@ -3830,7 +3830,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <button
                 type="button"
                 onClick={() => { void openTransferModal() }}
-                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-amber-400 border-2 border-zinc-700 hover:border-amber-600 transition-colors mb-3"
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-gray-600 hover:text-amber-700 border-2 border-gray-400 hover:border-amber-500 hover:bg-amber-50 transition-colors mb-3"
               >
                 ↔ Move Table
               </button>
@@ -3841,7 +3841,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <button
                 type="button"
                 onClick={() => { void openMergeModal() }}
-                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-purple-400 border-2 border-zinc-700 hover:border-purple-600 transition-colors mb-3"
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-gray-600 hover:text-purple-700 border-2 border-gray-400 hover:border-purple-500 hover:bg-purple-50 transition-colors mb-3"
               >
                 ⊕ Merge with…
               </button>
@@ -3850,7 +3850,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <button
                 type="button"
                 onClick={() => { setUnmergeError(null); setShowUnmergeConfirm(true) }}
-                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-purple-400 hover:text-white border-2 border-purple-700 hover:border-purple-400 hover:bg-purple-900/30 transition-colors mb-3"
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-purple-700 hover:text-white border-2 border-purple-500 hover:border-purple-400 hover:bg-purple-700 transition-colors mb-3"
               >
                 ⊘ Unmerge ({mergeLabel})
               </button>
@@ -3860,7 +3860,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
               <button
                 type="button"
                 onClick={() => { void openReassignModal() }}
-                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-indigo-400 border-2 border-zinc-700 hover:border-indigo-600 transition-colors mb-3"
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-gray-600 hover:text-indigo-700 border-2 border-gray-400 hover:border-indigo-500 hover:bg-indigo-50 transition-colors mb-3"
               >
                 <span className='inline-flex items-center gap-1'><UserCog size={16} aria-hidden='true' />Reassign Server</span>
               </button>
@@ -3873,7 +3873,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                 setCancelError(null)
                 setShowCancelDialog(true)
               }}
-              className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-zinc-400 hover:text-red-400 border-2 border-zinc-700 hover:border-red-700 transition-colors mb-3"
+              className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-gray-600 hover:text-red-700 border-2 border-gray-400 hover:border-red-500 hover:bg-red-50 transition-colors mb-3"
             >
               Cancel order
             </button>
@@ -3887,7 +3887,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                   setCompError(null)
                   setShowOrderCompDialog(true)
                 }}
-                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-emerald-400 hover:text-white border-2 border-emerald-800 hover:border-emerald-600 hover:bg-emerald-900/40 transition-colors"
+                className="w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold text-emerald-700 hover:text-white border-2 border-emerald-600 hover:border-emerald-500 hover:bg-emerald-700 transition-colors"
               >
                 Comp entire order
               </button>
@@ -3904,10 +3904,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
                   className={[
                     'w-full min-h-[48px] min-w-[48px] px-6 rounded-xl text-base font-semibold transition-colors border-2',
                     waivingDeliveryFee
-                      ? 'border-zinc-700 text-zinc-500 cursor-wait'
+                      ? 'border-gray-300 text-gray-400 cursor-wait'
                       : deliveryFeeWaived
-                        ? 'border-amber-600 text-amber-400 hover:border-amber-400 hover:bg-amber-900/20'
-                        : 'border-blue-700 text-blue-400 hover:border-blue-500 hover:bg-blue-900/20',
+                        ? 'border-amber-500 text-amber-700 hover:border-amber-600 hover:bg-amber-50'
+                        : 'border-blue-500 text-blue-700 hover:border-blue-600 hover:bg-blue-50',
                   ].join(' ')}
                 >
                   {waivingDeliveryFee


### PR DESCRIPTION
## Summary

Fixes #409 — A broad set of readability and colour consistency issues across the app.

### Root Cause
White or very light text (, ) was being used on the light off-white admin background ( = #EEEEEE), making it invisible. Dark text () was also used inside dark  containers, creating invisible text on dark backgrounds. Secondary buttons used  which rendered as invisible text.

### Changes by Area

**Order Page (OrderDetailClient)**
- Fixed table number, customer name, delivery note, scheduled time, delivery fee — all now use dark text on light bg (, , , )
- Covers section:  buttons changed from jarring dark () to subtle light style (); covers count from invisible  to 
- Footer total:  → ,  → 
- Action buttons: unified to consistent hierarchy — Print Bill/Mark as Due changed from dark-bg buttons to light outlined; ghost buttons () →  with matching hover colours
- "Link customer" button:  → 

**Admin > Menu**
- All secondary/cancel buttons:  (invisible) → 

**Floor Plan**
- Page heading:  →  (navy on off-white = readable)
- Helper text and refresh indicator:  → 

**Admin > Users**
- Secondary/cancel button: same fix as menu
- Inactive badge:  →  (distinct from page bg)

**Inventory**
-  title:  on  → 
- Log Adjustment / Log Wastage headings:  on  → 
- Wastage summary cards:  on  → 
- Margins summary cards: same fix

**Reports**
-  values:  on  → 
- Export CSV buttons:  (invisible on off-white) →  with visible hover
- Table item names / staff names / payment methods:  on  → 
- Discounts & Comps navy-on-navy boxes: all text changed to  / 
- Comp tab toggle buttons:  → 
- Custom date inputs:  → 

**Customers**
- Page heading:  → 
- Customer name column:  → 

**Reservations**
- Page heading:  → 
- Table row text:  → ,  → ,  → 
- Today-badge colour:  →  (sufficient contrast on light bg)
- Wait time:  → 
- Empty state messages:  → 