### PR TITLE
fix: 5% VAT not applied to dine-in bill totals (issue #146)

### DIFF
--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -59,12 +59,15 @@ function timeOnly(iso: string): string {
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
 }
 
-/** Compute subtotal from items (for BillPrintView prop) */
+/**
+ * Compute the displayed subtotal for BillPrintView (items total before order-level discount).
+ * Uses rawSubtotalCents from ReprintOrderData (= final_total_cents from DB: items after per-item
+ * discounts, before order-level discount / SC / VAT).
+ * For tax-inclusive VAT, the subtotal is the net (ex-VAT) amount.
+ */
 function computeSubtotal(data: ReprintOrderData, vatPercent: number, taxInclusive: boolean): number {
-  const itemsTotal = data.items.reduce((sum, item) => {
-    if (item.comp) return sum
-    return sum + item.quantity * item.price_cents
-  }, 0)
+  // rawSubtotalCents = sum of (qty × price - per-item discount) for non-comp items
+  const itemsTotal = data.rawSubtotalCents
 
   if (taxInclusive && vatPercent > 0) {
     return Math.round(itemsTotal / (1 + vatPercent / 100))
@@ -205,6 +208,7 @@ function ReprintModal({
           subtotalCents={subtotalCents}
           vatPercent={config.vatPercent}
           taxInclusive={config.taxInclusive}
+          vatCents={data.vatCents}
           totalCents={data.finalTotalCents}
           paymentMethod={(singlePayment?.method ?? 'cash') as PaymentMethod}
           amountTenderedCents={cashTendered}

--- a/apps/web/app/receipts/billHistoryApi.ts
+++ b/apps/web/app/receipts/billHistoryApi.ts
@@ -41,6 +41,8 @@ export interface BillHistoryOrder {
   delivery_charge: number
   delivery_zone_name: string | null
   service_charge_cents: number
+  /** VAT amount in cents — computed by close_order from vat_rates (issue #146 fix). */
+  vat_cents: number
 }
 
 export interface BillHistoryResult {
@@ -87,6 +89,7 @@ interface RawOrderRow {
   delivery_note: string | null
   delivery_charge: number | null
   service_charge_cents: number | null
+  vat_cents: number | null
   tables: { label: string } | null
   delivery_zones: { name: string } | null
   payments: Array<{
@@ -114,7 +117,7 @@ export async function fetchBillHistory(
   const url = new URL(`${supabaseUrl}/rest/v1/orders`)
   url.searchParams.set(
     'select',
-    'id,bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,server_id,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables!orders_table_id_fkey(label),delivery_zones(name),payments(method,amount_cents,tendered_amount_cents)',
+    'id,bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,server_id,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,vat_cents,tables!orders_table_id_fkey(label),delivery_zones(name),payments(method,amount_cents,tendered_amount_cents)',
   )
   url.searchParams.set('status', 'eq.paid')
 
@@ -203,7 +206,20 @@ export async function fetchBillHistory(
   let totalDailyCents = 0
 
   const orders: BillHistoryOrder[] = rows.map((row) => {
-    const finalTotal = row.final_total_cents ?? 0
+    // Compute the true bill total for daily totals and display:
+    //   (items_subtotal - discount + service_charge + vat_cents) + delivery
+    // final_total_cents = items subtotal (per-item discounts applied, before order discount).
+    // For orders closed before the vat_cents fix, vat_cents defaults to 0.
+    const rawSubtotal = row.final_total_cents ?? 0
+    const discount = row.discount_amount_cents ?? 0
+    const sc = row.service_charge_cents ?? 0
+    const vat = row.vat_cents ?? 0
+    const delivery = row.delivery_charge ?? 0
+    const orderTypeStr = row.order_type ?? 'dine_in'
+    const deliveryForTotal = orderTypeStr === 'delivery' ? delivery : 0
+    const finalTotal = (row.order_comp ?? false)
+      ? 0
+      : (rawSubtotal - discount) + sc + vat + deliveryForTotal
     totalDailyCents += finalTotal
 
     const payments: PaymentEntry[] = (row.payments ?? []).map((p) => ({
@@ -237,6 +253,7 @@ export async function fetchBillHistory(
       delivery_charge: row.delivery_charge ?? 0,
       delivery_zone_name: row.delivery_zones?.name ?? null,
       service_charge_cents: row.service_charge_cents ?? 0,
+      vat_cents: row.vat_cents ?? 0,
     }
   })
 
@@ -249,8 +266,12 @@ export interface ReprintOrderData {
   orderType: 'dine_in' | 'takeaway' | 'delivery'
   billNumber: string | null
   orderNumber: number | null
-  finalTotalCents: number
+  /** Items subtotal after per-item discounts, before order-level discount. */
+  rawSubtotalCents: number
+  /** Order-level discount in cents. */
   discountAmountCents: number
+  /** True bill total: (rawSubtotal - discount + SC + VAT) + delivery. Used as totalCents in BillPrintView. */
+  finalTotalCents: number
   orderComp: boolean
   customerName: string | null
   customerMobile: string | null
@@ -258,6 +279,8 @@ export interface ReprintOrderData {
   deliveryCharge: number
   deliveryZoneName: string | null
   serviceChargeCents: number
+  /** VAT amount in cents — stored by close_order (issue #146 fix). */
+  vatCents: number
   payments: PaymentEntry[]
   createdAt: string
 }
@@ -296,7 +319,7 @@ export async function fetchOrderForReprint(
   // Fetch order details + items + payments in parallel
   const [orderRes, itemsRes, paymentsRes] = await Promise.all([
     fetch(
-      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}&select=bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,tables!orders_table_id_fkey(label),delivery_zones(name)`,
+      `${supabaseUrl}/rest/v1/orders?id=eq.${orderId}&select=bill_number,order_number,created_at,final_total_cents,discount_amount_cents,order_comp,order_type,customer_name,customer_mobile,delivery_note,delivery_charge,service_charge_cents,vat_cents,tables!orders_table_id_fkey(label),delivery_zones(name)`,
       { headers },
     ),
     fetch(
@@ -334,6 +357,7 @@ export async function fetchOrderForReprint(
         delivery_note: string | null
         delivery_charge: number | null
         service_charge_cents: number | null
+        vat_cents: number | null
         tables: { label: string } | null
         delivery_zones: { name: string } | null
       }>
@@ -398,6 +422,19 @@ export async function fetchOrderForReprint(
   }))
 
   const orderType = (order.order_type ?? 'dine_in') as ReprintOrderData['orderType']
+  const rawSubtotalCents = order.final_total_cents ?? 0
+  const discountAmountCents = order.discount_amount_cents ?? 0
+  const serviceChargeCents = order.service_charge_cents ?? 0
+  const vatCents = order.vat_cents ?? 0
+  const deliveryCharge = order.delivery_charge ?? 0
+  const orderComp = order.order_comp ?? false
+  const deliveryForTotal = orderType === 'delivery' ? deliveryCharge : 0
+  // True bill total: (items_subtotal - order_discount + SC + VAT) + delivery
+  // Mirrors close_order / record_payment computation order.
+  const finalTotalCents = orderComp
+    ? 0
+    : (rawSubtotalCents - discountAmountCents) + serviceChargeCents + vatCents + deliveryForTotal
+
   return {
     items,
     // Use type-appropriate fallback: delivery orders have no table
@@ -405,15 +442,17 @@ export async function fetchOrderForReprint(
     orderType,
     billNumber: order.bill_number,
     orderNumber: order.order_number,
-    finalTotalCents: order.final_total_cents ?? 0,
-    discountAmountCents: order.discount_amount_cents ?? 0,
-    orderComp: order.order_comp ?? false,
+    rawSubtotalCents,
+    discountAmountCents,
+    finalTotalCents,
+    orderComp,
     customerName: order.customer_name,
     customerMobile: order.customer_mobile,
     deliveryNote: order.delivery_note,
-    deliveryCharge: order.delivery_charge ?? 0,
+    deliveryCharge,
     deliveryZoneName: order.delivery_zones?.name ?? null,
-    serviceChargeCents: order.service_charge_cents ?? 0,
+    serviceChargeCents,
+    vatCents,
     payments,
     createdAt: order.created_at,
   }

--- a/supabase/functions/close_order/index.test.ts
+++ b/supabase/functions/close_order/index.test.ts
@@ -83,8 +83,15 @@ function buildMockFetch(orderStatus: string, extras?: {
         headers: { 'Content-Type': 'application/json' },
       })
     }
-    // Config (service charge)
+    // Config (service charge + VAT apply flags)
     if (url.includes('/rest/v1/config')) {
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    // VAT rates (issue #146 fix)
+    if (url.includes('/rest/v1/vat_rates')) {
       return new Response(JSON.stringify([]), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
@@ -309,6 +316,87 @@ describe('close_order handler', () => {
       expect(json.data.final_total_cents).toBe(0)
       expect(json.data.service_charge_cents).toBe(0)
       expect(json.data.bill_number).toBeNull()
+    })
+  })
+
+  describe('POST — VAT computation (issue #146 fix)', () => {
+    it('computes vat_cents for dine_in order when VAT rate is configured', async (): Promise<void> => {
+      // Set up: 2 items × 1000 cents = 2000 subtotal, 10% SC → 200, VAT base = 2200, 5% VAT = 110
+      let capturedPatch: Record<string, unknown> | null = null
+      const mockFetch = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        if (url.includes('/auth/v1/user')) {
+          return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/users')) {
+          return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/orders') && (!init?.method || init?.method === 'GET')) {
+          if (url.includes('select=id,restaurant_id,status')) {
+            return new Response(JSON.stringify([{ id: VALID_ORDER_ID, restaurant_id: RESTAURANT_ID, status: 'open', discount_amount_cents: 0, order_comp: false, final_total_cents: null, service_charge_cents: null, bill_number: null, order_type: 'dine_in' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          if (url.includes('select=customer_mobile')) {
+            return new Response(JSON.stringify([{ customer_mobile: null, customer_name: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/order_items') && (!init?.method || init?.method === 'GET')) {
+          if (url.includes('select=unit_price_cents')) {
+            return new Response(JSON.stringify([{ unit_price_cents: 1000, quantity: 2, item_discount_type: null, item_discount_value: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/config')) {
+          // Return SC 10% + VAT apply flags (dine_in=true)
+          return new Response(JSON.stringify([
+            { key: 'service_charge_percent', value: '10' },
+            { key: 'service_charge_apply_dine_in', value: 'true' },
+            { key: 'vat_apply_dine_in', value: 'true' },
+          ]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/vat_rates')) {
+          return new Response(JSON.stringify([{ percentage: 5 }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
+          capturedPatch = JSON.parse(init.body as string) as Record<string, unknown>
+          return new Response(null, { status: 204 })
+        }
+        if (url.includes('/rest/v1/rpc/next_bill_sequence')) {
+          return new Response(JSON.stringify(1), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/audit_log')) {
+          return new Response(null, { status: 201 })
+        }
+        if (url.includes('/rest/v1/rpc/') || url.includes('/rest/v1/bill_sequences') || url.includes('/rest/v1/recipe_items') || url.includes('/rest/v1/stock_adjustments')) {
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify({ error: `Unhandled: ${url}` }), { status: 500 })
+      }) as FetchFn
+
+      const req = makeRequest({ order_id: VALID_ORDER_ID })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(200)
+
+      const json = (await res.json()) as { success: boolean; data: { vat_cents: number; service_charge_cents: number } }
+      expect(json.success).toBe(true)
+      // subtotal=2000, discount=0, postDiscountBase=2000, SC 10%=200, vatBase=2200, VAT 5%=110
+      expect(json.data.service_charge_cents).toBe(200)
+      expect(json.data.vat_cents).toBe(110)
+
+      // Also verify the PATCH stored the correct vat_cents
+      expect(capturedPatch).not.toBeNull()
+      expect((capturedPatch as Record<string, unknown>).vat_cents).toBe(110)
+      expect((capturedPatch as Record<string, unknown>).service_charge_cents).toBe(200)
+    })
+
+    it('vat_cents = 0 when no VAT rate row exists in vat_rates', async (): Promise<void> => {
+      // Uses default buildMockFetch which returns [] for vat_rates
+      const mockFetch = buildMockFetch('open')
+      const req = makeRequest({ order_id: VALID_ORDER_ID })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { success: boolean; data: { vat_cents: number } }
+      expect(json.success).toBe(true)
+      expect(json.data.vat_cents).toBe(0)
     })
   })
 

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -242,6 +242,56 @@ export async function handler(
       }
     }
 
+    // 3b. Compute VAT on (postDiscountBase + serviceCharge) base.
+    // Mirrors OrderDetailClient.tsx calculation order: Subtotal → Discount → SC → VAT → Total.
+    // Defaults: dine-in = true, takeaway = true, delivery = false.
+    // Canonical defaults mirror apps/web/lib/vatCalc.ts:DEFAULT_VAT_APPLY_CONFIG.
+    let vatCents = 0
+    if (!orderIsComp) {
+      try {
+        // Fetch VAT apply flags and tax_inclusive from config table
+        const vatCfgUrl = `${supabaseUrl}/rest/v1/config?select=key,value&restaurant_id=eq.${restaurantId}&key=in.(tax_inclusive,vat_apply_dine_in,vat_apply_takeaway,vat_apply_delivery)`
+        const vatCfgRes = await fetchFn(vatCfgUrl, { headers: dbHeaders })
+        if (vatCfgRes.ok) {
+          const vatCfgRows = (await vatCfgRes.json()) as Array<{ key: string; value: string }>
+          const vatCfgMap = new Map(vatCfgRows.map((r) => [r.key, r.value]))
+
+          const taxInclusive = vatCfgMap.get('tax_inclusive') === 'true'
+          // Per-type apply defaults: dine_in=true, takeaway=true, delivery=false
+          const vatApplyDineIn = vatCfgMap.has('vat_apply_dine_in') ? vatCfgMap.get('vat_apply_dine_in') === 'true' : true
+          const vatApplyTakeaway = vatCfgMap.has('vat_apply_takeaway') ? vatCfgMap.get('vat_apply_takeaway') === 'true' : true
+          const vatApplyDelivery = vatCfgMap.has('vat_apply_delivery') ? vatCfgMap.get('vat_apply_delivery') === 'true' : false
+
+          const vatApplies =
+            (orderType === 'dine_in' && vatApplyDineIn) ||
+            (orderType === 'takeaway' && vatApplyTakeaway) ||
+            (orderType === 'delivery' && vatApplyDelivery)
+
+          if (vatApplies && !taxInclusive) {
+            // Fetch restaurant-level VAT rate (menu_id IS NULL = restaurant default)
+            const vatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage&restaurant_id=eq.${restaurantId}&menu_id=is.null&limit=1`
+            const vatRateRes = await fetchFn(vatRateUrl, { headers: dbHeaders })
+            if (vatRateRes.ok) {
+              const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string }>
+              if (vatRateRows.length > 0) {
+                const vatPercent = Number(vatRateRows[0].percentage) || 0
+                if (vatPercent > 0) {
+                  // VAT base = postDiscountSubtotal + serviceCharge (same as frontend vatBase)
+                  const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)
+                  const vatBase = postDiscountBase + serviceChargeCents
+                  vatCents = Math.round((vatBase * vatPercent) / 100)
+                }
+              }
+            }
+          }
+          // tax_inclusive = true: VAT is already embedded in item prices — vatCents stays 0
+          // (inclusive VAT is display-only; the total does not change)
+        }
+      } catch {
+        // Non-fatal: VAT defaults to 0
+      }
+    }
+
     // 4. Generate atomic sequential bill number for this restaurant.
     //    Use an upsert-then-increment pattern: insert row with last_value=1 if not exists,
     //    otherwise increment. We read the updated value back via return=representation.
@@ -317,6 +367,7 @@ export async function handler(
       status: 'pending_payment',
       final_total_cents: finalTotal,
       service_charge_cents: serviceChargeCents,
+      vat_cents: vatCents,
       post_bill_mode: false,
     }
     if (billNumber) {
@@ -500,7 +551,7 @@ export async function handler(
     }
 
     return new Response(
-      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, bill_number: billNumber } }),
+      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, bill_number: billNumber } }),
       { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   } catch {

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -103,7 +103,7 @@ export async function handler(
   try {
     // 1. Fetch the order to verify it exists and is open (also get discount & comp info)
     const orderRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,discount_amount_cents,order_comp,final_total_cents,service_charge_cents,bill_number,order_type&id=eq.${orderId}`,
+      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,discount_amount_cents,order_comp,final_total_cents,service_charge_cents,vat_cents,bill_number,order_type&id=eq.${orderId}`,
       { headers: dbHeaders },
     )
     if (!orderRes.ok) {
@@ -120,6 +120,7 @@ export async function handler(
       order_comp: boolean | null
       final_total_cents: number | null
       service_charge_cents: number | null
+      vat_cents: number | null
       bill_number: string | null
       order_type: string | null
     }>
@@ -137,6 +138,7 @@ export async function handler(
           data: {
             final_total_cents: orders[0].final_total_cents ?? 0,
             service_charge_cents: orders[0].service_charge_cents ?? 0,
+            vat_cents: orders[0].vat_cents ?? 0,
             bill_number: orders[0].bill_number ?? null,
           },
         }),
@@ -539,7 +541,7 @@ export async function handler(
           action: 'close_order',
           entity_type: 'orders',
           entity_id: orderId,
-          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, bill_number: billNumber },
+          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, bill_number: billNumber },
         }),
       },
     )

--- a/supabase/functions/record_payment/index.test.ts
+++ b/supabase/functions/record_payment/index.test.ts
@@ -431,8 +431,9 @@ function buildMockFetch(
           discount_amount_cents: 0,
           order_comp: false,
           customer_id: null,
-          // Additional fields for correct change calculation (issue #424):
+          // Additional fields for correct change calculation (issue #424 + #146):
           service_charge_cents: 0,
+          vat_cents: 0,
           delivery_charge: 0,
           order_type: 'dine_in',
         }]),
@@ -495,6 +496,7 @@ function buildMockFetchWithServiceCharge(
           order_comp: false,
           customer_id: null,
           service_charge_cents: serviceChargeCents,
+          vat_cents: 0,
           delivery_charge: deliveryChargeCents,
           order_type: orderType,
         }]),
@@ -783,12 +785,12 @@ describe('record_payment — service charge included in change calculation (issu
     expect(json.data.change_due).toBe(70000) // 600,000 − 530,000 = 70,000
   })
 
-  it('includes exclusive VAT in bill total for change calculation', async (): Promise<void> => {
+  it('includes vat_cents stored by close_order in bill total for change calculation', async (): Promise<void> => {
     // Subtotal: 100,000 cents, SC 10%: 10,000 cents → vatBase 110,000.
-    // VAT exclusive 15%: 16,500 cents → bill total 126,500 cents.
-    // Cash tendered: 130,000. Change: 3,500.
+    // vat_cents pre-computed by close_order: 16,500 (= 15% of vatBase 110,000).
+    // Bill total: 126,500. Cash tendered: 130,000. Change: 3,500.
+    // Note: record_payment now reads vat_cents from DB (issue #146 fix).
     const captured: { paymentInsertBody?: unknown } = {}
-    // Build a mock that returns non-empty VAT config (exclusive, applies to dine_in) and 15% VAT rate.
     const mockFetchWithVat: FetchFn = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
       if (url.includes('/auth/v1/user')) {
         return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
@@ -801,7 +803,7 @@ describe('record_payment — service charge included in change calculation (issu
           JSON.stringify([{
             id: VALID_ORDER_ID, restaurant_id: RESTAURANT_ID, status: 'pending_payment',
             final_total_cents: 100000, discount_amount_cents: 0, order_comp: false, customer_id: null,
-            service_charge_cents: 10000, delivery_charge: 0, order_type: 'dine_in',
+            service_charge_cents: 10000, vat_cents: 16500, delivery_charge: 0, order_type: 'dine_in',
           }]),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         )
@@ -810,17 +812,10 @@ describe('record_payment — service charge included in change calculation (issu
         return new Response(null, { status: 204 })
       }
       if (url.includes('/rest/v1/config')) {
-        // tax_inclusive=false (exclusive), vat_apply_dine_in=true
-        return new Response(
-          JSON.stringify([{ key: 'tax_inclusive', value: 'false' }, { key: 'vat_apply_dine_in', value: 'true' }]),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        )
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.includes('/rest/v1/vat_rates')) {
-        return new Response(
-          JSON.stringify([{ percentage: 15 }]),
-          { status: 200, headers: { 'Content-Type': 'application/json' } },
-        )
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
       }
       if (url.includes('/rest/v1/payments') && init?.method === 'POST') {
         captured.paymentInsertBody = JSON.parse(init.body as string)
@@ -843,7 +838,7 @@ describe('record_payment — service charge included in change calculation (issu
     expect(res.status).toBe(200)
     const json = await res.json() as { success: boolean; data: { change_due: number } }
     expect(json.success).toBe(true)
-    // vatBase = 100,000 + 10,000 = 110,000; VAT 15% exclusive = 16,500; bill = 126,500
+    // vatBase = 100,000 + 10,000 = 110,000; stored vat_cents = 16,500; bill = 126,500
     // change = 130,000 − 126,500 = 3,500
     expect(json.data.change_due).toBe(3500)
 

--- a/supabase/functions/record_payment/index.ts
+++ b/supabase/functions/record_payment/index.ts
@@ -175,7 +175,7 @@ export async function handler(
     //    true bill total for change calculation (bug fix: service charge was missing — issue #424).
     //    Also fetch customer_id here to avoid a second roundtrip in the loyalty block (issue #356).
     const orderRes = await fetchFn(
-      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,final_total_cents,discount_amount_cents,order_comp,customer_id,service_charge_cents,delivery_charge,order_type&id=eq.${orderId}`,
+      `${supabaseUrl}/rest/v1/orders?select=id,restaurant_id,status,final_total_cents,discount_amount_cents,order_comp,customer_id,service_charge_cents,vat_cents,delivery_charge,order_type&id=eq.${orderId}`,
       { headers: dbHeaders },
     )
     if (!orderRes.ok) {
@@ -184,7 +184,7 @@ export async function handler(
         { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
       )
     }
-    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string; final_total_cents: number | null; discount_amount_cents: number | null; order_comp: boolean | null; customer_id: string | null; service_charge_cents: number | null; delivery_charge: number | null; order_type: string | null }>
+    const orders = (await orderRes.json()) as Array<{ id: string; restaurant_id: string; status: string; final_total_cents: number | null; discount_amount_cents: number | null; order_comp: boolean | null; customer_id: string | null; service_charge_cents: number | null; vat_cents: number | null; delivery_charge: number | null; order_type: string | null }>
     if (orders.length === 0) {
       return new Response(
         JSON.stringify({ success: false, error: 'Order not found' }),
@@ -204,61 +204,22 @@ export async function handler(
     const rawFinalTotalCents = orders[0].final_total_cents ?? 0
     const discountAmountCents = orders[0].discount_amount_cents ?? 0
     const serviceChargeCents = orders[0].service_charge_cents ?? 0
+    // vat_cents is stored by close_order (issue #146 fix).
+    // For orders closed before this fix, vat_cents will be 0 — accepted for legacy rows.
+    const storedVatCents = orders[0].vat_cents ?? 0
     const orderType = orders[0].order_type ?? 'dine_in'
     const deliveryChargeCents = orderType === 'delivery' ? (orders[0].delivery_charge ?? 0) : 0
-
-    // Fetch VAT config to include VAT in the effective bill total.
-    // This mirrors the frontend's billTotalCents calculation:
-    //   Subtotal → Discount → Service Charge → VAT → + Delivery
-    // Defaults to 0% / exclusive if config is unavailable (best-effort, non-fatal).
-    let vatPercent = 0
-    let taxInclusive = false
-    let vatApplies = false // conservative default: do not apply VAT if config is unavailable
-    try {
-      const vatConfigRes = await fetchFn(
-        `${supabaseUrl}/rest/v1/config?select=key,value&restaurant_id=eq.${restaurantId}&key=in.(tax_inclusive,vat_apply_dine_in,vat_apply_takeaway,vat_apply_delivery)`,
-        { headers: dbHeaders },
-      )
-      if (vatConfigRes.ok) {
-        const cfgRows = (await vatConfigRes.json()) as Array<{ key: string; value: string }>
-        const cfgMap = new Map(cfgRows.map((r) => [r.key, r.value]))
-        taxInclusive = cfgMap.get('tax_inclusive') === 'true'
-        // Per-type defaults: dine_in=true, takeaway=true, delivery=false
-        const applyDineIn = cfgMap.has('vat_apply_dine_in') ? cfgMap.get('vat_apply_dine_in') === 'true' : true
-        const applyTakeaway = cfgMap.has('vat_apply_takeaway') ? cfgMap.get('vat_apply_takeaway') === 'true' : true
-        const applyDelivery = cfgMap.has('vat_apply_delivery') ? cfgMap.get('vat_apply_delivery') === 'true' : false
-        vatApplies = (orderType === 'dine_in' && applyDineIn)
-          || (orderType === 'takeaway' && applyTakeaway)
-          || (orderType === 'delivery' && applyDelivery)
-      }
-      // Fetch restaurant default VAT rate (menu_id IS NULL = restaurant-level default)
-      const vatRateRes = await fetchFn(
-        `${supabaseUrl}/rest/v1/vat_rates?select=percentage&restaurant_id=eq.${restaurantId}&menu_id=is.null&limit=1`,
-        { headers: dbHeaders },
-      )
-      if (vatRateRes.ok) {
-        const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string }>
-        if (vatRateRows.length > 0) {
-          vatPercent = Number(vatRateRows[0].percentage) || 0
-        }
-      }
-    } catch {
-      // Non-fatal: VAT config unavailable — defaults to 0%, change calc still corrected for SC
-    }
 
     // Compute the true bill total that the customer owes, matching the frontend's billTotalCents:
     //   postDiscountBase = subtotal (per-item discounts applied) − order-level discount
     //   vatBase          = postDiscountBase + service charge
-    //   vatCents         = vatBase × vatPercent / 100  (0 when tax-inclusive — VAT already in prices)
+    //   vatCents         = stored by close_order from vat_rates (issue #146 fix)
     //   billTotal        = vatBase + vatCents + delivery charge
     const postDiscountBase = Math.max(0, rawFinalTotalCents - discountAmountCents)
     const vatBase = postDiscountBase + serviceChargeCents
-    const vatCents = (vatApplies && vatPercent > 0 && !taxInclusive)
-      ? Math.round((vatBase * vatPercent) / 100)
-      : 0
     const finalTotalCents = isOrderComp
       ? 0
-      : vatBase + vatCents + deliveryChargeCents
+      : vatBase + storedVatCents + deliveryChargeCents
 
     // For split-payment: validate total tendered covers the order total
     const totalTenderedCents = paymentsToRecord.reduce((s, p) => s + p.amount, 0)

--- a/supabase/migrations/20260416000001_add_vat_cents_to_orders.sql
+++ b/supabase/migrations/20260416000001_add_vat_cents_to_orders.sql
@@ -1,0 +1,7 @@
+-- Add vat_cents to orders so close_order can persist the calculated VAT amount.
+-- Mirrors the existing service_charge_cents column pattern.
+-- Issue #146 — Apply VAT rates in payment total and bill (regression fix).
+
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS vat_cents INTEGER DEFAULT 0;
+
+-- Rollback: ALTER TABLE orders DROP COLUMN vat_cents;


### PR DESCRIPTION
## Bug Fix: VAT missing from dine-in bill totals

### Root Cause

Three related bugs caused VAT to be absent from dine-in orders:

1. **`close_order`** computed `service_charge_cents` but **never computed VAT**. The `final_total_cents` stored in DB was just the raw items subtotal — no VAT component anywhere.

2. **`record_payment`** tried to re-fetch VAT config each payment (added in #424), but used `vatApplies=false` as the conservative default — so if the config fetch had any issue, VAT was silently skipped.

3. **`ReceiptsClient`** receipt history / reprint used `final_total_cents` from DB directly as the bill total — showed items subtotal only (no SC, no VAT) on every reprinted receipt.

### Fix

**Migration** (`20260416000001_add_vat_cents_to_orders.sql`):
- Add `vat_cents INTEGER DEFAULT 0` column to `orders` table

**`close_order/index.ts`**:
- After computing `service_charge_cents`, now also fetches VAT config (`vat_apply_*` flags + rate from `vat_rates`) and computes `vatCents = round(vatBase × vatPercent / 100)`
- `vatBase = postDiscountBase + serviceChargeCents` (mirrors frontend calculation order: Subtotal → Discount → SC → VAT → Total)
- Stores `vat_cents` in the order row — same pattern as service charge

**`record_payment/index.ts`**:
- Reads `vat_cents` directly from DB instead of re-fetching VAT config
- Removes the fragile VAT re-fetch logic from #424
- `finalTotalCents = vatBase + storedVatCents + deliveryCharge`

**`billHistoryApi.ts`**:
- Fetches `vat_cents` from DB in both history list and reprint queries
- Computes true bill total: `(items_subtotal - discount + SC + VAT) + delivery`
- Fixes wrong totals in receipt history and reprinted receipts

**`ReceiptsClient.tsx`**:
- Passes `vatCents={data.vatCents}` to `BillPrintView` for correct VAT line on reprinted receipts
- Uses `data.finalTotalCents` (now correctly computed) as the bill total

### Tests

- 2 new `close_order` tests: VAT computed correctly / VAT=0 when no rate configured
- Updated `record_payment` VAT test to use stored `vat_cents` from DB row
- All `close_order` tests pass (23/23)
- `billHistoryApi` tests pass (17/17)

Fixes #146