### PR TITLE
fix(#415): save category 401 — missing API key in Supabase request

### DIFF
--- a/apps/web/app/admin/menu/menuAdminApi.ts
+++ b/apps/web/app/admin/menu/menuAdminApi.ts
@@ -3,9 +3,12 @@ export interface ModifierInput {
   price_delta_cents: number
 }
 
+const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''
+
 function buildHeaders(accessToken: string, withPreferRepresentation = false): Record<string, string> {
   const h: Record<string, string> = {
     'Content-Type': 'application/json',
+    apikey: publishableKey,
     Authorization: `Bearer ${accessToken}`,
   }
   if (withPreferRepresentation) h['Prefer'] = 'return=representation'


### PR DESCRIPTION
## Summary

Fixes #415 — **Save Category** on `/admin/menu` fails with `401 No API key found in request`.

## Root cause

`buildHeaders()` in `menuAdminApi.ts` was only sending:
```
Authorization: Bearer <jwt>
```

Supabase REST API requires **both** headers:
```
apikey: <publishable_key>
Authorization: Bearer <jwt>
```

Without the `apikey` header the gateway rejects the request with 401 before the JWT can even be evaluated.

`menuAdminData.ts` (the data-fetch layer in the same directory) already used the correct two-header pattern. The write-path (`menuAdminApi.ts`) was simply missing it.

## Fix

Added `const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? ''` and included `apikey: publishableKey` in `buildHeaders()`. This aligns `menuAdminApi.ts` with the existing pattern in `menuAdminData.ts` and the Supabase SSR client.

No anon key is hard-coded — the value comes from the public env var already used by the Supabase browser client.

## Affected functions
- `callCreateMenu` ← triggered by Save Category (the failing action)
- `callUpdateMenu`
- `callDeleteMenu`
- `callUpdateMenuPrinterType`

All four use `postgrestRequest` → `buildHeaders`, so all are fixed.