### PR TITLE
fix: shift display uses anon auth after RLS migration dropped anon_read policy

### DIFF
--- a/apps/web/app/shifts/ShiftsClient.test.tsx
+++ b/apps/web/app/shifts/ShiftsClient.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import type { JSX } from 'react'
+
+// ─── Mock Next.js Link ────────────────────────────────────────────────────────
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }): JSX.Element => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+// ─── Mock supabase (not used in the paths under test) ────────────────────────
+vi.mock('@/lib/supabase', () => ({
+  supabase: { auth: { getSession: vi.fn().mockResolvedValue({ data: { session: null } }) } },
+}))
+
+// ─── Mock shiftRevenueApi ─────────────────────────────────────────────────────
+vi.mock('./shiftRevenueApi', () => ({
+  fetchShiftRevenue: vi.fn().mockResolvedValue({
+    orderCount: 0, totalCents: 0, cashCents: 0, cardCents: 0,
+    cashTenderedCents: 0, changeDueCents: 0,
+  }),
+}))
+
+// ─── Mock formatPrice / dateFormat ───────────────────────────────────────────
+vi.mock('@/lib/formatPrice', () => ({
+  formatPrice: vi.fn().mockReturnValue('৳0'),
+  DEFAULT_CURRENCY_SYMBOL: '৳',
+}))
+vi.mock('@/lib/dateFormat', () => ({
+  formatDateTime: vi.fn().mockReturnValue('2026-01-01 08:00'),
+}))
+
+// ─── Mock useUser — overridden per-test ──────────────────────────────────────
+const mockUseUser = vi.fn()
+vi.mock('@/lib/user-context', () => ({
+  useUser: (): ReturnType<typeof mockUseUser> => mockUseUser(),
+}))
+
+const SUPABASE_URL = 'https://example.supabase.co'
+const PUBLISHABLE_KEY = 'test-anon-key'
+
+describe('ShiftsClient — fetchActiveShiftOnMount', () => {
+  // Minimal localStorage mock — jsdom provides the real thing in most cases,
+  // but stubbing avoids any environment quirks
+  const localStorageMock = ((): Storage => {
+    let store: Record<string, string> = {}
+    return {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => { store[key] = value },
+      removeItem: (key: string) => { delete store[key] },
+      clear: () => { store = {} },
+      get length() { return Object.keys(store).length },
+      key: (index: number) => Object.keys(store)[index] ?? null,
+    } as Storage
+  })()
+
+  beforeEach((): void => {
+    vi.stubGlobal('fetch', vi.fn())
+    vi.stubGlobal('localStorage', localStorageMock)
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', PUBLISHABLE_KEY)
+    localStorageMock.clear()
+  })
+
+  afterEach((): void => {
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses JWT token and user_id filter when accessToken and userId are set', async (): Promise<void> => {
+    const TOKEN = 'my-jwt-token'
+    const USER_ID = 'user-abc-123'
+
+    mockUseUser.mockReturnValue({
+      accessToken: TOKEN, userId: USER_ID,
+      role: 'owner', isAdmin: true, loading: false,
+    })
+
+    // Server returns no open shift (empty array)
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: (): Promise<never[]> => Promise.resolve([]),
+    } as Response)
+
+    const { default: ShiftsClient } = await import('./ShiftsClient')
+    render(<ShiftsClient />)
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled())
+
+    const [calledUrl, calledInit] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit]
+
+    // URL must include user_id filter and closed_at=is.null
+    expect(calledUrl).toContain(`user_id=eq.${USER_ID}`)
+    expect(calledUrl).toContain('closed_at=is.null')
+
+    // Authorization must use the user's JWT, NOT the anon key
+    const headers = calledInit?.headers as Record<string, string>
+    expect(headers['Authorization']).toBe(`Bearer ${TOKEN}`)
+    expect(headers['Authorization']).not.toBe(`Bearer ${PUBLISHABLE_KEY}`)
+  })
+
+  it('falls back to localStorage when accessToken is null', async (): Promise<void> => {
+    mockUseUser.mockReturnValue({
+      accessToken: null, userId: null,
+      role: null, isAdmin: false, loading: false,
+    })
+
+    // Pre-populate localStorage with a stored shift
+    const storedShift = { shift_id: 'local-shift-1', started_at: '2026-01-01T08:00:00.000Z' }
+    localStorage.setItem('ikitchen_active_shift', JSON.stringify(storedShift))
+
+    const { default: ShiftsClient } = await import('./ShiftsClient')
+    const { getByTestId } = render(<ShiftsClient />)
+
+    // Should NOT call fetch (no token available)
+    expect(fetch).not.toHaveBeenCalled()
+
+    // Should show the shift loaded from localStorage
+    await waitFor(() => expect(getByTestId('shift-open')).toBeInTheDocument())
+  })
+
+  it('falls back to localStorage when accessToken is set but userId is empty', async (): Promise<void> => {
+    mockUseUser.mockReturnValue({
+      accessToken: 'some-token', userId: null,
+      role: 'owner', isAdmin: true, loading: false,
+    })
+
+    const { default: ShiftsClient } = await import('./ShiftsClient')
+    render(<ShiftsClient />)
+
+    // No userId → should not attempt remote fetch
+    expect(fetch).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/app/shifts/ShiftsClient.tsx
+++ b/apps/web/app/shifts/ShiftsClient.tsx
@@ -106,8 +106,7 @@ export default function ShiftsClient(): JSX.Element {
   useEffect(() => {
     void fetchActiveShiftOnMount()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [accessToken])
+  }, [accessToken, userId])
 
   async function handleOpenShift(): Promise<void> {
     setLoading(true)

--- a/apps/web/app/shifts/ShiftsClient.tsx
+++ b/apps/web/app/shifts/ShiftsClient.tsx
@@ -59,7 +59,7 @@ function getDuration(start: string, end: string): string {
 }
 
 export default function ShiftsClient(): JSX.Element {
-  const { accessToken: _at } = useUser(); const accessToken = _at ?? ''
+  const { accessToken: _at, userId: _uid } = useUser(); const accessToken = _at ?? ''; const userId = _uid ?? ''
   const [activeShift, setActiveShift] = useState<ActiveShift | null>(null)
   const [closedSummary, setClosedSummary] = useState<ShiftSummary | null>(null)
   const [loading, setLoading] = useState(false)
@@ -67,12 +67,21 @@ export default function ShiftsClient(): JSX.Element {
 
   async function fetchActiveShiftOnMount(): Promise<void> {
     try {
+      // Must use the user's JWT (not anon key) — the restaurant_isolation RLS policy
+      // on the shifts table requires an authenticated session. The anon_read policy
+      // was removed in migration 20260401001000_rls_restaurant_isolation.
+      if (!accessToken || !userId) {
+        setActiveShift(loadShiftFromStorage())
+        return
+      }
       const baseUrl = SUPABASE_URL ?? ''
-      const url = `${baseUrl}/rest/v1/shifts?select=id,opened_at&closed_at=is.null&limit=1`
-      const headers: Record<string, string> = {}
+      // Filter by user_id to match the open_shift guard check scope
+      const url = `${baseUrl}/rest/v1/shifts?select=id,opened_at&user_id=eq.${userId}&closed_at=is.null&limit=1`
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${accessToken}`,
+      }
       if (SUPABASE_ANON_KEY) {
         headers['apikey'] = SUPABASE_ANON_KEY
-        headers['Authorization'] = `Bearer ${SUPABASE_ANON_KEY}`
       }
       const res = await fetch(url, { headers })
       if (res.ok) {

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@/lib/supabase', () => ({
 }))
 
 vi.mock('@/lib/user-context', () => ({
-  useUser: vi.fn().mockReturnValue({ accessToken: null, isAdmin: false, role: null, loading: false }),
+  useUser: vi.fn().mockReturnValue({ accessToken: null, isAdmin: false, role: null, loading: false, userId: null }),
 }))
 
 vi.mock('@/components/KotPrintView', () => ({
@@ -1536,7 +1536,7 @@ describe('OrderDetailClient', () => {
       // Provide a real access token so handleQtyButton doesn't early-return on !accessToken
       const { useUser } = await import('@/lib/user-context')
       vi.mocked(useUser).mockReturnValue({
-        accessToken: 'test-token', isAdmin: false, role: 'server', loading: false,
+        accessToken: 'test-token', isAdmin: false, role: 'server', loading: false, userId: 'test-user-id',
       })
     })
 
@@ -1822,7 +1822,7 @@ describe('OrderDetailClient', () => {
 
       // Non-admin user — previously this button was admin-only
       const { useUser } = await import('@/lib/user-context')
-      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'waiter', loading: false })
+      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'waiter', loading: false, userId: 'test-user-id' })
 
       render(<OrderDetailClient tableId="delivery" orderId="order-delivery-1" />)
 
@@ -1999,7 +1999,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
 
     it('calls callReopenOrderForItems and transitions back to order step when "Add More Items" clicked', async (): Promise<void> => {
       const { useUser } = await import('@/lib/user-context')
-      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'server', loading: false })
+      vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'server', loading: false, userId: 'test-user-id' })
       const { callCloseOrder } = await import('./closeOrderApi')
       vi.mocked(callCloseOrder).mockResolvedValue(undefined)
       const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')

--- a/apps/web/app/tables/page.test.tsx
+++ b/apps/web/app/tables/page.test.tsx
@@ -17,7 +17,7 @@ vi.mock('./components/TableCard', () => ({
 }))
 
 vi.mock('@/lib/user-context', () => ({
-  useUser: () => ({ accessToken: 'test-key', role: 'owner', isAdmin: true, loading: false }),
+  useUser: () => ({ accessToken: 'test-key', role: 'owner', isAdmin: true, loading: false, userId: 'test-user-id' }),
 }))
 
 vi.mock('next/navigation', () => ({

--- a/apps/web/lib/user-context.tsx
+++ b/apps/web/lib/user-context.tsx
@@ -16,6 +16,7 @@ interface UserContextValue {
   isAdmin: boolean
   loading: boolean
   accessToken: string | null
+  userId: string | null
 }
 
 const UserContext = createContext<UserContextValue>({
@@ -23,12 +24,14 @@ const UserContext = createContext<UserContextValue>({
   isAdmin: false,
   loading: true,
   accessToken: null,
+  userId: null,
 })
 
 export function UserProvider({ children }: { children: ReactNode }): JSX.Element {
   const [role, setRole] = useState<UserRole | null>(null)
   const [loading, setLoading] = useState(true)
   const [accessToken, setAccessToken] = useState<string | null>(null)
+  const [userId, setUserId] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -41,6 +44,7 @@ export function UserProvider({ children }: { children: ReactNode }): JSX.Element
       if (!cancelled) {
         setRole(fetchedRole)
         setAccessToken(session?.access_token ?? null)
+        setUserId(session?.user.id ?? null)
         setLoading(false)
       }
     }
@@ -50,6 +54,7 @@ export function UserProvider({ children }: { children: ReactNode }): JSX.Element
     // Re-fetch role and token when auth state changes (login/logout/token refresh)
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
       setAccessToken(session?.access_token ?? null)
+      setUserId(session?.user.id ?? null)
       setLoading(true)
       void fetchRoleAndToken()
     })
@@ -65,6 +70,7 @@ export function UserProvider({ children }: { children: ReactNode }): JSX.Element
     isAdmin: isAdminRole(role),
     loading,
     accessToken,
+    userId,
   }
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>


### PR DESCRIPTION
## Problem

The Shift Management page showed a contradiction simultaneously:
- 🔴 **Error banner**: "User already has an open shift"
- 📋 **Card**: "No Active Shift — There is no shift currently open." (with Open Shift button)

Staff were completely unable to close their shift.

## Root Cause

Two queries using **inconsistent authentication**:

1. **`open_shift` edge function guard** (produces the error): Uses **service role key** → bypasses RLS → queries `shifts?user_id=eq.${staffId}&closed_at=is.null` → correctly finds the open shift → returns "User already has an open shift"

2. **`fetchActiveShiftOnMount` display** (produces the card): Uses **anon key** as the Bearer token → queries `shifts?closed_at=is.null&limit=1` → RLS `restaurant_isolation` policy calls `get_user_restaurant_id()` which needs `auth.uid()` → for anon token, `auth.uid() = NULL` → policy blocks → 0 rows → shows "No Active Shift"

The trigger: migration `20260401001000_rls_restaurant_isolation` **dropped the `allow_anon_read` policy** on `shifts` and replaced it with `restaurant_isolation`, which requires an authenticated session. The display query was never updated.

## Fix

- **`ShiftsClient.tsx`**: Use the user's JWT token as `Authorization` header in `fetchActiveShiftOnMount` instead of the anon key. Add `user_id=eq.${userId}` filter to match the `open_shift` guard scope exactly.
- **`user-context.tsx`**: Expose `userId` from `UserContext` so the component can include it in the query filter.
- **Test mocks**: Updated to include `userId` in `UserContextValue` mock objects.

## Files Changed

- `apps/web/app/shifts/ShiftsClient.tsx`
- `apps/web/lib/user-context.tsx`
- `apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx`
- `apps/web/app/tables/page.test.tsx`