### PR TITLE
fix: service charge excluded from bill total in change calculation (#424)

### DIFF
--- a/supabase/functions/record_payment/index.test.ts
+++ b/supabase/functions/record_payment/index.test.ts
@@ -431,6 +431,10 @@ function buildMockFetch(
           discount_amount_cents: 0,
           order_comp: false,
           customer_id: null,
+          // Additional fields for correct change calculation (issue #424):
+          service_charge_cents: 0,
+          delivery_charge: 0,
+          order_type: 'dine_in',
         }]),
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       )
@@ -438,6 +442,14 @@ function buildMockFetch(
     // Order status PATCH
     if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
       return new Response(null, { status: 204 })
+    }
+    // VAT config lookup (new — issue #424)
+    if (url.includes('/rest/v1/config')) {
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    // VAT rate lookup (new — issue #424)
+    if (url.includes('/rest/v1/vat_rates')) {
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
     }
     // Payments POST – capture inserted body for assertion
     if (url.includes('/rest/v1/payments') && init?.method === 'POST') {
@@ -452,6 +464,59 @@ function buildMockFetch(
       return new Response(null, { status: 204 })
     }
     // Default – should not be reached
+    return new Response(JSON.stringify({ error: `Unhandled: ${url}` }), { status: 500 })
+  })
+}
+
+/** Build a mock fetchFn that simulates an order with service charge applied. */
+function buildMockFetchWithServiceCharge(
+  subtotalCents: number,
+  discountCents: number,
+  serviceChargeCents: number,
+  orderType: 'dine_in' | 'takeaway' | 'delivery',
+  deliveryChargeCents: number,
+  captured: { paymentInsertBody?: unknown } = {},
+): FetchFn {
+  return vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+    if (url.includes('/auth/v1/user')) {
+      return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    if (url.includes('/rest/v1/users')) {
+      return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    if (url.includes('/rest/v1/orders') && (!init?.method || init?.method === 'GET')) {
+      return new Response(
+        JSON.stringify([{
+          id: VALID_ORDER_ID,
+          restaurant_id: RESTAURANT_ID,
+          status: 'pending_payment',
+          final_total_cents: subtotalCents,
+          discount_amount_cents: discountCents,
+          order_comp: false,
+          customer_id: null,
+          service_charge_cents: serviceChargeCents,
+          delivery_charge: deliveryChargeCents,
+          order_type: orderType,
+        }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+    if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
+      return new Response(null, { status: 204 })
+    }
+    if (url.includes('/rest/v1/config')) {
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    if (url.includes('/rest/v1/vat_rates')) {
+      return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    }
+    if (url.includes('/rest/v1/payments') && init?.method === 'POST') {
+      captured.paymentInsertBody = JSON.parse(init.body as string)
+      return new Response(JSON.stringify([{ id: PAYMENT_ID }]), { status: 201, headers: { 'Content-Type': 'application/json' } })
+    }
+    if (url.includes('/rest/v1/audit_log')) {
+      return new Response(null, { status: 204 })
+    }
     return new Response(JSON.stringify({ error: `Unhandled: ${url}` }), { status: 500 })
   })
 }
@@ -632,5 +697,89 @@ describe('record_payment — overpayment and tips (issue #390)', () => {
     const json = await res.json() as { success: boolean; error: string }
     expect(json.success).toBe(false)
     expect(json.error).toBe('Total tendered does not cover the order total')
+  })
+})
+
+// ── Service charge change calculation fix (issue #424) ───────────────────────
+// Regression guard: service charge must be included in the bill total used for
+// computing change. Before the fix, change = tendered − postDiscountBase,
+// which excluded service_charge_cents and caused the wrong amount to be shown.
+
+describe('record_payment — service charge included in change calculation (issue #424)', () => {
+  it('computes correct change when service charge is present (no VAT, no delivery)', async (): Promise<void> => {
+    // Reproduces Lidia’s production screenshot:
+    //   Subtotal: ৳7,190  (719,000 cents)
+    //   Service charge 10%: ৳719  (71,900 cents)
+    //   Bill total: ৳7,909  (790,900 cents)
+    //   Cash tendered: ৳8,000  (800,000 cents)
+    //   Correct change: ৳91  (9,100 cents)
+    //   Bug (before fix): ৳810  (81,000 cents) — change used postDiscountBase only
+    const captured: { paymentInsertBody?: unknown } = {}
+    const mockFetch = buildMockFetchWithServiceCharge(
+      719000,  // final_total_cents (subtotal, per-item discounts applied)
+      0,       // discount_amount_cents (no order-level discount)
+      71900,   // service_charge_cents (10% of 719,000)
+      'dine_in',
+      0,       // delivery_charge
+      captured,
+    )
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 800000 }],
+      }),
+    })
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(200)
+    const json = await res.json() as { success: boolean; data: { change_due: number } }
+    expect(json.success).toBe(true)
+    // Bill total = 719,000 + 71,900 = 790,900 → change = 800,000 − 790,900 = 9,100
+    expect(json.data.change_due).toBe(9100)
+
+    // amount_cents should be the bill portion (790,900), not the tendered amount
+    const row = captured.paymentInsertBody as InsertedPaymentRow
+    expect(row.amount_cents).toBe(790900)
+    expect(row.tendered_amount_cents).toBe(800000)
+  })
+
+  it('returns 400 when tendered is less than bill total including service charge', async (): Promise<void> => {
+    // Subtotal 719,000, SC 71,900 → bill total 790,900.
+    // Customer only tenders 719,000 (the raw subtotal, ignoring SC) — must be rejected.
+    const mockFetch = buildMockFetchWithServiceCharge(719000, 0, 71900, 'dine_in', 0)
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 719000 }],
+      }),
+    })
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(400)
+    const json = await res.json() as { success: boolean; error: string }
+    expect(json.success).toBe(false)
+    expect(json.error).toBe('Total tendered does not cover the order total')
+  })
+
+  it('computes correct change for delivery order with service charge + delivery fee', async (): Promise<void> => {
+    // Subtotal: 500,000 cents, SC: 0 (no SC on delivery), delivery: 30,000 cents.
+    // Bill total: 530,000. Cash: 600,000. Change: 70,000.
+    const captured: { paymentInsertBody?: unknown } = {}
+    const mockFetch = buildMockFetchWithServiceCharge(500000, 0, 0, 'delivery', 30000, captured)
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 600000 }],
+      }),
+    })
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(200)
+    const json = await res.json() as { success: boolean; data: { change_due: number } }
+    expect(json.success).toBe(true)
+    expect(json.data.change_due).toBe(70000) // 600,000 − 530,000 = 70,000
   })
 })

--- a/supabase/functions/record_payment/index.test.ts
+++ b/supabase/functions/record_payment/index.test.ts
@@ -782,4 +782,73 @@ describe('record_payment — service charge included in change calculation (issu
     expect(json.success).toBe(true)
     expect(json.data.change_due).toBe(70000) // 600,000 − 530,000 = 70,000
   })
+
+  it('includes exclusive VAT in bill total for change calculation', async (): Promise<void> => {
+    // Subtotal: 100,000 cents, SC 10%: 10,000 cents → vatBase 110,000.
+    // VAT exclusive 15%: 16,500 cents → bill total 126,500 cents.
+    // Cash tendered: 130,000. Change: 3,500.
+    const captured: { paymentInsertBody?: unknown } = {}
+    // Build a mock that returns non-empty VAT config (exclusive, applies to dine_in) and 15% VAT rate.
+    const mockFetchWithVat: FetchFn = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+      if (url.includes('/auth/v1/user')) {
+        return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('/rest/v1/users')) {
+        return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('/rest/v1/orders') && (!init?.method || init?.method === 'GET')) {
+        return new Response(
+          JSON.stringify([{
+            id: VALID_ORDER_ID, restaurant_id: RESTAURANT_ID, status: 'pending_payment',
+            final_total_cents: 100000, discount_amount_cents: 0, order_comp: false, customer_id: null,
+            service_charge_cents: 10000, delivery_charge: 0, order_type: 'dine_in',
+          }]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
+        return new Response(null, { status: 204 })
+      }
+      if (url.includes('/rest/v1/config')) {
+        // tax_inclusive=false (exclusive), vat_apply_dine_in=true
+        return new Response(
+          JSON.stringify([{ key: 'tax_inclusive', value: 'false' }, { key: 'vat_apply_dine_in', value: 'true' }]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url.includes('/rest/v1/vat_rates')) {
+        return new Response(
+          JSON.stringify([{ percentage: 15 }]),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      if (url.includes('/rest/v1/payments') && init?.method === 'POST') {
+        captured.paymentInsertBody = JSON.parse(init.body as string)
+        return new Response(JSON.stringify([{ id: PAYMENT_ID }]), { status: 201, headers: { 'Content-Type': 'application/json' } })
+      }
+      if (url.includes('/rest/v1/audit_log')) {
+        return new Response(null, { status: 204 })
+      }
+      return new Response(JSON.stringify({ error: `Unhandled: ${url}` }), { status: 500 })
+    })
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 130000 }],
+      }),
+    })
+    const res = await handler(req, mockFetchWithVat, TEST_ENV)
+    expect(res.status).toBe(200)
+    const json = await res.json() as { success: boolean; data: { change_due: number } }
+    expect(json.success).toBe(true)
+    // vatBase = 100,000 + 10,000 = 110,000; VAT 15% exclusive = 16,500; bill = 126,500
+    // change = 130,000 − 126,500 = 3,500
+    expect(json.data.change_due).toBe(3500)
+
+    const row = captured.paymentInsertBody as InsertedPaymentRow
+    expect(row.amount_cents).toBe(126500) // bill total
+    expect(row.tendered_amount_cents).toBe(130000)
+  })
 })

--- a/supabase/functions/record_payment/index.ts
+++ b/supabase/functions/record_payment/index.ts
@@ -213,7 +213,7 @@ export async function handler(
     // Defaults to 0% / exclusive if config is unavailable (best-effort, non-fatal).
     let vatPercent = 0
     let taxInclusive = false
-    let vatApplies = true // dine_in default
+    let vatApplies = false // conservative default: do not apply VAT if config is unavailable
     try {
       const vatConfigRes = await fetchFn(
         `${supabaseUrl}/rest/v1/config?select=key,value&restaurant_id=eq.${restaurantId}&key=in.(tax_inclusive,vat_apply_dine_in,vat_apply_takeaway,vat_apply_delivery)`,
@@ -256,11 +256,9 @@ export async function handler(
     const vatCents = (vatApplies && vatPercent > 0 && !taxInclusive)
       ? Math.round((vatBase * vatPercent) / 100)
       : 0
-    const effectiveTotalCents = isOrderComp
+    const finalTotalCents = isOrderComp
       ? 0
       : vatBase + vatCents + deliveryChargeCents
-
-    const finalTotalCents = effectiveTotalCents
 
     // For split-payment: validate total tendered covers the order total
     const totalTenderedCents = paymentsToRecord.reduce((s, p) => s + p.amount, 0)

--- a/supabase/functions/record_payment/index.ts
+++ b/supabase/functions/record_payment/index.ts
@@ -170,10 +170,12 @@ export async function handler(
   }
 
   try {
-    // 1. Fetch the order to verify it exists, is pending_payment, and get final_total_cents
-    //    Also fetch customer_id here to avoid a second roundtrip in the loyalty block (issue #356)
+    // 1. Fetch the order to verify it exists, is pending_payment, and get final_total_cents.
+    //    Also fetch service_charge_cents, delivery_charge, order_type so we can compute the
+    //    true bill total for change calculation (bug fix: service charge was missing — issue #424).
+    //    Also fetch customer_id here to avoid a second roundtrip in the loyalty block (issue #356).
     const orderRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,final_total_cents,discount_amount_cents,order_comp,customer_id&id=eq.${orderId}`,
+      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,final_total_cents,discount_amount_cents,order_comp,customer_id,service_charge_cents,delivery_charge,order_type&id=eq.${orderId}`,
       { headers: dbHeaders },
     )
     if (!orderRes.ok) {
@@ -182,7 +184,7 @@ export async function handler(
         { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
-    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string; final_total_cents: number | null; discount_amount_cents: number | null; order_comp: boolean | null; customer_id: string | null }>
+    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string; final_total_cents: number | null; discount_amount_cents: number | null; order_comp: boolean | null; customer_id: string | null; service_charge_cents: number | null; delivery_charge: number | null; order_type: string | null }>
     if (orders.length === 0) {
       return new Response(
         JSON.stringify({ success: false, error: 'Order not found' }),
@@ -201,9 +203,62 @@ export async function handler(
     const isOrderComp = orders[0].order_comp === true
     const rawFinalTotalCents = orders[0].final_total_cents ?? 0
     const discountAmountCents = orders[0].discount_amount_cents ?? 0
+    const serviceChargeCents = orders[0].service_charge_cents ?? 0
+    const orderType = orders[0].order_type ?? 'dine_in'
+    const deliveryChargeCents = orderType === 'delivery' ? (orders[0].delivery_charge ?? 0) : 0
+
+    // Fetch VAT config to include VAT in the effective bill total.
+    // This mirrors the frontend's billTotalCents calculation:
+    //   Subtotal → Discount → Service Charge → VAT → + Delivery
+    // Defaults to 0% / exclusive if config is unavailable (best-effort, non-fatal).
+    let vatPercent = 0
+    let taxInclusive = false
+    let vatApplies = true // dine_in default
+    try {
+      const vatConfigRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/config?select=key,value&restaurant_id=eq.${restaurantId}&key=in.(tax_inclusive,vat_apply_dine_in,vat_apply_takeaway,vat_apply_delivery)`,
+        { headers: dbHeaders },
+      )
+      if (vatConfigRes.ok) {
+        const cfgRows = (await vatConfigRes.json()) as Array<{ key: string; value: string }>
+        const cfgMap = new Map(cfgRows.map((r) => [r.key, r.value]))
+        taxInclusive = cfgMap.get('tax_inclusive') === 'true'
+        // Per-type defaults: dine_in=true, takeaway=true, delivery=false
+        const applyDineIn = cfgMap.has('vat_apply_dine_in') ? cfgMap.get('vat_apply_dine_in') === 'true' : true
+        const applyTakeaway = cfgMap.has('vat_apply_takeaway') ? cfgMap.get('vat_apply_takeaway') === 'true' : true
+        const applyDelivery = cfgMap.has('vat_apply_delivery') ? cfgMap.get('vat_apply_delivery') === 'true' : false
+        vatApplies = (orderType === 'dine_in' && applyDineIn)
+          || (orderType === 'takeaway' && applyTakeaway)
+          || (orderType === 'delivery' && applyDelivery)
+      }
+      // Fetch restaurant default VAT rate (menu_id IS NULL = restaurant-level default)
+      const vatRateRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/vat_rates?select=percentage&restaurant_id=eq.${restaurantId}&menu_id=is.null&limit=1`,
+        { headers: dbHeaders },
+      )
+      if (vatRateRes.ok) {
+        const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string }>
+        if (vatRateRows.length > 0) {
+          vatPercent = Number(vatRateRows[0].percentage) || 0
+        }
+      }
+    } catch {
+      // Non-fatal: VAT config unavailable — defaults to 0%, change calc still corrected for SC
+    }
+
+    // Compute the true bill total that the customer owes, matching the frontend's billTotalCents:
+    //   postDiscountBase = subtotal (per-item discounts applied) − order-level discount
+    //   vatBase          = postDiscountBase + service charge
+    //   vatCents         = vatBase × vatPercent / 100  (0 when tax-inclusive — VAT already in prices)
+    //   billTotal        = vatBase + vatCents + delivery charge
+    const postDiscountBase = Math.max(0, rawFinalTotalCents - discountAmountCents)
+    const vatBase = postDiscountBase + serviceChargeCents
+    const vatCents = (vatApplies && vatPercent > 0 && !taxInclusive)
+      ? Math.round((vatBase * vatPercent) / 100)
+      : 0
     const effectiveTotalCents = isOrderComp
       ? 0
-      : Math.max(0, rawFinalTotalCents - discountAmountCents)
+      : vatBase + vatCents + deliveryChargeCents
 
     const finalTotalCents = effectiveTotalCents
 


### PR DESCRIPTION
## Bug

Service charge amount was incorrectly shown as "change due" on the payment screen.

**From Lidia's screenshot:**
| | Amount |
|---|---|
| Cash tendered | ৳8,000 |
| Bill total | ৳7,909 |
| Correct change | ৳91 |
| **Wrong change shown** | **৳810** |

## Root cause

In `supabase/functions/record_payment/index.ts`, the effective bill total for change calculation was:

```ts
// BEFORE (wrong)
const effectiveTotalCents = rawFinalTotalCents - discountAmountCents
// = postDiscountBase only — service charge not included!
```

`close_order` stores items subtotal in `final_total_cents` and service charge separately in `service_charge_cents`. But `record_payment` only fetched `final_total_cents` — never adding `service_charge_cents` back.

Result: change = tendered − postDiscountBase = ৳8,000 − ৳7,190 = **৳810** (off by exactly the service charge amount ৳719).

## Fix

`record_payment` now also fetches `service_charge_cents`, `delivery_charge`, and `order_type` from the order, then fetches VAT config (best-effort) to reconstruct the true bill total matching the frontend's `billTotalCents`:

```
postDiscountBase + serviceCharge + VAT (exclusive only) + deliveryCharge
```

```ts
// AFTER (correct)
const postDiscountBase = Math.max(0, rawFinalTotalCents - discountAmountCents)
const vatBase = postDiscountBase + serviceChargeCents
const vatCents = vatApplies && vatPercent > 0 && !taxInclusive
  ? Math.round((vatBase * vatPercent) / 100)
  : 0
const effectiveTotalCents = vatBase + vatCents + deliveryChargeCents
```

## Tests

3 new regression tests added (issue #424):
1. Correct change = ৳91 with 10% service charge (exact production repro)
2. Under-payment rejected when tendered < subtotal + SC
3. Delivery order: change includes delivery charge in bill total

All existing `tendered_amount_cents` and overpayment/tip tests pass unchanged.