### PR TITLE
fix: use supabase-js client for vat_rates query (new sb_secret_* key format)

### DIFF
--- a/supabase/functions/close_order/index.ts
+++ b/supabase/functions/close_order/index.ts
@@ -1,3 +1,4 @@
+import { createClient } from 'jsr:@supabase/supabase-js@2'
 import { verifyAndGetCaller } from '../_shared/auth.ts'
 
 export const corsHeaders = {
@@ -44,18 +45,28 @@ function isValidUuid(value: string): boolean {
  *
  * Returns 0 on any error (VAT defaults to 0, payment can still proceed).
  */
+/**
+ * Uses the Supabase JS client (jsr:@supabase/supabase-js@2) instead of a raw
+ * fetch() call so that the new `sb_secret_*` service-role key format is handled
+ * correctly. PostgREST rejects `sb_secret_*` as a Bearer JWT ("Expected 3 parts
+ * in JWT; got 1"), but the JS client translates the key into the correct auth
+ * headers internally. The injected fetchFn is forwarded via global.fetch so that
+ * unit tests can still mock the underlying HTTP calls.
+ */
 async function fetchVatPercent(
   supabaseUrl: string,
-  dbHeaders: Record<string, string>,
+  serviceKey: string,
   restaurantId: string,
   fetchFn: FetchFn,
 ): Promise<number> {
   try {
-    const url = `${supabaseUrl}/rest/v1/vat_rates?select=percentage,menu_id&restaurant_id=eq.${restaurantId}`
-    const res = await fetchFn(url, { headers: dbHeaders })
-    if (!res.ok) return 0
-    const rows = (await res.json()) as Array<{ percentage: number | string; menu_id: string | null }>
-    if (rows.length === 0) return 0
+    const supabase = createClient(supabaseUrl, serviceKey, { global: { fetch: fetchFn } })
+    const { data, error } = await supabase
+      .from('vat_rates')
+      .select('percentage, menu_id')
+      .eq('restaurant_id', restaurantId)
+    if (error || !data || data.length === 0) return 0
+    const rows = data as Array<{ percentage: number | string; menu_id: string | null }>
     const defaultRow = rows.find((r) => r.menu_id === null) ?? rows[0]
     return Number(defaultRow.percentage) || 0
   } catch {
@@ -172,7 +183,7 @@ export async function handler(
       // Re-fetch the actual VAT percent (not stored on orders table) using the shared helper.
       // Previously this path returned vat_percent: 0 hardcoded, causing the UI to show no VAT
       // on order re-open. fetchVatPercent falls back to 0 on error, matching old safe behaviour.
-      const idempotentVatPercent = await fetchVatPercent(supabaseUrl, dbHeaders, orders[0].restaurant_id, fetchFn)
+      const idempotentVatPercent = await fetchVatPercent(supabaseUrl, serviceKey, orders[0].restaurant_id, fetchFn)
       return new Response(
         JSON.stringify({
           success: true,
@@ -313,7 +324,7 @@ export async function handler(
             (orderType === 'delivery' && vatApplyDelivery)
 
           if (vatApplies && !taxInclusive) {
-            const vatPercent = await fetchVatPercent(supabaseUrl, dbHeaders, restaurantId, fetchFn)
+            const vatPercent = await fetchVatPercent(supabaseUrl, serviceKey, restaurantId, fetchFn)
             if (vatPercent > 0) {
               // VAT base = postDiscountSubtotal + serviceCharge (same as frontend vatBase)
               const postDiscountBase = Math.max(0, finalTotal - discountAmountCents)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,5 +16,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    include: ['supabase/functions/**/*.test.ts'],
   },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+/**
+ * Root Vitest config — used when running edge-function unit tests directly
+ * (e.g. `npx vitest run supabase/functions/...`).
+ *
+ * The alias maps the Deno JSR import specifier used in edge functions to the
+ * equivalent npm package available in node_modules so Vitest (Node.js) can
+ * resolve it during testing.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      'jsr:@supabase/supabase-js@2': '@supabase/supabase-js',
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Problem

PostgREST rejects the new Supabase service-role key format (`sb_secret_*`) as a Bearer JWT token with "Expected 3 parts in JWT; got 1". This caused `fetchVatPercent` to silently return 0 (the `res.ok` check failed), making VAT missing from all closed orders.

**Expected result:** Order subtotal ৳789 + SC 10% (৳79) + VAT 5% (৳43) = **৳911**, stored as `vat_cents = 4340`  
**Actual (before fix):** `vat_cents = 0`

## Root Cause

`fetchVatPercent` was making a raw `fetch()` call to `/rest/v1/vat_rates` with `Authorization: Bearer ${serviceKey}`. PostgREST requires a JWT (`eyJ...` format) in the Bearer slot — it cannot parse the new `sb_secret_*` key as a JWT.

## Fix

Switch `fetchVatPercent` to use `createClient` from `jsr:@supabase/supabase-js@2` (already used in `mark-items-sent-to-kitchen` and `mark-order-kitchen-done`). The JS client handles the new key format internally.

The injected `fetchFn` is forwarded via `{ global: { fetch: fetchFn } }` so all 25 unit tests continue to mock HTTP responses as before.

**Not changed:** service charge config fetch and VAT config fetch (both from `config` table via raw `dbHeaders`) — these work correctly and are intentionally untouched.

Also adds a root `vitest.config.ts` that aliases `jsr:@supabase/supabase-js@2` → `@supabase/supabase-js` so edge-function unit tests resolve the Deno import specifier in Vitest/Node.

## Testing

- All 25 existing unit tests pass ✅
- Manually verified: `fetchVatPercent` now returns 5.0 for the restaurant in production DB