### PR TITLE
feat(#414): make /register fully self-service — remove super_admin requirement

### DIFF
--- a/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.test.tsx
+++ b/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.test.tsx
@@ -175,11 +175,12 @@ describe('ProvisionRestaurantForm — public variant', () => {
     expect(screen.queryByText(/super admin — provisioning/i)).not.toBeInTheDocument()
   })
 
-  it('shows "Please log in" message when accessToken is null', () => {
+  it('renders the form directly for unauthenticated visitors (no login prompt)', () => {
     mockAccessToken = null
     render(<ProvisionRestaurantForm variant="public" />)
-    expect(screen.getByText(/please log in to complete registration/i)).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: /go to login/i })).toBeInTheDocument()
+    // No login prompt — form is shown directly for self-service
+    expect(screen.queryByText(/please log in/i)).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/restaurant name/i)).toBeInTheDocument()
   })
 })
 

--- a/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.tsx
+++ b/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.tsx
@@ -81,10 +81,6 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
   const [success, setSuccess] = useState<{ restaurantId: string; name: string } | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [showPassword, setShowPassword] = useState(false)
-  // public variant: skip the client-side super-admin check.
-  // Security is enforced server-side — the provision_restaurant edge function
-  // calls verifySuperAdmin() which requires is_super_admin = true in the users
-  // table. Any non-super-admin token will get a 403 from the edge function.
   const [isSuperAdmin, setIsSuperAdmin] = useState<boolean | null>(variant === 'public' ? true : null)
 
   useEffect(() => {
@@ -114,8 +110,8 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
     }
 
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-    if (!supabaseUrl || !accessToken) {
-      setSubmitError('Not authenticated. Please refresh and try again.')
+    if (!supabaseUrl) {
+      setSubmitError('Configuration error. Please refresh and try again.')
       return
     }
 
@@ -139,23 +135,6 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
     } finally {
       setSubmitting(false)
     }
-  }
-
-  // — Public variant: no token means user isn't logged in —
-  if (variant === 'public' && !accessToken) {
-    return (
-      <div className="flex flex-col gap-6">
-        <div className="bg-yellow-900/30 border border-yellow-700 text-yellow-300 rounded-xl px-4 py-3">
-          <p className="font-medium">Please log in to complete registration.</p>
-          <p className="text-sm mt-1 text-yellow-400">
-            You need to be authenticated as a super-admin to set up a restaurant.
-          </p>
-        </div>
-        <Link href="/login" className="text-indigo-400 hover:underline text-sm">
-          Go to login →
-        </Link>
-      </div>
-    )
   }
 
   // — Loading while permission check runs (admin variant only) —

--- a/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.tsx
+++ b/apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.tsx
@@ -81,7 +81,7 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
   const [success, setSuccess] = useState<{ restaurantId: string; name: string } | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [showPassword, setShowPassword] = useState(false)
-  const [isSuperAdmin, setIsSuperAdmin] = useState<boolean | null>(variant === 'public' ? true : null)
+  const [canAccessForm, setCanAccessForm] = useState<boolean | null>(variant === 'public' ? true : null)
 
   useEffect(() => {
     // In public variant, skip super-admin check — show form directly
@@ -91,8 +91,8 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
         if (!supabaseUrl || !accessToken) return
 
     fetchIsSuperAdmin(supabaseUrl, accessToken)
-      .then((val) => setIsSuperAdmin(val))
-      .catch(() => setIsSuperAdmin(false))
+      .then((val) => setCanAccessForm(val))
+      .catch(() => setCanAccessForm(false))
   }, [accessToken, variant])
 
   function setField<K extends keyof FormValues>(key: K, value: FormValues[K]): void {
@@ -138,7 +138,7 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
   }
 
   // — Loading while permission check runs (admin variant only) —
-  if (isSuperAdmin === null) {
+  if (canAccessForm === null) {
     return (
       <div className="flex flex-col gap-6">
         <h1 className="text-2xl font-bold text-white">New Restaurant</h1>
@@ -148,7 +148,7 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
   }
 
   // — Access denied (admin variant only) —
-  if (!isSuperAdmin) {
+  if (!canAccessForm) {
     return (
       <div className="flex flex-col gap-6">
         <h1 className="text-2xl font-bold text-white">New Restaurant</h1>
@@ -178,7 +178,7 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
               </p>
             </div>
             <p className="text-sm text-green-400">
-              Your restaurant has been set up! You can now log in with the credentials you provided.
+              Your restaurant has been set up! Check your email inbox and click the confirmation link to activate your account, then log in.
             </p>
             <Link
               href="/login"
@@ -209,7 +209,7 @@ export default function ProvisionRestaurantForm({ variant = 'admin' }: Provision
             </p>
           </div>
           <p className="text-sm text-green-400">
-            The owner account has been created. They can now log in with the credentials you set.
+            The owner account has been created. They will receive a confirmation email — they must click the link before logging in.
           </p>
           <Link
             href="/admin/restaurants"

--- a/apps/web/app/admin/restaurants/restaurantAdminApi.ts
+++ b/apps/web/app/admin/restaurants/restaurantAdminApi.ts
@@ -20,6 +20,7 @@ function slugify(name: string): string {
     .replace(/[^a-z0-9\s-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '') // strip leading/trailing hyphens
     .slice(0, 48)
 }
 
@@ -40,7 +41,7 @@ export async function callProvisionRestaurant(
   input: ProvisionRestaurantInput,
 ): Promise<{ restaurantId: string }> {
   const slug = slugify(input.name)
-  if (!slug) {
+  if (!slug || !/^[a-z0-9]/.test(slug)) {
     throw new Error('Restaurant name must contain at least one letter or number')
   }
 

--- a/apps/web/app/admin/restaurants/restaurantAdminApi.ts
+++ b/apps/web/app/admin/restaurants/restaurantAdminApi.ts
@@ -5,10 +5,11 @@ interface ActionResponse {
 }
 
 function buildHeaders(accessToken: string): Record<string, string> {
-  return {
-    'Content-Type': 'application/json',
-    Authorization: `Bearer ${accessToken}`,
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`
   }
+  return headers
 }
 
 /** Auto-generate a URL-safe slug from a restaurant name */

--- a/apps/web/app/admin/restaurants/restaurantAdminApi.ts
+++ b/apps/web/app/admin/restaurants/restaurantAdminApi.ts
@@ -20,8 +20,8 @@ function slugify(name: string): string {
     .replace(/[^a-z0-9\s-]/g, '')
     .replace(/\s+/g, '-')
     .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '') // strip leading/trailing hyphens
     .slice(0, 48)
+    .replace(/^-+|-+$/g, '') // strip leading/trailing hyphens (re-applied after slice)
 }
 
 export interface ProvisionRestaurantInput {

--- a/apps/web/app/register/page.test.tsx
+++ b/apps/web/app/register/page.test.tsx
@@ -26,8 +26,8 @@ describe('RegisterPage', () => {
     expect(form).toHaveAttribute('data-variant', 'public')
   })
 
-  it('shows the super-admin provisioning tagline', () => {
+  it('shows the self-service tagline', () => {
     render(<RegisterPage />)
-    expect(screen.getByText(/ikitchen pos.*super-admin provisioning/i)).toBeInTheDocument()
+    expect(screen.getByText(/ikitchen pos.*get started in minutes/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/app/register/page.tsx
+++ b/apps/web/app/register/page.tsx
@@ -7,7 +7,7 @@ export default function RegisterPage(): JSX.Element {
       <div className="w-full max-w-2xl">
         <div className="mb-8 text-center">
           <h1 className="text-3xl font-bold text-white mb-2">Set up your restaurant</h1>
-          <p className="text-zinc-400">iKitchen POS — Super-admin provisioning</p>
+          <p className="text-zinc-400">iKitchen POS — Get started in minutes</p>
         </div>
         <ProvisionRestaurantForm variant="public" />
       </div>

--- a/apps/web/e2e/register.spec.ts
+++ b/apps/web/e2e/register.spec.ts
@@ -9,14 +9,15 @@ test.describe('/register page — unauthenticated', () => {
   // Override the default authenticated storageState for this describe block
   test.use({ storageState: { cookies: [], origins: [] } })
 
-  test('unauthenticated user sees login prompt', async ({ page }) => {
+  test('unauthenticated user can access the self-service registration form', async ({ page }) => {
     await page.goto('/register')
 
     // The page is accessible (middleware lets unauthenticated users through)
     await expect(page).toHaveURL(/\/register/)
 
-    // The form shows a "please log in" message for unauthenticated visitors
-    await expect(page.getByText(/please log in to complete registration/i)).toBeVisible()
+    // Self-service: the form is shown directly — no login gate for unauthenticated visitors
+    await expect(page.getByRole('heading', { name: /set up your restaurant/i })).toBeVisible()
+    await expect(page.getByLabel(/restaurant name/i)).toBeVisible()
   })
 
   test('page heading "Set up your restaurant" is visible', async ({ page }) => {

--- a/apps/web/e2e/register.spec.ts
+++ b/apps/web/e2e/register.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 
 /**
- * E2E tests for the /register page (super-admin restaurant provisioning).
+ * E2E tests for the /register page (self-service restaurant registration).
  * Viewport: 1280x800 (set globally in playwright.config.ts).
  */
 

--- a/apps/web/e2e/table-merge-split.spec.ts
+++ b/apps/web/e2e/table-merge-split.spec.ts
@@ -118,10 +118,11 @@ test.describe('Table Merge & Split', () => {
   test('merge flow: selecting secondary table calls merge_tables function', async ({ page }) => {
     await page.route(ORDERS_API_PATTERN, (route, request) => {
       const url = request.url()
-      // Merge modal fetch: select includes "table_id" and the embedded tables() relation.
-      // The URL is URL-encoded so "tables(" becomes "tables%28" — check for table_id
-      // which is present in the merge modal request but not the order summary request.
-      if (url.includes('table_id') && (url.includes('tables%28') || url.includes('tables('))) {
+      // Merge modal fetch: select includes the embedded tables relation with locked_by_order_id.
+      // PostgREST join hint encodes as "tables%21orders_table_id_fkey%28...%29" so we can't
+      // rely on "tables(" or "tables%28". Use "locked_by_order_id" as the unique discriminator
+      // — it only appears in the merge-modal orders request.
+      if (url.includes('locked_by_order_id')) {
         return route.fulfill({
           status: 200,
           contentType: 'application/json',

--- a/supabase/functions/provision_restaurant/index.ts
+++ b/supabase/functions/provision_restaurant/index.ts
@@ -2,10 +2,10 @@
  * provision_restaurant — public self-service edge function.
  *
  * Creates a new restaurant and its owner account in one atomic-ish operation:
- *   1. Validates slug uniqueness
+ *   1. Validates slug uniqueness (unique constraint in DB is the duplicate-prevention guard)
  *   2. Creates row in `restaurants` (including optional branch_name)
- *   3. Creates the owner account via Supabase Auth admin API
- *      - If owner_password is provided: createUser with password (owner can log in immediately)
+ *   3. Creates the owner account via Supabase Auth admin API with email confirmation required
+ *      - If owner_password is provided: createUser WITHOUT email_confirm (owner must confirm inbox)
  *      - Otherwise: invite (owner receives an email invitation)
  *   4. Creates row in `users` with role = 'owner'
  *   5. Seeds default config (currency_code, currency_symbol, vat_percentage, service_charge)
@@ -13,7 +13,9 @@
  * On any failure after the restaurant row is created, cleanup is attempted.
  *
  * Auth: none required — this is a public self-service endpoint.
- * Security is maintained through input validation and rate limiting at the infrastructure layer.
+ * Rate limiting: Supabase Edge Functions enforce per-project concurrency limits. The unique
+ * slug + email constraints in the DB prevent duplicate-registration abuse. Additional WAF
+ * or API-gateway rate rules can be layered at the Supabase project or network level.
  */
 
 export const corsHeaders = {
@@ -84,9 +86,10 @@ export async function handler(
       { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   }
-  if (typeof payload['slug'] !== 'string' || !/^[a-z0-9-]+$/.test(payload['slug'] as string)) {
+  // Slug must start and end with an alphanumeric char; interior hyphens are allowed
+  if (typeof payload['slug'] !== 'string' || !/^[a-z0-9]+(-[a-z0-9]+)*$/.test(payload['slug'] as string)) {
     return new Response(
-      JSON.stringify({ success: false, error: 'slug is required and must be lowercase alphanumeric with hyphens' }),
+      JSON.stringify({ success: false, error: 'slug is required and must be lowercase alphanumeric with hyphens (no leading/trailing hyphens)' }),
       { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   }
@@ -106,9 +109,14 @@ export async function handler(
   const ownerPassword = typeof payload['owner_password'] === 'string' && (payload['owner_password'] as string).length >= 8
     ? (payload['owner_password'] as string)
     : null
-  const timezone = typeof payload['timezone'] === 'string' && payload['timezone'].trim()
+  const rawTimezone = typeof payload['timezone'] === 'string' && payload['timezone'].trim()
     ? (payload['timezone'] as string).trim()
     : 'Asia/Dhaka'
+  // Validate against IANA timezone list
+  const validTimezones: string[] = typeof (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf === 'function'
+    ? ((Intl as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf('timeZone') as string[])
+    : []
+  const timezone = validTimezones.length === 0 || validTimezones.includes(rawTimezone) ? rawTimezone : 'Asia/Dhaka'
   const currencyCode = typeof payload['currency_code'] === 'string' && payload['currency_code'].trim()
     ? (payload['currency_code'] as string).trim().toUpperCase()
     // legacy field name support
@@ -176,13 +184,14 @@ export async function handler(
 
   if (ownerPassword) {
     // Create user with password via admin API — owner can log in immediately
+    // Do NOT set email_confirm: true on a public endpoint — the owner must prove
+    // they control the inbox before the account becomes active.
     const createRes = await fetchFn(`${supabaseUrl}/auth/v1/admin/users`, {
       method: 'POST',
       headers: serviceHeaders,
       body: JSON.stringify({
         email: ownerEmail,
         password: ownerPassword,
-        email_confirm: true,
         user_metadata: { restaurant_id: restaurant.id },
       }),
     })

--- a/supabase/functions/provision_restaurant/index.ts
+++ b/supabase/functions/provision_restaurant/index.ts
@@ -13,9 +13,10 @@
  * On any failure after the restaurant row is created, cleanup is attempted.
  *
  * Auth: none required — this is a public self-service endpoint.
- * Rate limiting: Supabase Edge Functions enforce per-project concurrency limits. The unique
- * slug + email constraints in the DB prevent duplicate-registration abuse. Additional WAF
- * or API-gateway rate rules can be layered at the Supabase project or network level.
+ * Rate limiting: No application-level rate limiting is applied. The unique slug + email
+ * constraints in the DB prevent duplicate-registration abuse for identical inputs, but do not
+ * cap requests with distinct values. WAF or API-gateway rate rules can be layered at the
+ * Supabase project or network level for broader protection.
  */
 
 export const corsHeaders = {
@@ -116,7 +117,13 @@ export async function handler(
   const validTimezones: string[] = typeof (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf === 'function'
     ? ((Intl as { supportedValuesOf: (key: string) => string[] }).supportedValuesOf('timeZone') as string[])
     : []
-  const timezone = validTimezones.length === 0 || validTimezones.includes(rawTimezone) ? rawTimezone : 'Asia/Dhaka'
+  if (validTimezones.length > 0 && !validTimezones.includes(rawTimezone)) {
+    return new Response(
+      JSON.stringify({ success: false, error: `Invalid timezone "${rawTimezone}"` }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  const timezone = rawTimezone
   const currencyCode = typeof payload['currency_code'] === 'string' && payload['currency_code'].trim()
     ? (payload['currency_code'] as string).trim().toUpperCase()
     // legacy field name support

--- a/supabase/functions/provision_restaurant/index.ts
+++ b/supabase/functions/provision_restaurant/index.ts
@@ -1,5 +1,5 @@
 /**
- * provision_restaurant — super-admin-only edge function.
+ * provision_restaurant — public self-service edge function.
  *
  * Creates a new restaurant and its owner account in one atomic-ish operation:
  *   1. Validates slug uniqueness
@@ -12,7 +12,8 @@
  *
  * On any failure after the restaurant row is created, cleanup is attempted.
  *
- * Auth: caller must be authenticated AND have is_super_admin = true in the users table.
+ * Auth: none required — this is a public self-service endpoint.
+ * Security is maintained through input validation and rate limiting at the infrastructure layer.
  */
 
 export const corsHeaders = {
@@ -35,56 +36,6 @@ function readEnv(): HandlerEnv | null {
   const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
   if (!supabaseUrl || !serviceKey) return null
   return { supabaseUrl, serviceKey }
-}
-
-/** Verify the JWT and confirm the caller has is_super_admin = true. */
-async function verifySuperAdmin(
-  req: Request,
-  supabaseUrl: string,
-  serviceKey: string,
-  fetchFn: FetchFn,
-): Promise<{ callerId: string } | { error: string; status: 401 | 403 }> {
-  const authHeader = req.headers.get('Authorization')
-  if (!authHeader?.startsWith('Bearer ')) {
-    return { error: 'Unauthorized', status: 401 }
-  }
-  const token = authHeader.slice(7).trim()
-  if (!token) return { error: 'Unauthorized', status: 401 }
-
-  // Verify JWT
-  let callerId: string
-  try {
-    const userRes = await fetchFn(`${supabaseUrl}/auth/v1/user`, {
-      headers: { apikey: serviceKey, Authorization: `Bearer ${token}` },
-    })
-    if (!userRes.ok) return { error: 'Unauthorized', status: 401 }
-    const user = (await userRes.json()) as { id?: string }
-    if (!user.id) return { error: 'Unauthorized', status: 401 }
-    callerId = user.id
-  } catch {
-    return { error: 'Unauthorized', status: 401 }
-  }
-
-  // Check is_super_admin flag
-  try {
-    const roleRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/users?id=eq.${encodeURIComponent(callerId)}&select=is_super_admin&limit=1`,
-      {
-        headers: {
-          apikey: serviceKey,
-          Authorization: `Bearer ${serviceKey}`,
-        },
-      },
-    )
-    if (!roleRes.ok) return { error: 'Unauthorized', status: 401 }
-    const rows = (await roleRes.json()) as Array<{ is_super_admin: boolean }>
-    if (!rows || rows.length === 0) return { error: 'Forbidden', status: 403 }
-    if (!rows[0].is_super_admin) return { error: 'Forbidden — super-admin only', status: 403 }
-  } catch {
-    return { error: 'Unauthorized', status: 401 }
-  }
-
-  return { callerId }
 }
 
 export async function handler(
@@ -112,15 +63,6 @@ export async function handler(
   }
 
   const { supabaseUrl, serviceKey } = env
-
-  // --- auth ---
-  const auth = await verifySuperAdmin(req, supabaseUrl, serviceKey, fetchFn)
-  if ('error' in auth) {
-    return new Response(
-      JSON.stringify({ success: false, error: auth.error }),
-      { status: auth.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-    )
-  }
 
   // --- parse body ---
   let body: unknown


### PR DESCRIPTION
## Summary

Closes #414

Makes the `/register` page fully self-service so any visitor can register a new restaurant without needing a super-admin token.

## Changes

### `supabase/functions/provision_restaurant/index.ts`
- Removed the `verifySuperAdmin()` call entirely — the function is now a public endpoint
- Atomic provisioning flow is preserved: restaurant row → auth user → user profile (role=owner) → default config
- Cleanup on partial failure is still in place

### `apps/web/app/admin/restaurants/new/ProvisionRestaurantForm.tsx`
- Removed the unauthenticated login-prompt block for the `public` variant
- Form now renders directly for all visitors (authenticated or not)
- `handleSubmit` no longer requires `accessToken` — only `supabaseUrl` is checked
- All validation (name, email, password) remains intact

### `apps/web/app/admin/restaurants/restaurantAdminApi.ts`
- `buildHeaders()` now skips the `Authorization` header when token is empty (unauthenticated visitors)

### `apps/web/app/register/page.tsx`
- Updated subtitle from 'Super-admin provisioning' → 'Get started in minutes'

### Tests updated
- `ProvisionRestaurantForm.test.tsx`: replaced 'Please log in' test with new assertion that unauthenticated visitors see the form directly
- `page.test.tsx`: updated tagline assertion to match new copy

## Notes
- One pre-existing test failure exists in `ProvisionRestaurantForm.test.tsx` ('shows error when owner email is invalid') — confirmed present on `main` before this PR, not introduced by these changes
- The `/admin/restaurants` route remains super-admin-only (middleware unchanged)
- Admin variant of `ProvisionRestaurantForm` still requires `is_super_admin` (middleware enforced)