### PR TITLE
fix: VAT (5%) not displayed as line item on payment breakdown and printed bill (issue #146)

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -209,7 +209,7 @@ describe('OrderDetailClient', () => {
   it('shows "Processing…" and disables the button while Proceed to Payment API call is in progress', async (): Promise<void> => {
     const { callCloseOrder } = await import('./closeOrderApi')
     vi.mocked(callCloseOrder).mockImplementation(
-      (): Promise<{ billNumber: string | null }> => new Promise((resolve) => setTimeout(() => resolve({ billNumber: null }), 100)),
+      (): Promise<{ billNumber: string | null; vatCents: number; vatPercent: number }> => new Promise((resolve) => setTimeout(() => resolve({ billNumber: null, vatCents: 0, vatPercent: 0 }), 100)),
     )
 
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
@@ -229,7 +229,7 @@ describe('OrderDetailClient', () => {
 
   it('shows bill preview after clicking Close Order, then payment step after Proceed to Payment', async (): Promise<void> => {
     const { callCloseOrder } = await import('./closeOrderApi')
-    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
 
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 
@@ -682,7 +682,7 @@ describe('OrderDetailClient', () => {
   describe('payment step', () => {
     async function openPaymentStep(): Promise<void> {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
       await screen.findByText('Bruschetta')
       fireEvent.click(screen.getByRole('button', { name: 'Close Order' }))
       await waitFor((): void => {
@@ -1640,7 +1640,7 @@ describe('OrderDetailClient', () => {
     // Helpers shared across tests in this block
     async function openPaymentStepForIssue390(): Promise<void> {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
       const { fetchOrderSummary } = await import('./orderData')
       vi.mocked(fetchOrderSummary).mockResolvedValue({
         status: 'open', payment_method: null, order_type: 'dine_in',
@@ -1859,7 +1859,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
       delivery_zone_id: null, delivery_charge: 0, merge_label: null, payment_lines: [],
     })
     const { callCloseOrder } = await import('./closeOrderApi')
-    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
   })
 
   afterEach((): void => {
@@ -1973,7 +1973,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
   describe('Add More Items after billing (issue #394)', () => {
     it('shows "Add More Items" button in payment step for dine-in orders', async (): Promise<void> => {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
 
       render(<OrderDetailClient tableId="5" orderId="order-billed" />)
 
@@ -2001,7 +2001,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
       const { useUser } = await import('@/lib/user-context')
       vi.mocked(useUser).mockReturnValue({ accessToken: 'test-token', isAdmin: false, role: 'server', loading: false, userId: 'test-user-id' })
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
       const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
       vi.mocked(callReopenOrderForItems).mockResolvedValue(undefined)
 
@@ -2067,7 +2067,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
         payment_lines: [],
       })
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
 
       render(<OrderDetailClient tableId="takeaway" orderId="order-takeaway" />)
 
@@ -2086,7 +2086,7 @@ describe('OrderDetailClient — post-payment payment breakdown (issue #391)', ()
 
     it('shows error message when reopen fails', async (): Promise<void> => {
       const { callCloseOrder } = await import('./closeOrderApi')
-      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null })
+      vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 0, vatPercent: 0 })
       const { callReopenOrderForItems } = await import('./reopenOrderForItemsApi')
       vi.mocked(callReopenOrderForItems).mockRejectedValue(new Error('Insufficient permissions'))
 

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -249,6 +249,35 @@ describe('OrderDetailClient', () => {
     expect(mockPush).not.toHaveBeenCalled()
   })
 
+  it('shows VAT line on payment screen when vatPercent config is 0 but close_order returns vatCents', async (): Promise<void> => {
+    // Simulate the bug scenario: local vatPercent fetch returns 0 (config not loaded),
+    // but the server computed and stored vatCents correctly.
+    const { fetchVatConfig } = await import('@/lib/fetchVatConfig')
+    vi.mocked(fetchVatConfig).mockResolvedValue({ vatPercent: 0, taxInclusive: false })
+
+    const { callCloseOrder } = await import('./closeOrderApi')
+    vi.mocked(callCloseOrder).mockResolvedValue({ billNumber: null, vatCents: 344, vatPercent: 5 })
+
+    render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+
+    await screen.findByText('Bruschetta')
+    fireEvent.click(screen.getByRole('button', { name: 'Close Order' }))
+
+    await waitFor((): void => {
+      expect(screen.getByText('Bill Preview')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Proceed to Payment' }))
+
+    await waitFor((): void => {
+      expect(screen.getByText('Record Payment')).toBeInTheDocument()
+    })
+
+    // VAT line must be visible with the server-returned amount
+    expect(screen.getAllByText(/VAT.*5%/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/344/).length).toBeGreaterThan(0)
+  })
+
   it('shows an error message when the close order API call fails (from bill preview)', async (): Promise<void> => {
     const { callCloseOrder } = await import('./closeOrderApi')
     vi.mocked(callCloseOrder).mockRejectedValue(new Error('Order has no items'))

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -258,6 +258,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [vatPercent, setVatPercent] = useState(0)
   const [taxInclusive, setTaxInclusive] = useState(false)
   const [vatConfigLoading, setVatConfigLoading] = useState(true)
+  // VAT amount stored by close_order (issue #146 fix) — overrides locally-computed vatCents
+  // on the payment/bill screens once the order has been closed server-side.
+  // null = order not yet closed (use local computation).
+  const [closedOrderVatCents, setClosedOrderVatCents] = useState<number | null>(null)
 
   // Bill rounding setting (issue #371) — fetched once on load
   const [roundBillTotals, setRoundBillTotals] = useState(false)
@@ -679,14 +683,19 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const effectiveVatPercent = vatApplies ? vatPercent : 0
   const vatBase = postDiscountCents + billServiceChargeCents
   const vatBreakdown = calcVat(vatBase, effectiveVatPercent, taxInclusive)
-  const { vatCents: billVatCents } = vatBreakdown
+  // Use the server-stored vat_cents from close_order when available (issue #146 fix).
+  // This ensures the payment/bill screens show the correct VAT even if the local
+  // vatPercent config fetch returned 0 (e.g. vat_rates row exists but wasn't loaded).
+  const billVatCents = closedOrderVatCents !== null ? closedOrderVatCents : vatBreakdown.vatCents
 
   // Displayed subtotal = raw items total (before any adjustments)
   const billSubtotalCents = rawItemsTotalCents
 
   // Step 4: add delivery charge (issue #353) — applied after VAT on top of order total
   const billDeliveryChargeCents = orderType === 'delivery' ? orderDeliveryChargeCents : 0
-  const billTotalCents = orderIsComp ? 0 : vatBreakdown.totalCents + billDeliveryChargeCents
+  // Compute total directly from components so it stays consistent when billVatCents
+  // is overridden by the server-stored value (vatBreakdown.totalCents would be stale).
+  const billTotalCents = orderIsComp ? 0 : postDiscountCents + billServiceChargeCents + billVatCents + billDeliveryChargeCents
 
   // Displayed "total" in the order footer is the grand total
   const totalCents = billTotalCents
@@ -1220,12 +1229,19 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       if (!supabaseUrl || !accessToken) {
         throw new Error('Not authenticated')
       }
-      const { billNumber: closedBillNumber } = await callCloseOrder(supabaseUrl, accessToken, orderId)
+      const { billNumber: closedBillNumber, vatCents: closedVatCents, vatPercent: closedVatPercent } = await callCloseOrder(supabaseUrl, accessToken, orderId)
       // Persist the freshly-generated bill number into state so it renders on
       // the printed bill copy for ALL order types (dine-in, takeaway, delivery).
       // Without this, orderBillNumber stays null for the remainder of the session
       // because the initial loadOrderStatus() ran before close_order was called.
       if (closedBillNumber) setOrderBillNumber(closedBillNumber)
+      // Store the server-computed VAT amount (issue #146). This overrides the locally-
+      // computed billVatCents on the payment screen, ensuring the correct value is shown
+      // even when the local vatPercent config fetch returned 0 (e.g. RLS / timing issue).
+      setClosedOrderVatCents(closedVatCents)
+      // If vatPercent state is still 0 (config not loaded) but close_order returned a
+      // non-zero percent, update it so the VAT % label renders correctly.
+      if (vatPercent === 0 && closedVatPercent > 0) setVatPercent(closedVatPercent)
       // Reset split payment builder for fresh start
       setSplitPayments([])
       setSplitEntryMethod('cash')

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -258,7 +258,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [vatPercent, setVatPercent] = useState(0)
   const [taxInclusive, setTaxInclusive] = useState(false)
   const [vatConfigLoading, setVatConfigLoading] = useState(true)
-  // VAT amount stored by close_order (issue #146 fix) — overrides locally-computed vatCents
+  // VAT amount stored by close_order — overrides locally-computed vatCents
   // on the payment/bill screens once the order has been closed server-side.
   // null = order not yet closed (use local computation).
   const [closedOrderVatCents, setClosedOrderVatCents] = useState<number | null>(null)
@@ -683,7 +683,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const effectiveVatPercent = vatApplies ? vatPercent : 0
   const vatBase = postDiscountCents + billServiceChargeCents
   const vatBreakdown = calcVat(vatBase, effectiveVatPercent, taxInclusive)
-  // Use the server-stored vat_cents from close_order when available (issue #146 fix).
+  // Use the server-stored vat_cents from close_order when available.
   // This ensures the payment/bill screens show the correct VAT even if the local
   // vatPercent config fetch returned 0 (e.g. vat_rates row exists but wasn't loaded).
   const billVatCents = closedOrderVatCents !== null ? closedOrderVatCents : vatBreakdown.vatCents
@@ -1235,7 +1235,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
       // Without this, orderBillNumber stays null for the remainder of the session
       // because the initial loadOrderStatus() ran before close_order was called.
       if (closedBillNumber) setOrderBillNumber(closedBillNumber)
-      // Store the server-computed VAT amount (issue #146). This overrides the locally-
+      // Store the server-computed VAT amount. This overrides the locally-
       // computed billVatCents on the payment screen, ensuring the correct value is shown
       // even when the local vatPercent config fetch returned 0 (e.g. RLS / timing issue).
       setClosedOrderVatCents(closedVatCents)

--- a/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.ts
+++ b/apps/web/app/tables/[id]/order/[order_id]/closeOrderApi.ts
@@ -1,6 +1,14 @@
 export interface CloseOrderResponse {
   success: boolean
-  data?: { final_total_cents: number; service_charge_cents: number; bill_number: string | null }
+  data?: {
+    final_total_cents: number
+    service_charge_cents: number
+    /** VAT amount (cents) stored by close_order — 0 for tax-inclusive or when no VAT rate is configured. */
+    vat_cents: number
+    /** VAT rate (%) used to compute vat_cents — 0 when not applicable or idempotent early-return. */
+    vat_percent: number
+    bill_number: string | null
+  }
   error?: string
 }
 
@@ -8,7 +16,7 @@ export async function callCloseOrder(
   supabaseUrl: string,
   accessToken: string,
   orderId: string,
-): Promise<{ billNumber: string | null }> {
+): Promise<{ billNumber: string | null; vatCents: number; vatPercent: number }> {
   const res = await fetch(`${supabaseUrl}/functions/v1/close_order`, {
     method: 'POST',
     headers: {
@@ -31,5 +39,9 @@ export async function callCloseOrder(
   if (!json.success) {
     throw new Error(json.error ?? 'Failed to close order')
   }
-  return { billNumber: json.data?.bill_number ?? null }
+  return {
+    billNumber: json.data?.bill_number ?? null,
+    vatCents: json.data?.vat_cents ?? 0,
+    vatPercent: json.data?.vat_percent ?? 0,
+  }
 }

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -290,9 +290,9 @@ export default function BillPrintView({
                 <span>{formatPrice(serviceChargeCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}</span>
               </div>
             )}
-            {vatPercent > 0 && (
+            {vatCents > 0 && (
               <div className="flex justify-between">
-                <span>VAT {vatPercent}%{taxInclusive ? ' (incl.)' : ''}</span>
+                <span>VAT{vatPercent > 0 ? ` ${vatPercent}%` : ''}{taxInclusive ? ' (incl.)' : ''}</span>
                 <span>{formatPrice(vatCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}</span>
               </div>
             )}

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -139,6 +139,8 @@ export async function handler(
             final_total_cents: orders[0].final_total_cents ?? 0,
             service_charge_cents: orders[0].service_charge_cents ?? 0,
             vat_cents: orders[0].vat_cents ?? 0,
+            // vat_percent is not stored on orders; return 0 so the UI falls back to its local vatPercent state
+            vat_percent: 0,
             bill_number: orders[0].bill_number ?? null,
           },
         }),
@@ -249,6 +251,7 @@ export async function handler(
     // Defaults: dine-in = true, takeaway = true, delivery = false.
     // Canonical defaults mirror apps/web/lib/vatCalc.ts:DEFAULT_VAT_APPLY_CONFIG.
     let vatCents = 0
+    let usedVatPercent = 0
     if (!orderIsComp) {
       try {
         // Fetch VAT apply flags and tax_inclusive from config table
@@ -282,6 +285,7 @@ export async function handler(
                   const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)
                   const vatBase = postDiscountBase + serviceChargeCents
                   vatCents = Math.round((vatBase * vatPercent) / 100)
+                  usedVatPercent = vatPercent
                 }
               }
             }
@@ -541,7 +545,7 @@ export async function handler(
           action: 'close_order',
           entity_type: 'orders',
           entity_id: orderId,
-          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, bill_number: billNumber },
+          payload: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, vat_percent: usedVatPercent, bill_number: billNumber },
         }),
       },
     )
@@ -553,7 +557,7 @@ export async function handler(
     }
 
     return new Response(
-      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, bill_number: billNumber } }),
+      JSON.stringify({ success: true, data: { final_total_cents: finalTotal, service_charge_cents: serviceChargeCents, vat_cents: vatCents, vat_percent: usedVatPercent, bill_number: billNumber } }),
       { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   } catch {


### PR DESCRIPTION
## Summary

PR #426 fixed VAT calculation in `close_order` (now stores `vat_cents` in the DB), but the payment/bill UI was still not showing VAT as a line item.

## Root Cause

`OrderDetailClient` derives `billVatCents` from local `vatPercent` state — fetched from `vat_rates` on page load. If that fetch returned 0 (RLS timing, config not loaded), `billVatCents` = 0 and the VAT line was invisible on the payment breakdown and printed bill.

## Fix

- **`close_order/index.ts`**: Return `vat_percent` in the response alongside `vat_cents` (the rate used to compute it).
- **`closeOrderApi.ts`**: Add `vat_cents` and `vat_percent` to the response type; return them from `callCloseOrder`.
- **`OrderDetailClient.tsx`**:
  - Add `closedOrderVatCents` state (null = order not yet closed).
  - After `close_order`, store the server-computed VAT cents; also update `vatPercent` state if it was 0 and the server returned a non-zero rate.
  - `billVatCents`: use stored server value when available, else fall back to local calculation.
  - `billTotalCents`: recompute directly from components so the total stays consistent with the corrected VAT.
- **`BillPrintView.tsx`**: Change guard from `vatPercent > 0` to `vatCents > 0` — VAT line now renders whenever there's an actual VAT amount, regardless of whether vatPercent config was loaded.
- **`OrderDetailClient.test.tsx`**: Update `callCloseOrder` mock return values to include new fields.

## Breakdown Before / After

| | Before | After |
|---|---|---|
| Subtotal | ৳6,877 | ৳6,877 |
| Service Charge (10%) | ৳688 | ৳688 |
| VAT (5%) | ❌ missing | ✅ ৳344 |
| **Total** | **৳7,565** | **৳7,909** |