### PR TITLE
fix: server VAT rate query — fetch all rates, not just menu_id=null (issue #146)

### DIFF
--- a/supabase/functions/close_order/index.test.ts
+++ b/supabase/functions/close_order/index.test.ts
@@ -354,7 +354,8 @@ describe('close_order handler', () => {
           ]), { status: 200, headers: { 'Content-Type': 'application/json' } })
         }
         if (url.includes('/rest/v1/vat_rates')) {
-          return new Response(JSON.stringify([{ percentage: 5 }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          // Return with menu_id: null (restaurant-level default) — mirrors real DB row format
+          return new Response(JSON.stringify([{ percentage: 5, menu_id: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
         }
         if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
           capturedPatch = JSON.parse(init.body as string) as Record<string, unknown>
@@ -397,6 +398,110 @@ describe('close_order handler', () => {
       const json = (await res.json()) as { success: boolean; data: { vat_cents: number } }
       expect(json.success).toBe(true)
       expect(json.data.vat_cents).toBe(0)
+    })
+
+    it('applies VAT when vat_rate row has non-null menu_id (bug fix: was silently returning 0)', async (): Promise<void> => {
+      // Regression test for the primary bug: vat_rates row has menu_id set (non-null),
+      // which the old &menu_id=is.null filter would miss, returning 0. The fix fetches all
+      // rates and falls back to vatRateRows[0] when no menu_id=null row exists.
+      const mockFetch = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        if (url.includes('/auth/v1/user')) {
+          return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/users')) {
+          return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/orders') && (!init?.method || init?.method === 'GET')) {
+          if (url.includes('select=id,restaurant_id,status')) {
+            return new Response(JSON.stringify([{ id: VALID_ORDER_ID, restaurant_id: RESTAURANT_ID, status: 'open', discount_amount_cents: 0, order_comp: false, final_total_cents: null, service_charge_cents: null, bill_number: null, order_type: 'dine_in' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          if (url.includes('select=customer_mobile')) {
+            return new Response(JSON.stringify([{ customer_mobile: null, customer_name: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/order_items') && (!init?.method || init?.method === 'GET')) {
+          if (url.includes('select=unit_price_cents')) {
+            return new Response(JSON.stringify([{ unit_price_cents: 1000, quantity: 2, item_discount_type: null, item_discount_value: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/config')) {
+          return new Response(JSON.stringify([
+            { key: 'vat_apply_dine_in', value: 'true' },
+          ]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/vat_rates')) {
+          // Only row has a non-null menu_id — the old &menu_id=is.null filter would return []
+          // The fix must still pick this up via the vatRateRows[0] fallback
+          return new Response(JSON.stringify([{ percentage: 7, menu_id: 'aaaa1111-0000-0000-0000-000000000000' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/orders') && init?.method === 'PATCH') {
+          return new Response(null, { status: 204 })
+        }
+        if (url.includes('/rest/v1/rpc/next_bill_sequence')) {
+          return new Response(JSON.stringify(1), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/audit_log')) {
+          return new Response(null, { status: 201 })
+        }
+        if (url.includes('/rest/v1/rpc/') || url.includes('/rest/v1/bill_sequences') || url.includes('/rest/v1/recipe_items') || url.includes('/rest/v1/stock_adjustments')) {
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify({ error: `Unhandled: ${url}` }), { status: 500 })
+      }) as FetchFn
+
+      const req = makeRequest({ order_id: VALID_ORDER_ID })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { success: boolean; data: { vat_cents: number; vat_percent: number } }
+      expect(json.success).toBe(true)
+      // subtotal=2000, no SC, VAT base=2000, 7% VAT = 140
+      expect(json.data.vat_cents).toBe(140)
+      expect(json.data.vat_percent).toBe(7)
+    })
+  })
+
+  describe('POST — idempotent vat_percent (Fix 2: was hardcoded 0)', () => {
+    it('returns actual vat_percent on idempotent pending_payment path', async (): Promise<void> => {
+      // The idempotent path now re-fetches the VAT rate so vat_percent is not hardcoded 0.
+      const mockFetch = vi.fn(async (url: string, init?: RequestInit): Promise<Response> => {
+        if (url.includes('/auth/v1/user')) {
+          return new Response(JSON.stringify({ id: ACTOR_ID }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/users')) {
+          return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/orders') && (!init?.method || init?.method === 'GET')) {
+          if (url.includes('select=id,restaurant_id,status')) {
+            return new Response(JSON.stringify([{
+              id: VALID_ORDER_ID,
+              restaurant_id: RESTAURANT_ID,
+              status: 'pending_payment',
+              discount_amount_cents: 0,
+              order_comp: false,
+              final_total_cents: 5000,
+              service_charge_cents: 500,
+              vat_cents: 250,
+              bill_number: 'RN0000001',
+              order_type: 'dine_in',
+            }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+          }
+          return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        if (url.includes('/rest/v1/vat_rates')) {
+          return new Response(JSON.stringify([{ percentage: 5, menu_id: null }]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        }
+        return new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      }) as FetchFn
+
+      const req = makeRequest({ order_id: VALID_ORDER_ID })
+      const res = await handler(req, mockFetch, TEST_ENV)
+      expect(res.status).toBe(200)
+      const json = (await res.json()) as { success: boolean; data: { vat_percent: number; vat_cents: number } }
+      expect(json.success).toBe(true)
+      expect(json.data.vat_cents).toBe(250)
+      expect(json.data.vat_percent).toBe(5)  // was 0 before the fix
     })
   })
 

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -26,6 +26,43 @@ function isValidUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
 }
 
+/**
+ * Fetch the effective VAT percent for a restaurant.
+ *
+ * Mirrors the restaurant-level fallback logic in apps/web/lib/fetchVatConfig.ts:
+ *   1. Prefer a row with menu_id IS NULL (restaurant-level default)
+ *   2. Fall back to the first available row (handles the case where the only
+ *      vat_rates row has a non-null menu_id, e.g. a per-category rate)
+ *
+ * Note: unlike fetchVatConfig.ts, this helper does NOT implement menu-specific
+ * matching (level 1 in the frontend's 3-tier precedence) because close_order
+ * operates at the order level and does not have a single canonical menu_id.
+ * For the vast majority of restaurants with one VAT rate this is equivalent.
+ *
+ * No &limit added intentionally — we must see all rows to find the null-menu_id
+ * one; a single-row query would replicate the original bug.
+ *
+ * Returns 0 on any error (VAT defaults to 0, payment can still proceed).
+ */
+async function fetchVatPercent(
+  supabaseUrl: string,
+  dbHeaders: Record<string, string>,
+  restaurantId: string,
+  fetchFn: FetchFn,
+): Promise<number> {
+  try {
+    const url = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${restaurantId}`
+    const res = await fetchFn(url, { headers: dbHeaders })
+    if (!res.ok) return 0
+    const rows = (await res.json()) as Array<{ percentage: number | string; menu_id: string | null }>
+    if (rows.length === 0) return 0
+    const defaultRow = rows.find((r) => r.menu_id === null) ?? rows[0]
+    return Number(defaultRow.percentage) || 0
+  } catch {
+    return 0
+  }
+}
+
 export async function handler(
   req: Request,
   fetchFn: FetchFn = fetch,
@@ -132,24 +169,10 @@ export async function handler(
     }
     // Idempotent: if already pending_payment, return existing data (issue #318)
     if (orders[0].status === 'pending_payment') {
-      // Re-fetch the actual VAT percent (not stored on orders table) using same logic as main path.
-      // This avoids returning vat_percent: 0 which caused the UI to display wrong VAT line on re-open.
-      let idempotentVatPercent = 0
-      try {
-        const idempRestaurantId = orders[0].restaurant_id
-        // Fetch ALL vat_rates — mirror fetchVatConfig.ts: prefer menu_id IS NULL, fall back to first row
-        const idempVatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${idempRestaurantId}`
-        const idempVatRateRes = await fetchFn(idempVatRateUrl, { headers: dbHeaders })
-        if (idempVatRateRes.ok) {
-          const idempVatRateRows = (await idempVatRateRes.json()) as Array<{ percentage: number | string; menu_id: string | null }>
-          if (idempVatRateRows.length > 0) {
-            const idempDefaultRow = idempVatRateRows.find((r) => r.menu_id === null) ?? idempVatRateRows[0]
-            idempotentVatPercent = Number(idempDefaultRow.percentage) || 0
-          }
-        }
-      } catch {
-        // Non-fatal: fall back to 0 — UI uses its local vatPercent state as fallback
-      }
+      // Re-fetch the actual VAT percent (not stored on orders table) using the shared helper.
+      // Previously this path returned vat_percent: 0 hardcoded, causing the UI to show no VAT
+      // on order re-open. fetchVatPercent falls back to 0 on error, matching old safe behaviour.
+      const idempotentVatPercent = await fetchVatPercent(supabaseUrl, dbHeaders, orders[0].restaurant_id, fetchFn)
       return new Response(
         JSON.stringify({
           success: true,
@@ -290,27 +313,13 @@ export async function handler(
             (orderType === 'delivery' && vatApplyDelivery)
 
           if (vatApplies && !taxInclusive) {
-            // Fetch ALL VAT rates for this restaurant — mirrors fetchVatConfig.ts logic exactly.
-            // Bug fix: previously used &menu_id=is.null which silently returned empty when the VAT
-            // rate row has a non-null menu_id (e.g. assigned to a specific menu category).
-            // Fix: fetch all rates and apply same precedence as frontend:
-            //   prefer menu_id IS NULL (restaurant-level default), fall back to first available row.
-            const vatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${restaurantId}`
-            const vatRateRes = await fetchFn(vatRateUrl, { headers: dbHeaders })
-            if (vatRateRes.ok) {
-              const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string; menu_id: string | null }>
-              if (vatRateRows.length > 0) {
-                // Mirror fetchVatConfig.ts: prefer restaurant-level default, fall back to first row
-                const defaultRow = vatRateRows.find((r) => r.menu_id === null) ?? vatRateRows[0]
-                const vatPercent = Number(defaultRow.percentage) || 0
-                if (vatPercent > 0) {
-                  // VAT base = postDiscountSubtotal + serviceCharge (same as frontend vatBase)
-                  const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)
-                  const vatBase = postDiscountBase + serviceChargeCents
-                  vatCents = Math.round((vatBase * vatPercent) / 100)
-                  usedVatPercent = vatPercent
-                }
-              }
+            const vatPercent = await fetchVatPercent(supabaseUrl, dbHeaders, restaurantId, fetchFn)
+            if (vatPercent > 0) {
+              // VAT base = postDiscountSubtotal + serviceCharge (same as frontend vatBase)
+              const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)
+              const vatBase = postDiscountBase + serviceChargeCents
+              vatCents = Math.round((vatBase * vatPercent) / 100)
+              usedVatPercent = vatPercent
             }
           }
           // tax_inclusive = true: VAT is already embedded in item prices — vatCents stays 0

--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -132,6 +132,24 @@ export async function handler(
     }
     // Idempotent: if already pending_payment, return existing data (issue #318)
     if (orders[0].status === 'pending_payment') {
+      // Re-fetch the actual VAT percent (not stored on orders table) using same logic as main path.
+      // This avoids returning vat_percent: 0 which caused the UI to display wrong VAT line on re-open.
+      let idempotentVatPercent = 0
+      try {
+        const idempRestaurantId = orders[0].restaurant_id
+        // Fetch ALL vat_rates — mirror fetchVatConfig.ts: prefer menu_id IS NULL, fall back to first row
+        const idempVatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${idempRestaurantId}`
+        const idempVatRateRes = await fetchFn(idempVatRateUrl, { headers: dbHeaders })
+        if (idempVatRateRes.ok) {
+          const idempVatRateRows = (await idempVatRateRes.json()) as Array<{ percentage: number | string; menu_id: string | null }>
+          if (idempVatRateRows.length > 0) {
+            const idempDefaultRow = idempVatRateRows.find((r) => r.menu_id === null) ?? idempVatRateRows[0]
+            idempotentVatPercent = Number(idempDefaultRow.percentage) || 0
+          }
+        }
+      } catch {
+        // Non-fatal: fall back to 0 — UI uses its local vatPercent state as fallback
+      }
       return new Response(
         JSON.stringify({
           success: true,
@@ -139,8 +157,7 @@ export async function handler(
             final_total_cents: orders[0].final_total_cents ?? 0,
             service_charge_cents: orders[0].service_charge_cents ?? 0,
             vat_cents: orders[0].vat_cents ?? 0,
-            // vat_percent is not stored on orders; return 0 so the UI falls back to its local vatPercent state
-            vat_percent: 0,
+            vat_percent: idempotentVatPercent,
             bill_number: orders[0].bill_number ?? null,
           },
         }),
@@ -273,13 +290,19 @@ export async function handler(
             (orderType === 'delivery' && vatApplyDelivery)
 
           if (vatApplies && !taxInclusive) {
-            // Fetch restaurant-level VAT rate (menu_id IS NULL = restaurant default)
-            const vatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage&restaurant_id=eq.${restaurantId}&menu_id=is.null&limit=1`
+            // Fetch ALL VAT rates for this restaurant — mirrors fetchVatConfig.ts logic exactly.
+            // Bug fix: previously used &menu_id=is.null which silently returned empty when the VAT
+            // rate row has a non-null menu_id (e.g. assigned to a specific menu category).
+            // Fix: fetch all rates and apply same precedence as frontend:
+            //   prefer menu_id IS NULL (restaurant-level default), fall back to first available row.
+            const vatRateUrl = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${restaurantId}`
             const vatRateRes = await fetchFn(vatRateUrl, { headers: dbHeaders })
             if (vatRateRes.ok) {
-              const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string }>
+              const vatRateRows = (await vatRateRes.json()) as Array<{ percentage: number | string; menu_id: string | null }>
               if (vatRateRows.length > 0) {
-                const vatPercent = Number(vatRateRows[0].percentage) || 0
+                // Mirror fetchVatConfig.ts: prefer restaurant-level default, fall back to first row
+                const defaultRow = vatRateRows.find((r) => r.menu_id === null) ?? vatRateRows[0]
+                const vatPercent = Number(defaultRow.percentage) || 0
                 if (vatPercent > 0) {
                   // VAT base = postDiscountSubtotal + serviceCharge (same as frontend vatBase)
                   const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)


### PR DESCRIPTION
## Root Cause

The `close_order` edge function was querying `vat_rates` with a `&menu_id=is.null` filter. When the VAT rate row has a **non-null `menu_id`** (e.g. assigned to a specific menu category), the query returned an empty array — so `vatCents` stayed at 0 and that zero was stored in the DB.

Previous fix attempts (#426, #430, #432) all failed because they didn't fix this server-side query.

## Fixes

### Fix 1 — Primary bug (VAT rate query)
In `close_order/index.ts`, removed the `&menu_id=is.null` filter. Now fetches **all** `vat_rates` for the restaurant and applies the same precedence logic as `fetchVatConfig.ts`:
- Prefer `menu_id IS NULL` (restaurant-level default)
- Fall back to `vatRateRows[0]` when no null-`menu_id` row exists

### Fix 2 — Idempotent path
The `pending_payment` early-return path was returning `vat_percent: 0` hardcoded. It now re-fetches the actual VAT rate using the same corrected query, so the UI gets the real percent on order re-open.

### Fix 3 — Receipt history list
Already fully implemented in `billHistoryApi.ts` — `final_total_cents` on `BillHistoryOrder` is already computed as `(rawSubtotal - discount) + service_charge_cents + vat_cents + delivery`. No code changes required.

## Expected result after fix
Subtotal ৳789 → +10% SC (৳79) → ৳868 → +5% VAT (৳43) → Grand Total **৳911**

## Tests
Added 2 new test cases:
- VAT rate with non-null `menu_id` is correctly picked up via `vatRateRows[0]` fallback (was silently returning 0 before this fix)
- Idempotent path returns actual `vat_percent` (was hardcoded 0 before this fix)

All 25 unit tests pass.