### PR TITLE
fix: previous bills not printing in bill receipt section (#431)

### DIFF
--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -202,8 +202,9 @@ function ReprintModal({
       aria-labelledby={titleId}
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50"
     >
-      {/* Hidden print area — only visible during window.print() */}
-      <div ref={printRef} aria-hidden="true">
+      {/* Hidden print area — only marked as print-area (visible) while window.print() is active.
+           The print CSS in globals.css hides body * and reveals only .print-area descendants. */}
+      <div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : ''}>
         <BillPrintView
           tableLabel={data.tableLabel}
           orderId={order.id}

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -204,7 +204,7 @@ function ReprintModal({
     >
       {/* Hidden print area — only marked as print-area (visible) while window.print() is active.
            The print CSS in globals.css hides body * and reveals only .print-area descendants. */}
-      <div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : ''}>
+      <div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : undefined}>
         <BillPrintView
           tableLabel={data.tableLabel}
           orderId={order.id}

--- a/apps/web/e2e/receipts.spec.ts
+++ b/apps/web/e2e/receipts.spec.ts
@@ -453,4 +453,58 @@ test.describe('Admin (owner) view', () => {
     await page.keyboard.press('Escape')
     await expect(page.getByRole('dialog')).not.toBeVisible()
   })
+
+  test('Re-print button applies print-area class to BillPrintView wrapper (issue #431)', async ({ page }) => {
+    // Regression test: the hidden print wrapper must receive the `print-area` class
+    // when Re-print is clicked so that globals.css @media print reveals the receipt.
+    // Before the fix the wrapper had no class, so body * { visibility: hidden } hid
+    // everything and nothing appeared in the print preview.
+    await page.route('**/rest/v1/orders?**', async (route) => {
+      const url = route.request().url()
+      if (url.includes('id=eq.')) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([{
+            bill_number: 'RN0001234', order_number: 7, created_at: TODAY_ISO,
+            final_total_cents: 120000, discount_amount_cents: 0, order_comp: false,
+            order_type: 'dine_in', customer_name: null, customer_mobile: null,
+            delivery_note: null, delivery_charge: 0, service_charge_cents: 0,
+            tables: { label: 'T3' }, delivery_zones: null,
+          }]),
+        })
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify([PAID_ORDER]),
+        })
+      }
+    })
+    await page.route('**/rest/v1/config?**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    })
+    await page.route('**/rest/v1/vat_rates?**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    })
+    await page.route('**/rest/v1/restaurants?**', async (route) => {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+    })
+    await page.route('**/rest/v1/users?**', async (route) => { await route.continue() })
+    await mockReprintEndpoints(page)
+
+    // Intercept window.print so the browser doesn't open a real print dialog
+    await page.addInitScript(() => { window.print = () => {} })
+
+    await page.goto('/receipts')
+    await page.getByRole('button', { name: 'Re-print receipt' }).first().click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+
+    await page.getByRole('dialog').getByRole('button', { name: 'Re-print' }).click()
+
+    // After clicking Re-print the wrapper div must have the print-area class so that
+    // globals.css @media print makes it visible.
+    const wrapper = page.locator('[aria-hidden="true"].print-area').first()
+    await expect(wrapper).toBeAttached()
+  })
 })


### PR DESCRIPTION
## Problem

Fixes #431.

Staff were unable to print previous bills from the bill receipt (receipts page). Clicking Re-print opened the modal but nothing appeared in the print preview and no print dialog showed.

## Root Cause

`ReprintModal` wraps `BillPrintView` in a plain `<div>`:

```tsx
<div ref={printRef} aria-hidden="true">
  <BillPrintView ... />
</div>
```

The `globals.css` print styles hide *everything* and only reveal elements with the `.print-area` class:

```css
@media print {
  body * { visibility: hidden; }           /* hides everything */
  .print-area, .print-area * { visibility: visible; }  /* reveals only print-area */
}
```

Because the wrapper had no `.print-area` class, calling `window.print()` showed a blank page every time.

`OrderDetailClient.tsx` already handles this correctly by conditionally applying `print-area` when `printingBill` is true — this fix applies the same pattern to `ReprintModal`.

## Fix

Conditionally add `print-area` to the BillPrintView wrapper when `printed` is `true` (set just before `window.print()` is called):

```tsx
<div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : ''}>
```

## Tests

Added a regression e2e test in `receipts.spec.ts` that:
1. Opens the reprint modal
2. Clicks Re-print (with `window.print` stubbed to avoid a real dialog)
3. Asserts the wrapper div has the `print-area` class