### PR TITLE
fix: bill/payment page stuck on Loading/Printing — add timeouts for hanging fetch and unreliable afterprint

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -357,9 +357,17 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     // remain accessible and the user can still complete the transaction.
     // The clearTimeout in .finally() cancels this timer when the request
     // completes normally.
-    const loadingTimeout = setTimeout(() => { setStatusLoading(false) }, 10000)
+    // timedOut flag prevents a late-resolving fetch from triggering unexpected
+    // state transitions (e.g. setStep('payment')) after the user has already
+    // started interacting with the order-action buttons.
+    let timedOut = false
+    const loadingTimeout = setTimeout(() => {
+      timedOut = true
+      setStatusLoading(false)
+    }, 10000)
     fetchOrderSummary(supabaseUrl, accessToken, orderId)
       .then((summary) => {
+        if (timedOut) return // stale response — loading timeout already fired; discard
         if (summary.status === 'paid') {
           setOrderIsPaid(true)
           setPaidPaymentMethod(summary.payment_method)

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -352,6 +352,12 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     }
 
     setStatusLoading(true)
+    // Safety net: if the network request hangs (e.g. spotty WiFi on a restaurant
+    // tablet), clear the loading state after 10 s so the order action buttons
+    // remain accessible and the user can still complete the transaction.
+    // The clearTimeout in .finally() cancels this timer when the request
+    // completes normally.
+    const loadingTimeout = setTimeout(() => { setStatusLoading(false) }, 10000)
     fetchOrderSummary(supabaseUrl, accessToken, orderId)
       .then((summary) => {
         if (summary.status === 'paid') {
@@ -413,6 +419,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         // Non-fatal: fall back to normal order view if status check fails
       })
       .finally(() => {
+        clearTimeout(loadingTimeout)
         setStatusLoading(false)
       })
   }
@@ -1084,7 +1091,16 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     // Browser print fallback
     setTimeout(() => {
       window.print()
+      // Safety net: clear print state after 15 s if afterprint never fires
+      // (mobile PWA / Android WebView). Without this, printingBill stays true
+      // forever — the bill button stays "Printing…", billPrintGuardRef is locked,
+      // and the success-screen redirect is permanently blocked.
+      const printFallback = setTimeout(() => {
+        setPrintingBill(false)
+        billPrintGuardRef.current = false
+      }, 15000)
       window.addEventListener('afterprint', () => {
+        clearTimeout(printFallback)
         setPrintingBill(false)
         billPrintGuardRef.current = false
       }, { once: true })
@@ -1107,7 +1123,15 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
     setPrintingPreBill(true)
     setTimeout(() => {
       window.print()
+      // Safety net: clear print state after 15 s if afterprint never fires
+      // (mobile PWA / Android WebView). Without this, printingPreBill stays true
+      // forever — the button stays "Printing…" and billPrintGuardRef is locked.
+      const printFallback = setTimeout(() => {
+        setPrintingPreBill(false)
+        billPrintGuardRef.current = false
+      }, 15000)
       window.addEventListener('afterprint', () => {
+        clearTimeout(printFallback)
         setPrintingPreBill(false)
         billPrintGuardRef.current = false
       }, { once: true })

--- a/apps/web/lib/kotPrint.ts
+++ b/apps/web/lib/kotPrint.ts
@@ -178,7 +178,9 @@ export async function printKot(options: KotPrintOptions): Promise<PrintResult> {
       const errorMessage = buildBridgeErrorMessage(detail)
       await onBeforeBrowserPrint?.()
       await new Promise<void>((resolve) => {
-        window.addEventListener('afterprint', () => resolve(), { once: true })
+        // Safety net: resolve after 15 s if afterprint never fires (mobile PWA / Android WebView).
+        const timeoutId = setTimeout(resolve, 15000)
+        window.addEventListener('afterprint', () => { clearTimeout(timeoutId); resolve() }, { once: true })
         window.print()
       })
       await onAfterBrowserPrint?.()
@@ -189,7 +191,11 @@ export async function printKot(options: KotPrintOptions): Promise<PrintResult> {
   // Browser print fallback
   await onBeforeBrowserPrint?.()
   await new Promise<void>((resolve) => {
-    window.addEventListener('afterprint', () => resolve(), { once: true })
+    // Safety net: resolve after 15 s if afterprint never fires (mobile PWA / Android WebView).
+    // Without this the promise hangs forever, keeping kotStatus / reprintingKot stuck
+    // and the UI frozen (back button disabled, order page inaccessible).
+    const timeoutId = setTimeout(resolve, 15000)
+    window.addEventListener('afterprint', () => { clearTimeout(timeoutId); resolve() }, { once: true })
     window.print()
   })
   await onAfterBrowserPrint?.()
@@ -241,7 +247,9 @@ export async function printBill(options: BillPrintOptions): Promise<PrintResult>
       const errorMessage = buildBridgeErrorMessage(detail)
       await onBeforeBrowserPrint?.()
       await new Promise<void>((resolve) => {
-        window.addEventListener('afterprint', () => resolve(), { once: true })
+        // Safety net: resolve after 15 s if afterprint never fires (mobile PWA / Android WebView).
+        const timeoutId = setTimeout(resolve, 15000)
+        window.addEventListener('afterprint', () => { clearTimeout(timeoutId); resolve() }, { once: true })
         window.print()
       })
       await onAfterBrowserPrint?.()
@@ -252,7 +260,11 @@ export async function printBill(options: BillPrintOptions): Promise<PrintResult>
   // Browser print fallback
   await onBeforeBrowserPrint?.()
   await new Promise<void>((resolve) => {
-    window.addEventListener('afterprint', () => resolve(), { once: true })
+    // Safety net: resolve after 15 s if afterprint never fires (mobile PWA / Android WebView).
+    // Without this the promise hangs forever, keeping printingBill / billPrintGuardRef stuck
+    // and the payment page inaccessible.
+    const timeoutId = setTimeout(resolve, 15000)
+    window.addEventListener('afterprint', () => { clearTimeout(timeoutId); resolve() }, { once: true })
     window.print()
   })
   await onAfterBrowserPrint?.()


### PR DESCRIPTION
## Bug

The bill submission / payment page could get stuck on **Loading…** or **Printing…** with a spinning wheel, preventing the user from completing the transaction.

## Root causes

### 1. "Loading…" stuck — CRITICAL (blocks payment completion)

`loadOrderStatus()` calls `fetchOrderSummary()` with no timeout. On spotty WiFi (common on restaurant tablets), `fetch()` can hang indefinitely, keeping `statusLoading = true`. While loading, ALL order-action buttons are hidden — Close Order, Proceed to Payment, Add Items — and the user literally cannot complete the transaction.

**Fix:** Added a 10-second `setTimeout` safety net in `loadOrderStatus()`. If `fetchOrderSummary` never resolves, the loading state is cleared after 10 s so the order-action buttons become accessible. The `clearTimeout()` in the `.finally()` block cancels the timer when the request completes normally.

### 2. "Printing…" stuck — UX blocker

Both `kotPrint.ts` (`printKot` / `printBill`) and `OrderDetailClient.tsx` (`handlePrintBill` / `handlePrintPreBill`) rely solely on the `afterprint` browser event to clear print state. On mobile PWA and some Android WebViews, `afterprint` is not reliably fired. When it doesn't fire:
- `printingBill` / `printingPreBill` state stays `true` forever → buttons stuck on "Printing…"
- `billPrintGuardRef.current` stays `true` → all future print attempts silently no-op
- The success-screen auto-redirect to `/tables` is permanently blocked
- In `doBackToTables`, the awaited `printKot()` never resolves → back button stuck on "Sending to kitchen…" (disabled)

**Fix:** Added a 15-second `setTimeout` fallback in each location. If `afterprint` doesn't fire within 15 s, the promise resolves / print state is cleared. `clearTimeout()` cancels the fallback when `afterprint` fires normally.

## Files changed

- `apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx` — 10 s loading timeout + 15 s print fallback
- `apps/web/lib/kotPrint.ts` — 15 s afterprint fallback in all four browser-print paths

## No edge-function changes

`close_order` and `record_payment` were audited and are correct. The `user_restaurants` references in other functions are comments only (the actual queries already use `users.restaurant_id` — same fix applied in PR #422).