### PR TITLE
fix: complimentary bills (৳0 total) not appearing in Receipt history

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -1284,7 +1284,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       try {
         const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
         if (!supabaseUrl || !accessToken) throw new Error('Not authenticated')
+        // Payment method is arbitrary for a ৳0 settlement — 'cash' is used as the
+        // conventional placeholder since no physical tender changes hands.
         await callRecordSplitPayment(supabaseUrl, accessToken, orderId, [{ method: 'cash', amountCents: 0 }])
+        setConfirmedSplitPayments([{ method: 'cash', amountCents: 0 }])
         setConfirmedPaymentMethod('cash')
         setStep('success')
       } catch (err) {

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -1277,10 +1277,21 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   async function handleRecordPayment(): Promise<void> {
     setPaymentError(null)
 
-    // Fully comped order (total = ৳0) — skip payment recording, go straight to success
+    // Fully comped order (total = ৳0) — record a ৳0 payment so the order is
+    // marked 'paid' and appears in Receipt history (bug fix: comp bills invisible).
     if (billTotalCents === 0) {
-      setConfirmedPaymentMethod('cash')
-      setStep('success')
+      setPaying(true)
+      try {
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+        if (!supabaseUrl || !accessToken) throw new Error('Not authenticated')
+        await callRecordSplitPayment(supabaseUrl, accessToken, orderId, [{ method: 'cash', amountCents: 0 }])
+        setConfirmedPaymentMethod('cash')
+        setStep('success')
+      } catch (err) {
+        setPaymentError(err instanceof Error ? err.message : 'Failed to record payment')
+      } finally {
+        setPaying(false)
+      }
       return
     }
 

--- a/supabase/functions/record_payment/index.test.ts
+++ b/supabase/functions/record_payment/index.test.ts
@@ -852,3 +852,70 @@ describe('record_payment — service charge included in change calculation (issu
     expect(row.tendered_amount_cents).toBe(130000)
   })
 })
+
+// ── Complimentary order (৳0 total) tests (comp bill receipt fix) ─────────────
+// Regression guard: a fully comped order (all items [COMP], total = ৳0) must
+// be accepted by record_payment and marked 'paid' so it appears in receipt history.
+
+describe('record_payment — complimentary orders (৳0 bill)', () => {
+  it('accepts a ৳0 split payment and marks the order paid', async (): Promise<void> => {
+    const captured: { paymentInsertBody?: unknown } = {}
+    // Comp order: final_total_cents=0 (all items comped, no charge)
+    const mockFetch = buildMockFetch(0, captured)
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 0 }],
+      }),
+    })
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(200)
+    const json = await res.json() as { success: boolean; data: { payment_id: string; change_due: number } }
+    expect(json.success).toBe(true)
+    expect(json.data.change_due).toBe(0)
+
+    // A ৳0 payment row must still be inserted so the order shows in receipt history
+    const row = captured.paymentInsertBody as InsertedPaymentRow
+    expect(row.amount_cents).toBe(0)
+    expect(row.tendered_amount_cents).toBe(0)
+    expect(row.method).toBe('cash')
+  })
+
+  it('rejects a negative payment amount even for a ৳0 order', async (): Promise<void> => {
+    const mockFetch = buildMockFetch(0)
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: -10 }],
+      }),
+    })
+    // amount < 0 must still be rejected at validation (400) before reaching DB
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(400)
+    const json = await res.json() as { success: boolean; error: string }
+    expect(json.success).toBe(false)
+    expect(json.error).toBe('each payment amount must not be negative')
+  })
+
+  it('rejects under-payment when bill total is non-zero', async (): Promise<void> => {
+    // Ensure the existing under-payment guard is not regressed by the ৳0 allowance
+    const mockFetch = buildMockFetch(50000)
+    const req = new Request('http://localhost/functions/v1/record_payment', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+      body: JSON.stringify({
+        order_id: VALID_ORDER_ID,
+        payments: [{ method: 'cash', amount: 0 }],
+      }),
+    })
+    const res = await handler(req, mockFetch, TEST_ENV)
+    expect(res.status).toBe(400)
+    const json = await res.json() as { success: boolean; error: string }
+    expect(json.success).toBe(false)
+    expect(json.error).toBe('Total tendered does not cover the order total')
+  })
+})

--- a/supabase/functions/record_payment/index.ts
+++ b/supabase/functions/record_payment/index.ts
@@ -121,9 +121,9 @@ export async function handler(
           { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
         )
       }
-      if (typeof row['amount'] !== 'number' || (row['amount'] as number) <= 0) {
+      if (typeof row['amount'] !== 'number' || (row['amount'] as number) < 0) {
         return new Response(
-          JSON.stringify({ success: false, error: 'each payment amount must be a positive number' }),
+          JSON.stringify({ success: false, error: 'each payment amount must not be negative' }),
           { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
         )
       }
@@ -140,9 +140,9 @@ export async function handler(
         { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
-    if ((payload['amount'] as number) <= 0) {
+    if ((payload['amount'] as number) < 0) {
       return new Response(
-        JSON.stringify({ success: false, error: 'amount must be greater than 0' }),
+        JSON.stringify({ success: false, error: 'amount must not be negative' }),
         { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }


### PR DESCRIPTION
## Bug

After settling a fully-complimentary bill (all items [COMP], total = ৳0), the order **does not appear in the Receipt section**. Normal paid orders show correctly.

## Root Cause (two bugs)

### 1. Frontend — order never marked `paid`
In `OrderDetailClient.tsx`, when `billTotalCents === 0` the payment handler took an early-return shortcut that skipped calling `record_payment` entirely and went straight to the success step. The order was **never updated to `status = paid`** in the database. The receipts query filters `status=eq.paid`, so the order was permanently invisible there.

### 2. Backend — ৳0 amount explicitly rejected
In `record_payment/index.ts`, both the single-payment and split-payment validation paths checked `amount <= 0` and returned a 400 error. Even if the frontend had sent a ৳0 payment it would have been refused.

## Fix

### `record_payment/index.ts`
- Changed validation from `amount <= 0` → `amount < 0` (allow zero for comp orders)
- Updated error message to `amount must not be negative`

### `OrderDetailClient.tsx`
- Replaced the early-return shortcut for `billTotalCents === 0` with an actual call to `callRecordSplitPayment(..., [{ method: 'cash', amountCents: 0 }])`
- This writes a ৳0 payment row and marks the order `paid`, making it visible in receipt history

## Tests
3 new integration tests added to `supabase/functions/record_payment/index.test.ts`:
- ✅ Accepts ৳0 split payment and marks order paid
- ✅ Rejects negative amount even for ৳0 order (guard not regressed)
- ✅ Rejects under-payment when bill total is non-zero (guard not regressed)