### PR TITLE
feat: Back to POS button + order type filter on Receipts page

### DIFF
--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -10,7 +10,8 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import type { JSX } from 'react'
-import { Receipt, Printer, ChevronDown, ChevronUp, Search, RefreshCw, CalendarDays } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { Receipt, Printer, ChevronDown, ChevronUp, Search, RefreshCw, CalendarDays, ArrowLeft } from 'lucide-react'
 import { useUser } from '@/lib/user-context'
 import { supabase } from '@/lib/supabase'
 import {
@@ -435,6 +436,7 @@ function ReceiptRow({
 
 export default function ReceiptsClient(): JSX.Element {
   const { isAdmin, loading: userLoading, accessToken } = useUser()
+  const router = useRouter()
   const [orders, setOrders] = useState<BillHistoryOrder[]>([])
   const [totalDailyCents, setTotalDailyCents] = useState(0)
   const [truncated, setTruncated] = useState(false)
@@ -460,6 +462,10 @@ export default function ReceiptsClient(): JSX.Element {
   // Bill number search — client-side filter applied on top of the loaded orders list.
   // Works for all order types (dine-in, takeaway, delivery).
   const [billSearch, setBillSearch] = useState('')
+
+  // Order type filter — client-side, applied after fetch.
+  type OrderTypeFilter = 'all' | 'dine_in' | 'takeaway' | 'delivery'
+  const [orderTypeFilter, setOrderTypeFilter] = useState<OrderTypeFilter>('all')
 
   // Re-print state
   const [reprintOrder, setReprintOrder] = useState<BillHistoryOrder | null>(null)
@@ -553,12 +559,18 @@ export default function ReceiptsClient(): JSX.Element {
   // useMemo avoids re-running .filter() on renders triggered by unrelated state
   // (e.g. reprintOrder modal toggling).
   const billSearchTrimmed = billSearch.trim().toUpperCase()
-  const filteredOrders = useMemo(
-    () => billSearchTrimmed
-      ? orders.filter((o) => (o.bill_number ?? '').toUpperCase().includes(billSearchTrimmed))
-      : orders,
-    [orders, billSearchTrimmed],
-  )
+
+  // Apply both filters: bill number search + order type
+  const filteredOrders = useMemo(() => {
+    let result = orders
+    if (billSearchTrimmed) {
+      result = result.filter((o) => (o.bill_number ?? '').toUpperCase().includes(billSearchTrimmed))
+    }
+    if (orderTypeFilter !== 'all') {
+      result = result.filter((o) => o.order_type === orderTypeFilter)
+    }
+    return result
+  }, [orders, billSearchTrimmed, orderTypeFilter])
 
   if (userLoading) {
     return (
@@ -574,6 +586,16 @@ export default function ReceiptsClient(): JSX.Element {
       <div className="bg-brand-navy border-b border-brand-blue px-4 py-4">
         <div className="max-w-3xl mx-auto flex flex-col gap-3">
           <div className="flex items-center gap-3">
+            {/* Back to POS button */}
+            <button
+              type="button"
+              onClick={() => router.push('/tables')}
+              aria-label="Back to POS"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue text-white/80 hover:text-white hover:bg-brand-blue/80 transition-colors text-sm shrink-0"
+            >
+              <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+              <span className="hidden sm:inline">Back to POS</span>
+            </button>
             <Receipt className="w-6 h-6 text-brand-gold" aria-hidden="true" />
             <h1 className="text-xl font-bold text-white font-heading">
               {isAdmin ? 'Bill History' : 'Shift Receipts'}
@@ -666,6 +688,32 @@ export default function ReceiptsClient(): JSX.Element {
             )}
           </div>
 
+          {/* Order type filter tabs */}
+          <div className="flex items-center gap-1" role="group" aria-label="Filter by order type">
+            {(
+              [
+                { value: 'all', label: 'All' },
+                { value: 'dine_in', label: 'Dine-in' },
+                { value: 'takeaway', label: 'Takeaway' },
+                { value: 'delivery', label: 'Delivery' },
+              ] as const
+            ).map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setOrderTypeFilter(value)}
+                aria-pressed={orderTypeFilter === value}
+                className={`px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
+                  orderTypeFilter === value
+                    ? 'bg-brand-gold text-brand-navy'
+                    : 'bg-brand-blue text-white/70 hover:text-white'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
           {/* Staff: show shift info */}
           {!isAdmin && shiftData && (
             <p className="text-white/60 text-sm">
@@ -698,7 +746,7 @@ export default function ReceiptsClient(): JSX.Element {
             </div>
             <div className="text-right">
               <p className="text-sm text-brand-navy/60">
-                {billSearchTrimmed
+                {(billSearchTrimmed || orderTypeFilter !== 'all')
                   ? `${filteredOrders.length} of ${orders.length} bill${orders.length !== 1 ? 's' : ''}`
                   : `${orders.length} bill${orders.length !== 1 ? 's' : ''}`}
               </p>
@@ -758,24 +806,43 @@ export default function ReceiptsClient(): JSX.Element {
           </div>
         )}
 
-        {/* Empty state — receipts loaded but bill-number filter matches nothing */}
+        {/* Empty state — receipts loaded but filters match nothing */}
         {!loading && !error && orders.length > 0 && filteredOrders.length === 0 && (
           <div className="flex flex-col items-center gap-3 py-16 text-brand-navy/50">
             <Search className="w-12 h-12" />
             <p className="text-base font-medium">No match</p>
-            <p className="text-sm text-center">
-              No bill found with number &ldquo;{billSearch.trim()}&rdquo; in the current date range.
-            </p>
+            {billSearchTrimmed ? (
+              <p className="text-sm text-center">
+                No bill found with number &ldquo;{billSearch.trim()}&rdquo; in the current date range.
+              </p>
+            ) : (
+              <p className="text-sm text-center">
+                No {orderTypeFilter === 'dine_in' ? 'Dine-in' : orderTypeFilter === 'takeaway' ? 'Takeaway' : 'Delivery'} orders found for the selected period.
+              </p>
+            )}
             <p className="text-xs text-center text-brand-navy/40">
               {isAdmin ? 'Try a different date range if the bill was issued on another day.' : 'The bill may be outside your current shift window.'}
             </p>
-            <button
-              type="button"
-              onClick={() => setBillSearch('')}
-              className="text-brand-gold text-sm hover:underline"
-            >
-              Clear search
-            </button>
+            <div className="flex gap-3">
+              {billSearchTrimmed && (
+                <button
+                  type="button"
+                  onClick={() => setBillSearch('')}
+                  className="text-brand-gold text-sm hover:underline"
+                >
+                  Clear search
+                </button>
+              )}
+              {orderTypeFilter !== 'all' && (
+                <button
+                  type="button"
+                  onClick={() => setOrderTypeFilter('all')}
+                  className="text-brand-gold text-sm hover:underline"
+                >
+                  Show all types
+                </button>
+              )}
+            </div>
           </div>
         )}
 

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -34,6 +34,8 @@ import type { SplitPaymentLine } from '@/components/BillPrintView'
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
 const STORAGE_KEY = 'ikitchen_active_shift'
 
+type OrderTypeFilter = 'all' | 'dine_in' | 'takeaway' | 'delivery'
+
 interface ShiftData {
   shift_id: string
   started_at: string
@@ -464,7 +466,6 @@ export default function ReceiptsClient(): JSX.Element {
   const [billSearch, setBillSearch] = useState('')
 
   // Order type filter — client-side, applied after fetch.
-  type OrderTypeFilter = 'all' | 'dine_in' | 'takeaway' | 'delivery'
   const [orderTypeFilter, setOrderTypeFilter] = useState<OrderTypeFilter>('all')
 
   // Re-print state
@@ -591,7 +592,7 @@ export default function ReceiptsClient(): JSX.Element {
               type="button"
               onClick={() => router.push('/tables')}
               aria-label="Back to POS"
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-brand-blue text-white/80 hover:text-white hover:bg-brand-blue/80 transition-colors text-sm shrink-0"
+              className="flex items-center gap-1.5 px-3 min-h-[48px] rounded-lg bg-brand-blue text-white/80 hover:text-white hover:bg-brand-blue/80 transition-colors text-sm shrink-0"
             >
               <ArrowLeft className="w-4 h-4" aria-hidden="true" />
               <span className="hidden sm:inline">Back to POS</span>
@@ -703,7 +704,7 @@ export default function ReceiptsClient(): JSX.Element {
                 type="button"
                 onClick={() => setOrderTypeFilter(value)}
                 aria-pressed={orderTypeFilter === value}
-                className={`px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
+                className={`px-3 min-h-[48px] rounded-lg text-sm font-medium transition-colors ${
                   orderTypeFilter === value
                     ? 'bg-brand-gold text-brand-navy'
                     : 'bg-brand-blue text-white/70 hover:text-white'
@@ -811,7 +812,11 @@ export default function ReceiptsClient(): JSX.Element {
           <div className="flex flex-col items-center gap-3 py-16 text-brand-navy/50">
             <Search className="w-12 h-12" />
             <p className="text-base font-medium">No match</p>
-            {billSearchTrimmed ? (
+            {billSearchTrimmed && orderTypeFilter !== 'all' ? (
+              <p className="text-sm text-center">
+                No {orderTypeFilter === 'dine_in' ? 'Dine-in' : orderTypeFilter === 'takeaway' ? 'Takeaway' : 'Delivery'} bill found with number &ldquo;{billSearch.trim()}&rdquo; in the current date range.
+              </p>
+            ) : billSearchTrimmed ? (
               <p className="text-sm text-center">
                 No bill found with number &ldquo;{billSearch.trim()}&rdquo; in the current date range.
               </p>

--- a/apps/web/e2e/receipts.spec.ts
+++ b/apps/web/e2e/receipts.spec.ts
@@ -165,6 +165,23 @@ test.describe('Staff (server) view', () => {
     await expect(page.getByText('Payment breakdown')).toBeVisible()
     await expect(page.getByText('Total Paid')).toBeVisible()
   })
+
+  test('Back to POS button is visible to staff', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    await expect(page.getByRole('button', { name: 'Back to POS' })).toBeVisible()
+  })
+
+  test('order type filter tabs are visible to staff', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Dine-in' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Takeaway' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Delivery' })).toBeVisible()
+  })
 })
 
 // ─── Admin (owner) tests ──────────────────────────────────────────────────────
@@ -291,6 +308,105 @@ test.describe('Admin (owner) view', () => {
 
     await page.getByRole('dialog').getByRole('button', { name: 'Close' }).click()
     await expect(page.getByRole('dialog')).not.toBeVisible()
+  })
+
+  test('Back to POS button navigates to /tables', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    const backBtn = page.getByRole('button', { name: 'Back to POS' })
+    await expect(backBtn).toBeVisible()
+    await backBtn.click()
+
+    await expect(page).toHaveURL(/\/tables/)
+  })
+
+  test('Back to POS button has adequate touch target (min 48px)', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    const backBtn = page.getByRole('button', { name: 'Back to POS' })
+    const box = await backBtn.boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.height).toBeGreaterThanOrEqual(48)
+  })
+
+  test('order type filter tabs are visible', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    await expect(page.getByRole('button', { name: 'All' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Dine-in' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Takeaway' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Delivery' })).toBeVisible()
+  })
+
+  test('order type filter tabs have adequate touch targets (min 48px)', async ({ page }) => {
+    await mockDataEndpoints(page, [])
+    await page.goto('/receipts')
+
+    for (const label of ['All', 'Dine-in', 'Takeaway', 'Delivery']) {
+      const btn = page.getByRole('button', { name: label })
+      const box = await btn.boundingBox()
+      expect(box).not.toBeNull()
+      expect(box!.height).toBeGreaterThanOrEqual(48)
+    }
+  })
+
+  test('order type filter hides non-matching receipts', async ({ page }) => {
+    const takeawayOrder = {
+      ...PAID_ORDER,
+      id: 'order-takeaway-1',
+      order_type: 'takeaway',
+      bill_number: 'RN0009999',
+      tables: (null as unknown) as typeof PAID_ORDER['tables'],
+    }
+    await mockDataEndpoints(page, [PAID_ORDER, takeawayOrder])
+    await page.goto('/receipts')
+
+    // Both orders visible initially
+    await expect(page.getByText('RN0001234')).toBeVisible()
+    await expect(page.getByText('RN0009999')).toBeVisible()
+
+    // Filter to Dine-in only
+    await page.getByRole('button', { name: 'Dine-in' }).click()
+    await expect(page.getByText('RN0001234')).toBeVisible()
+    await expect(page.getByText('RN0009999')).not.toBeVisible()
+
+    // Reset to All
+    await page.getByRole('button', { name: 'All' }).click()
+    await expect(page.getByText('RN0009999')).toBeVisible()
+  })
+
+  test('order type filter updates bill count summary', async ({ page }) => {
+    const takeawayOrder = {
+      ...PAID_ORDER,
+      id: 'order-takeaway-2',
+      order_type: 'takeaway',
+      bill_number: 'RN0009998',
+      tables: (null as unknown) as typeof PAID_ORDER['tables'],
+    }
+    await mockDataEndpoints(page, [PAID_ORDER, takeawayOrder])
+    await page.goto('/receipts')
+
+    // Initially 2 of 2
+    await expect(page.getByText('2 bills')).toBeVisible()
+
+    // Filter to Dine-in — shows 1 of 2
+    await page.getByRole('button', { name: 'Dine-in' }).click()
+    await expect(page.getByText('1 of 2 bills')).toBeVisible()
+  })
+
+  test('empty state shows type-specific message when order type filter active', async ({ page }) => {
+    // Only dine_in orders — filter to Delivery should show empty state
+    await mockDataEndpoints(page, [PAID_ORDER])
+    await page.goto('/receipts')
+
+    await page.getByRole('button', { name: 'Delivery' }).click()
+
+    await expect(page.getByText('No match', { exact: true })).toBeVisible()
+    await expect(page.getByText(/No Delivery orders found/)).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Show all types' })).toBeVisible()
   })
 
   test('Escape key closes re-print modal', async ({ page }) => {


### PR DESCRIPTION
## Summary

Two UX improvements for the Receipt/Bills section:

### 1. "Back to POS" button
- Added an ArrowLeft icon button in the receipt page header
- Visible to **all users** (staff + admin)
- Navigates to `/tables` (the main floor plan / table selection screen)
- Shows icon-only on mobile, icon + label on sm+ screens

### 2. Order type filter
- New tab-style filter bar: **All | Dine-in | Takeaway | Delivery**
- Client-side filtering — no extra network requests
- Works in combination with existing bill number search
- Bill count summary updates to show `X of Y bills` when a filter is active
- Empty state messaging updated to indicate which filter produced no results, with a 'Show all types' clear button

### Files changed
- `apps/web/app/receipts/ReceiptsClient.tsx`
