### PR TITLE
fix: bill number on bill copies and receipt search for all order types

### DIFF
--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -457,6 +457,10 @@ export default function ReceiptsClient(): JSX.Element {
     useRange: false,
   })
 
+  // Bill number search — client-side filter applied on top of the loaded orders list.
+  // Works for all order types (dine-in, takeaway, delivery).
+  const [billSearch, setBillSearch] = useState('')
+
   // Re-print state
   const [reprintOrder, setReprintOrder] = useState<BillHistoryOrder | null>(null)
 
@@ -543,6 +547,14 @@ export default function ReceiptsClient(): JSX.Element {
   const currencySymbol = config?.currencySymbol ?? '৳'
   const roundBillTotals = config?.roundBillTotals ?? false
 
+  // Client-side bill-number filter — applied after the server fetch.
+  // Trims whitespace and matches case-insensitively anywhere in bill_number.
+  // An empty search shows all loaded orders (no network round-trip needed).
+  const billSearchTrimmed = billSearch.trim().toUpperCase()
+  const filteredOrders = billSearchTrimmed
+    ? orders.filter((o) => (o.bill_number ?? '').toUpperCase().includes(billSearchTrimmed))
+    : orders
+
   if (userLoading) {
     return (
       <div className="min-h-[60vh] flex items-center justify-center">
@@ -626,6 +638,29 @@ export default function ReceiptsClient(): JSX.Element {
             </div>
           )}
 
+          {/* Bill number search — visible to both admin and staff for all order types */}
+          <div className="flex items-center gap-2">
+            <Search className="w-4 h-4 text-brand-gold shrink-0" aria-hidden="true" />
+            <input
+              type="search"
+              value={billSearch}
+              onChange={(e) => setBillSearch(e.target.value)}
+              placeholder="Search by bill number…"
+              aria-label="Search by bill number"
+              className="bg-brand-blue text-white border border-brand-grey rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:border-brand-gold placeholder:text-white/40 w-52"
+            />
+            {billSearch && (
+              <button
+                type="button"
+                onClick={() => setBillSearch('')}
+                className="text-white/50 hover:text-white text-xs transition-colors"
+                aria-label="Clear bill number search"
+              >
+                ✕
+              </button>
+            )}
+          </div>
+
           {/* Staff: show shift info */}
           {!isAdmin && shiftData && (
             <p className="text-white/60 text-sm">
@@ -657,7 +692,11 @@ export default function ReceiptsClient(): JSX.Element {
               </p>
             </div>
             <div className="text-right">
-              <p className="text-sm text-brand-navy/60">{orders.length} bill{orders.length !== 1 ? 's' : ''}</p>
+              <p className="text-sm text-brand-navy/60">
+                {billSearchTrimmed
+                  ? `${filteredOrders.length} of ${orders.length} bill${orders.length !== 1 ? 's' : ''}`
+                  : `${orders.length} bill${orders.length !== 1 ? 's' : ''}`}
+              </p>
               <button
                 type="button"
                 onClick={() => {
@@ -701,7 +740,7 @@ export default function ReceiptsClient(): JSX.Element {
           </div>
         )}
 
-        {/* Empty state */}
+        {/* Empty state — no receipts loaded at all */}
         {!loading && !error && orders.length === 0 && (
           <div className="flex flex-col items-center gap-3 py-16 text-brand-navy/50">
             <Receipt className="w-12 h-12" />
@@ -714,10 +753,28 @@ export default function ReceiptsClient(): JSX.Element {
           </div>
         )}
 
-        {/* Order list */}
-        {!loading && orders.length > 0 && (
+        {/* Empty state — receipts loaded but bill-number filter matches nothing */}
+        {!loading && !error && orders.length > 0 && filteredOrders.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-16 text-brand-navy/50">
+            <Search className="w-12 h-12" />
+            <p className="text-base font-medium">No match</p>
+            <p className="text-sm text-center">
+              No bill found with number &ldquo;{billSearch.trim()}&rdquo;.
+            </p>
+            <button
+              type="button"
+              onClick={() => setBillSearch('')}
+              className="text-brand-gold text-sm hover:underline"
+            >
+              Clear search
+            </button>
+          </div>
+        )}
+
+        {/* Order list — filtered by bill number when a search term is entered */}
+        {!loading && filteredOrders.length > 0 && (
           <div className="flex flex-col gap-2">
-            {orders.map((order) => (
+            {filteredOrders.map((order) => (
               <ReceiptRow
                 key={order.id}
                 order={order}

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -8,7 +8,7 @@
  * Both roles: per-entry re-print action using existing BillPrintView.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import type { JSX } from 'react'
 import { Receipt, Printer, ChevronDown, ChevronUp, Search, RefreshCw, CalendarDays } from 'lucide-react'
 import { useUser } from '@/lib/user-context'
@@ -550,10 +550,15 @@ export default function ReceiptsClient(): JSX.Element {
   // Client-side bill-number filter — applied after the server fetch.
   // Trims whitespace and matches case-insensitively anywhere in bill_number.
   // An empty search shows all loaded orders (no network round-trip needed).
+  // useMemo avoids re-running .filter() on renders triggered by unrelated state
+  // (e.g. reprintOrder modal toggling).
   const billSearchTrimmed = billSearch.trim().toUpperCase()
-  const filteredOrders = billSearchTrimmed
-    ? orders.filter((o) => (o.bill_number ?? '').toUpperCase().includes(billSearchTrimmed))
-    : orders
+  const filteredOrders = useMemo(
+    () => billSearchTrimmed
+      ? orders.filter((o) => (o.bill_number ?? '').toUpperCase().includes(billSearchTrimmed))
+      : orders,
+    [orders, billSearchTrimmed],
+  )
 
   if (userLoading) {
     return (
@@ -653,7 +658,7 @@ export default function ReceiptsClient(): JSX.Element {
               <button
                 type="button"
                 onClick={() => setBillSearch('')}
-                className="text-white/50 hover:text-white text-xs transition-colors"
+                className="min-w-[44px] min-h-[44px] flex items-center justify-center text-white/50 hover:text-white text-sm transition-colors"
                 aria-label="Clear bill number search"
               >
                 ✕
@@ -759,7 +764,10 @@ export default function ReceiptsClient(): JSX.Element {
             <Search className="w-12 h-12" />
             <p className="text-base font-medium">No match</p>
             <p className="text-sm text-center">
-              No bill found with number &ldquo;{billSearch.trim()}&rdquo;.
+              No bill found with number &ldquo;{billSearch.trim()}&rdquo; in the current date range.
+            </p>
+            <p className="text-xs text-center text-brand-navy/40">
+              {isAdmin ? 'Try a different date range if the bill was issued on another day.' : 'The bill may be outside your current shift window.'}
             </p>
             <button
               type="button"

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -209,7 +209,7 @@ describe('OrderDetailClient', () => {
   it('shows "Processing…" and disables the button while Proceed to Payment API call is in progress', async (): Promise<void> => {
     const { callCloseOrder } = await import('./closeOrderApi')
     vi.mocked(callCloseOrder).mockImplementation(
-      (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 100)),
+      (): Promise<{ billNumber: string | null }> => new Promise((resolve) => setTimeout(() => resolve({ billNumber: null }), 100)),
     )
 
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
@@ -229,7 +229,7 @@ describe('OrderDetailClient', () => {
 
   it('shows bill preview after clicking Close Order, then payment step after Proceed to Payment', async (): Promise<void> => {
     const { callCloseOrder } = await import('./closeOrderApi')
-    vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
 
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 
@@ -682,7 +682,7 @@ describe('OrderDetailClient', () => {
   describe('payment step', () => {
     async function openPaymentStep(): Promise<void> {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
       await screen.findByText('Bruschetta')
       fireEvent.click(screen.getByRole('button', { name: 'Close Order' }))
       await waitFor((): void => {
@@ -1640,7 +1640,7 @@ describe('OrderDetailClient', () => {
     // Helpers shared across tests in this block
     async function openPaymentStepForIssue390(): Promise<void> {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
       const { fetchOrderSummary } = await import('./orderData')
       vi.mocked(fetchOrderSummary).mockResolvedValue({
         status: 'open', payment_method: null, order_type: 'dine_in',
@@ -1859,7 +1859,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
       delivery_zone_id: null, delivery_charge: 0, merge_label: null, payment_lines: [],
     })
     const { callCloseOrder } = await import('./closeOrderApi')
-    vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
   })
 
   afterEach((): void => {
@@ -1973,7 +1973,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
   describe('Add More Items after billing (issue #394)', () => {
     it('shows "Add More Items" button in payment step for dine-in orders', async (): Promise<void> => {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
 
       render(<OrderDetailClient tableId="5" orderId="order-billed" />)
 
@@ -2001,7 +2001,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
       const { useUser } = await import('@/lib/user-context')
       vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'server', loading: false, userId: 'test-user-id' })
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
       const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
       vi.mocked(callReopenOrderForItems).mockResolvedValue(undefined)
 
@@ -2067,7 +2067,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
         payment_lines: [],
       })
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
 
       render(<OrderDetailClient tableId="takeaway" orderId="order-takeaway" />)
 
@@ -2086,7 +2086,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
 
     it('shows error message when reopen fails', async (): Promise<void> => {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue(undefined)
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
       const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
       vi.mocked(callReopenOrderForItems).mockRejectedValue(new Error('Insufficient permissions'))
 

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -1220,7 +1220,12 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       if (!supabaseUrl || !accessToken) {
         throw new Error('Not authenticated')
       }
-      await callCloseOrder(supabaseUrl, accessToken, orderId)
+      const { billNumber: closedBillNumber } = await callCloseOrder(supabaseUrl, accessToken, orderId)
+      // Persist the freshly-generated bill number into state so it renders on
+      // the printed bill copy for ALL order types (dine-in, takeaway, delivery).
+      // Without this, orderBillNumber stays null for the remainder of the session
+      // because the initial loadOrderStatus() ran before close_order was called.
+      if (closedBillNumber) setOrderBillNumber(closedBillNumber)
       // Reset split payment builder for fresh start
       setSplitPayments([])
       setSplitEntryMethod('cash')

--- a/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.test.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.test.ts
@@ -91,6 +91,45 @@ describe('callCloseOrder', () => {
     ).rejects.toThrow('Internal server error')
   })
 
+  it('returns billNumber from the response when bill_number is a string', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean; data: { final_total_cents: number; service_charge_cents: number; bill_number: string } }> =>
+        Promise.resolve({ success: true, data: { final_total_cents: 5450, service_charge_cents: 0, bill_number: 'RN0001234' } }),
+    } as Response)
+
+    const result = await callCloseOrder('https://example.supabase.co', 'test-key', 'order-123')
+
+    expect(result.billNumber).toBe('RN0001234')
+  })
+
+  it('returns billNumber: null when edge function returns bill_number: null', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean; data: { final_total_cents: number; service_charge_cents: number; bill_number: null } }> =>
+        Promise.resolve({ success: true, data: { final_total_cents: 5450, service_charge_cents: 0, bill_number: null } }),
+    } as Response)
+
+    const result = await callCloseOrder('https://example.supabase.co', 'test-key', 'order-123')
+
+    expect(result.billNumber).toBeNull()
+  })
+
+  it('returns billNumber: null when edge function response omits the data field', async (): Promise<void> => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: (): Promise<{ success: boolean }> =>
+        Promise.resolve({ success: true }),
+    } as Response)
+
+    const result = await callCloseOrder('https://example.supabase.co', 'test-key', 'order-123')
+
+    expect(result.billNumber).toBeNull()
+  })
+
   it('throws a user-friendly message on HTTP 409 (issue #318)', async (): Promise<void> => {
     vi.mocked(fetch).mockResolvedValue({
       ok: false,

--- a/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.ts
@@ -8,7 +8,7 @@ export async function callCloseOrder(
   supabaseUrl: string,
   accessToken: string,
   orderId: string,
-): Promise<void> {
+): Promise<{ billNumber: string | null }> {
   const res = await fetch(`${supabaseUrl}/functions/v1/close_order`, {
     method: 'POST',
     headers: {
@@ -31,4 +31,5 @@ export async function callCloseOrder(
   if (!json.success) {
     throw new Error(json.error ?? 'Failed to close order')
   }
+  return { billNumber: json.data?.bill_number ?? null }
 }


### PR DESCRIPTION
## Problem

Two related bugs reported by Lidia (updated scope: all order types — dine-in, takeaway, delivery):

1. **Bill number missing from printed bill copies** — `callCloseOrder` returned `void` and discarded the `bill_number` from the edge function response. So `orderBillNumber` state stayed `null` for the lifetime of the session, and `BillPrintView` received no bill number prop on any fresh order close — regardless of order type.

2. **No way to search/find a bill by bill number** in the Receipt section — the filter UI only offered date-range selection; there was no bill number field at all.

## Root Cause (Bug 1)

`closeOrderApi.ts` declared `callCloseOrder` as `Promise<void>` and called `res.json()` but threw away the result. The `close_order` edge function always returns `bill_number` in its response payload, but the frontend never used it.

`OrderDetailClient` sets `orderBillNumber` from `loadOrderStatus()` on initial mount — but that runs *before* `callCloseOrder`, so the bill number is always `null` at print time on any fresh session.

## Fix

### `closeOrderApi.ts`
- Changed return type from `Promise<void>` → `Promise<{ billNumber: string | null }>`
- Returns `json.data?.bill_number` from the edge function response

### `OrderDetailClient.tsx`
- `handleProceedToPayment` now captures `{ billNumber: closedBillNumber }` from `callCloseOrder`
- Calls `setOrderBillNumber(closedBillNumber)` immediately after close — so the state is populated before any print action for **all order types** (dine-in, takeaway, delivery)

### `ReceiptsClient.tsx`
- Added `billSearch` state (client-side string filter)
- Computed `filteredOrders` = case-insensitive substring match on `bill_number` across **all order types**
- Added bill number search input visible to both admin and staff roles, with a clear (✕) button
- Summary card shows "N of M bills" when a filter is active
- Added empty-state for "filter matches nothing" with a clear-search button

### `OrderDetailClient.test.tsx`
- Updated all `callCloseOrder` mocks from `mockResolvedValue(undefined)` → `mockResolvedValue({ billNumber: null })` to match the new return type

## Testing
- `BillPrintView.test.tsx` — 33/33 pass
- TypeScript: no new errors in production source files (pre-existing test-only errors untouched)