### PR TITLE
feat: configurable bill print font size for thermal printer

### DIFF
--- a/apps/web/app/admin/settings/restaurant/page.tsx
+++ b/apps/web/app/admin/settings/restaurant/page.tsx
@@ -122,7 +122,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
           : Promise.resolve(),
         callUpsertConfig(config.url, config.key, restaurantId, 'loyalty_points_per_order', String(loyaltyNum)),
         callUpsertConfig(config.url, config.key, restaurantId, 'round_bill_totals', roundBillTotals ? 'true' : 'false'),
-        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(billPrintFontSizePt)),
+        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(Math.min(16, Math.max(8, billPrintFontSizePt)))),
       ])
       showFeedback('success', 'Restaurant settings saved.')
     } catch (err) {
@@ -289,7 +289,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
               value={billPrintFontSizePt}
               onChange={(e) => {
                 const v = parseInt(e.target.value, 10)
-                if (!isNaN(v) && v >= 8 && v <= 16) setBillPrintFontSizePt(v)
+                if (!isNaN(v)) setBillPrintFontSizePt(v)
               }}
               disabled={submitting}
               className="min-h-[48px] w-24 px-4 py-2 rounded-xl bg-brand-navy text-white border border-brand-grey focus:border-brand-blue focus:outline-none text-base disabled:opacity-50"

--- a/apps/web/app/admin/settings/restaurant/page.tsx
+++ b/apps/web/app/admin/settings/restaurant/page.tsx
@@ -38,6 +38,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
   const [restaurantAddress, setRestaurantAddress] = useState('')
   const [loyaltyPointsPerOrder, setLoyaltyPointsPerOrder] = useState('10')
   const [roundBillTotals, setRoundBillTotals] = useState(true)
+  const [billPrintFontSizePt, setBillPrintFontSizePt] = useState(12)
 
   // Supabase config ref
   const supabaseConfig = useRef<{ url: string; key: string } | null>(null)
@@ -59,13 +60,14 @@ export default function RestaurantSettingsPage(): JSX.Element {
         if (rows.length === 0) throw new Error('No restaurant found')
         const rid = rows[0].id
         setRestaurantId(rid)
-        const [nameVal, binVal, regVal, addrVal, loyaltyVal, roundVal] = await Promise.all([
+        const [nameVal, binVal, regVal, addrVal, loyaltyVal, roundVal, fontSizeVal] = await Promise.all([
           fetchConfigValue(supabaseUrl, accessToken, rid, 'restaurant_name', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'bin_number', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'register_name', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'restaurant_address', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'loyalty_points_per_order', '10'),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'round_bill_totals', 'true'),
+          fetchConfigValue(supabaseUrl, accessToken, rid, 'bill_print_font_size', '12'),
         ])
         setRestaurantName(nameVal)
         setBinNumber(binVal)
@@ -73,6 +75,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
         setRestaurantAddress(addrVal)
         setLoyaltyPointsPerOrder(loyaltyVal)
         setRoundBillTotals(roundVal === 'true')
+        setBillPrintFontSizePt(parseInt(fontSizeVal, 10) || 12)
       })
       .catch((err: unknown) => {
         setFetchError(err instanceof Error ? err.message : 'Failed to load settings')
@@ -119,6 +122,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
           : Promise.resolve(),
         callUpsertConfig(config.url, config.key, restaurantId, 'loyalty_points_per_order', String(loyaltyNum)),
         callUpsertConfig(config.url, config.key, restaurantId, 'round_bill_totals', roundBillTotals ? 'true' : 'false'),
+        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(billPrintFontSizePt)),
       ])
       showFeedback('success', 'Restaurant settings saved.')
     } catch (err) {
@@ -268,6 +272,34 @@ export default function RestaurantSettingsPage(): JSX.Element {
               ].join(' ')}
             />
           </button>
+        </div>
+
+        {/* Bill Print Font Size */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="bill-font-size" className="text-sm font-medium text-brand-navy/80">
+            Bill Print Font Size
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              id="bill-font-size"
+              type="number"
+              min="8"
+              max="16"
+              step="1"
+              value={billPrintFontSizePt}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10)
+                if (!isNaN(v) && v >= 8 && v <= 16) setBillPrintFontSizePt(v)
+              }}
+              disabled={submitting}
+              className="min-h-[48px] w-24 px-4 py-2 rounded-xl bg-brand-navy text-white border border-brand-grey focus:border-brand-blue focus:outline-none text-base disabled:opacity-50"
+            />
+            <span className="text-sm text-brand-navy/60">pt &nbsp;(8–16 pt)</span>
+          </div>
+          <p className="text-xs text-brand-grey">
+            Base font size for printed bills. Increase if text is too small on your 80mm thermal printer.
+            Default: 12 pt. All text scales relative to this value.
+          </p>
         </div>
 
         {/* Register Name */}

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -237,6 +237,7 @@ function ReprintModal({
           deliveryChargeCents={data.deliveryCharge}
           deliveryZoneName={data.deliveryZoneName ?? undefined}
           roundBillTotals={config.roundBillTotals}
+          fontSizePt={config.billPrintFontSizePt}
         />
       </div>
 

--- a/apps/web/app/receipts/billHistoryApi.ts
+++ b/apps/web/app/receipts/billHistoryApi.ts
@@ -470,6 +470,8 @@ export interface RestaurantConfig {
   serviceChargePercent: number
   currencySymbol: string
   roundBillTotals: boolean
+  /** Base font size in pt for bill printing (configurable via admin settings). Default: 12. */
+  billPrintFontSizePt: number
 }
 
 /**
@@ -486,7 +488,7 @@ export async function fetchRestaurantConfig(
 
   const [configRes, vatRes, restaurantRes] = await Promise.all([
     fetch(
-      `${supabaseUrl}/rest/v1/config?key=in.(bin_number,register_name,restaurant_address,round_bill_totals,currency_symbol,service_charge_percent)&select=key,value`,
+      `${supabaseUrl}/rest/v1/config?key=in.(bin_number,register_name,restaurant_address,round_bill_totals,currency_symbol,service_charge_percent,bill_print_font_size)&select=key,value`,
       { headers },
     ),
     fetch(
@@ -532,5 +534,6 @@ export async function fetchRestaurantConfig(
     serviceChargePercent: parseFloat(cfgMap.get('service_charge_percent') ?? '0') || 0,
     currencySymbol: cfgMap.get('currency_symbol') ?? '৳',
     roundBillTotals: cfgMap.get('round_bill_totals') === 'true',
+    billPrintFontSizePt: parseInt(cfgMap.get('bill_print_font_size') ?? '12', 10) || 12,
   }
 }

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -161,6 +161,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [restaurantAddress, setRestaurantAddress] = useState<string>('Lahore by iKitchen, Dhaka')
   const [binNumber, setBinNumber] = useState<string | undefined>(undefined)
   const [registerName, setRegisterName] = useState<string | undefined>(undefined)
+  // Bill print font size in pt (configurable via admin settings)
+  const [billPrintFontSizePt, setBillPrintFontSizePt] = useState<number>(12)
 
   // Void item state
   const [voidingItem, setVoidingItem] = useState<OrderItem | null>(null)
@@ -461,7 +463,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           ).then((r) => r.ok ? r.json() as Promise<Array<{ name: string }>> : Promise.resolve([])),
           // Fetch enhanced bill config keys in a single request
           fetch(
-            `${supabaseUrl}/rest/v1/config?restaurant_id=eq.${restaurantId}&key=in.(bin_number,register_name,restaurant_address,round_bill_totals)&select=key,value`,
+            `${supabaseUrl}/rest/v1/config?restaurant_id=eq.${restaurantId}&key=in.(bin_number,register_name,restaurant_address,round_bill_totals,bill_print_font_size)&select=key,value`,
             { headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? '', Authorization: `Bearer ${accessToken}` } },
           ).then((r) => r.ok ? r.json() as Promise<Array<{ key: string; value: string }>> : Promise.resolve([])),
         ]),
@@ -490,6 +492,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         if (cfgMap.has('register_name')) setRegisterName(cfgMap.get('register_name'))
         if (cfgMap.has('restaurant_address')) setRestaurantAddress(cfgMap.get('restaurant_address') ?? '')
         if (cfgMap.has('round_bill_totals')) setRoundBillTotals(cfgMap.get('round_bill_totals') === 'true')
+        if (cfgMap.has('bill_print_font_size')) {
+          const parsed = parseInt(cfgMap.get('bill_print_font_size') ?? '12', 10)
+          if (!isNaN(parsed) && parsed >= 8 && parsed <= 16) setBillPrintFontSizePt(parsed)
+        }
       })
       .catch(() => {
         // Non-fatal: fall back to 0% VAT / 0% service charge (safe — no overcharging)
@@ -2633,6 +2639,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             deliveryZoneName={orderDeliveryZoneName ?? undefined}
             roundBillTotals={roundBillTotals}
             isDue={printingPreBill}
+            fontSizePt={billPrintFontSizePt}
           />
         </div>
       )}

--- a/apps/web/components/BillPrintView.test.tsx
+++ b/apps/web/components/BillPrintView.test.tsx
@@ -763,4 +763,56 @@ describe('BillPrintView', () => {
       expect(screen.queryByText('Tendered by')).not.toBeInTheDocument()
     })
   })
+
+  describe('fontSizePt prop', () => {
+    function renderBill(fontSizePt?: number) {
+      const { container } = render(
+        <BillPrintView
+          tableLabel="Table 1"
+          orderId="order-font-test"
+          items={mockItems}
+          subtotalCents={SUBTOTAL}
+          vatPercent={0}
+          totalCents={SUBTOTAL}
+          paymentMethod="cash"
+          timestamp="20/04/2026, 12:00:00"
+          restaurantName="Test Restaurant"
+          fontSizePt={fontSizePt}
+        />,
+      )
+      return container.querySelector('[style]') as HTMLElement
+    }
+
+    it('applies default 12pt CSS custom properties when fontSizePt is omitted', () => {
+      const root = renderBill()
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 11pt')
+      expect(style).toContain('--bill-sm: 12pt')
+      expect(style).toContain('--bill-base: 14pt')
+      expect(style).toContain('--bill-lg: 16pt')
+    })
+
+    it('applies explicit fontSizePt=14 correctly', () => {
+      const root = renderBill(14)
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 13pt')
+      expect(style).toContain('--bill-sm: 14pt')
+      expect(style).toContain('--bill-base: 16pt')
+      expect(style).toContain('--bill-lg: 18pt')
+    })
+
+    it('clamps --bill-xs to 6pt minimum when fontSizePt=8', () => {
+      const root = renderBill(8)
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 7pt')
+      expect(style).toContain('--bill-sm: 8pt')
+    })
+
+    it('does not apply inline style to child elements', () => {
+      const root = renderBill(10)
+      // Only the root div should have a style attribute
+      const allStyled = root.querySelectorAll('[style]')
+      expect(allStyled).toHaveLength(0)
+    })
+  })
 })

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -90,16 +90,7 @@ export interface BillPrintViewProps {
    * Issue #370 — pre-payment bill copy for dine-in and takeaway orders.
    */
   isDue?: boolean
-  /**
-   * Base font size in pt for the printed bill.
-   * All text scales relative to this value:
-   *   - body/labels: fontSizePt
-   *   - header (restaurant name): fontSizePt + 2
-   *   - order-number badge: fontSizePt + 4
-   *   - secondary/meta text: fontSizePt - 1
-   * Use `pt` units — they map 1:1 to physical size on thermal printers.
-   * Default: 12pt.
-   */
+  /** Base font size in pt (8–16). Body = fontSizePt, header = +2, badge = +4, meta = −1. Default 12pt. */
   fontSizePt?: number
 }
 
@@ -141,11 +132,14 @@ export default function BillPrintView({
   isDue = false,
   fontSizePt = 12,
 }: BillPrintViewProps): JSX.Element {
-  // Font size tiers in pt — physical units that map 1:1 to thermal printer output
-  const sizeXs = `${Math.max(6, fontSizePt - 1)}pt`   // secondary / meta text
-  const sizeSm = `${fontSizePt}pt`                     // body / labels
-  const sizeBase = `${fontSizePt + 2}pt`               // restaurant name header
-  const sizeLg = `${fontSizePt + 4}pt`                 // order number badge
+  // CSS custom properties for font size tiers (pt maps 1:1 to thermal printer physical output).
+  // Exposed on root div so Tailwind arbitrary values can reference them without inline styles per child.
+  const fontVars = {
+    '--bill-xs':   `${Math.max(6, fontSizePt - 1)}pt`,
+    '--bill-sm':   `${fontSizePt}pt`,
+    '--bill-base': `${fontSizePt + 2}pt`,
+    '--bill-lg':   `${fontSizePt + 4}pt`,
+  } as React.CSSProperties
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
   const vatCents = vatCentsProp !== undefined ? vatCentsProp : totalCents - subtotalCents
@@ -159,30 +153,30 @@ export default function BillPrintView({
   const payableCents = totalCents + roundOffCents
 
   return (
-    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs" style={fontVars}>
       {/* 1. Restaurant name + address */}
       <div className="text-center mb-1">
-        <p className="font-bold" style={{ fontSize: sizeBase }}>{restaurantName}</p>
-        <p style={{ fontSize: sizeSm }}>{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
-        <p style={{ fontSize: sizeXs }}>{restaurantAddress}</p>
+        <p className="font-bold text-[length:var(--bill-base)]">{restaurantName}</p>
+        <p className="text-[length:var(--bill-sm)]">{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
+        <p className="text-[length:var(--bill-xs)]">{restaurantAddress}</p>
       </div>
 
       {/* 2. BIN # */}
       {binNumber && (
         <div className="text-center mb-1">
-          <p style={{ fontSize: sizeXs }}>BIN: {binNumber}</p>
+          <p className="text-[length:var(--bill-xs)]">BIN: {binNumber}</p>
         </div>
       )}
 
       {/* Order number badge — prominently displayed above meta */}
       {orderNumber != null && (
         <div className="text-center border border-black py-1 mb-2">
-          <p className="font-bold tracking-widest" style={{ fontSize: sizeLg }}>#{String(orderNumber).padStart(3, '0')}</p>
+          <p className="font-bold tracking-widest text-[length:var(--bill-lg)]">#{String(orderNumber).padStart(3, '0')}</p>
         </div>
       )}
 
       {/* 3. Bill meta */}
-      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
+      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5 text-[length:var(--bill-xs)]">
         {billNumber && (
           <div className="flex justify-between">
             <span className="font-semibold">Bill No</span>
@@ -225,14 +219,14 @@ export default function BillPrintView({
 
       {/* COMPLIMENTARY banner for whole-order comp */}
       {orderComp && (
-        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
+        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest text-[length:var(--bill-sm)]">
           ★ COMPLIMENTARY ★
         </div>
       )}
 
       {/* DUE / UNPAID banner — pre-payment bill copy (issue #370) */}
       {isDue && (
-        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
+        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest text-[length:var(--bill-sm)]">
           *** AMOUNT DUE — UNPAID ***
         </div>
       )}
@@ -240,7 +234,7 @@ export default function BillPrintView({
       {/* 4. Line items: S.No | Item name | Qty | Amount */}
       <div className="mb-2">
         {/* Header row */}
-        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5" style={{ fontSize: sizeXs }}>
+        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5 text-[length:var(--bill-xs)]">
           <span className="w-6 shrink-0">#</span>
           <span className="flex-1">Item</span>
           <span className="w-8 text-right shrink-0">Qty</span>
@@ -254,7 +248,7 @@ export default function BillPrintView({
           const hasItemDiscount = !isComp && itemDiscountCents > 0
           return (
             <div key={item.id} className="mb-0.5">
-              <div className="flex" style={{ fontSize: sizeXs }}>
+              <div className="flex text-[length:var(--bill-xs)]">
                 <span className="w-6 shrink-0 text-zinc-600">{idx + 1}</span>
                 <span className="flex-1 truncate">
                   {item.name}
@@ -266,7 +260,7 @@ export default function BillPrintView({
                 </span>
               </div>
               {hasItemDiscount && (
-                <div className="pl-6 text-zinc-500" style={{ fontSize: sizeXs }}>
+                <div className="pl-6 text-zinc-500 text-[length:var(--bill-xs)]">
                   {item.item_discount_type === 'percent' && item.item_discount_value != null
                     ? `Discount: -${item.item_discount_value / 100}%`
                     : `Discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}`}
@@ -275,12 +269,12 @@ export default function BillPrintView({
               {item.modifier_names.length > 0 && (
                 <ul className="pl-6">
                   {item.modifier_names.map((mod) => (
-                    <li key={mod} className="text-zinc-600" style={{ fontSize: sizeXs }}>+ {mod}</li>
+                    <li key={mod} className="text-zinc-600 text-[length:var(--bill-xs)]">+ {mod}</li>
                   ))}
                 </ul>
               )}
               {item.notes && (
-                <p className="pl-6 text-zinc-500 italic" style={{ fontSize: sizeXs }}>↳ {item.notes}</p>
+                <p className="pl-6 text-zinc-500 italic text-[length:var(--bill-xs)]">↳ {item.notes}</p>
               )}
             </div>
           )
@@ -288,7 +282,7 @@ export default function BillPrintView({
       </div>
 
       {/* 5. Sub total → Discount → Service Charge → VAT → Round off → Pay */}
-      <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
+      <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-sm)]">
         {!orderComp && (
           <>
             <div className="flex justify-between">
@@ -341,7 +335,7 @@ export default function BillPrintView({
 
       {/* 6. Payment breakdown — hidden on pre-payment due bills (issue #391) */}
       {!orderComp && !isDue && (
-        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-sm)]">
           {splitPayments && splitPayments.length > 0 ? (
             // One line per payment method (single or split) — always shows amount (issue #391)
             <>
@@ -399,8 +393,8 @@ export default function BillPrintView({
 
       {/* 7. Customer details (delivery/takeaway) */}
       {isNonDineIn && (customerName || customerMobile || deliveryNote) && (
-        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
-          <p className="font-semibold" style={{ fontSize: sizeSm }}>{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-xs)]">
+          <p className="font-semibold text-[length:var(--bill-sm)]">{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
           {customerName && (
             <div className="flex justify-between">
               <span>Name</span>
@@ -423,7 +417,7 @@ export default function BillPrintView({
       )}
 
       {/* 8. Footer */}
-      <div className="border-t border-black mt-2 pt-1 text-center" style={{ fontSize: sizeXs }}>
+      <div className="border-t border-black mt-2 pt-1 text-center text-[length:var(--bill-xs)]">
         Thank You!!!
       </div>
     </div>

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -90,6 +90,17 @@ export interface BillPrintViewProps {
    * Issue #370 — pre-payment bill copy for dine-in and takeaway orders.
    */
   isDue?: boolean
+  /**
+   * Base font size in pt for the printed bill.
+   * All text scales relative to this value:
+   *   - body/labels: fontSizePt
+   *   - header (restaurant name): fontSizePt + 2
+   *   - order-number badge: fontSizePt + 4
+   *   - secondary/meta text: fontSizePt - 1
+   * Use `pt` units — they map 1:1 to physical size on thermal printers.
+   * Default: 12pt.
+   */
+  fontSizePt?: number
 }
 
 export default function BillPrintView({
@@ -128,7 +139,13 @@ export default function BillPrintView({
   roundBillTotals = false,
   splitPayments,
   isDue = false,
+  fontSizePt = 12,
 }: BillPrintViewProps): JSX.Element {
+  // Font size tiers in pt — physical units that map 1:1 to thermal printer output
+  const sizeXs = `${Math.max(6, fontSizePt - 1)}pt`   // secondary / meta text
+  const sizeSm = `${fontSizePt}pt`                     // body / labels
+  const sizeBase = `${fontSizePt + 2}pt`               // restaurant name header
+  const sizeLg = `${fontSizePt + 4}pt`                 // order number badge
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
   const vatCents = vatCentsProp !== undefined ? vatCentsProp : totalCents - subtotalCents
@@ -145,27 +162,27 @@ export default function BillPrintView({
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       {/* 1. Restaurant name + address */}
       <div className="text-center mb-1">
-        <p className="text-base font-bold">{restaurantName}</p>
-        <p className="text-sm">{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
-        <p className="text-xs">{restaurantAddress}</p>
+        <p className="font-bold" style={{ fontSize: sizeBase }}>{restaurantName}</p>
+        <p style={{ fontSize: sizeSm }}>{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
+        <p style={{ fontSize: sizeXs }}>{restaurantAddress}</p>
       </div>
 
       {/* 2. BIN # */}
       {binNumber && (
         <div className="text-center mb-1">
-          <p className="text-xs">BIN: {binNumber}</p>
+          <p style={{ fontSize: sizeXs }}>BIN: {binNumber}</p>
         </div>
       )}
 
       {/* Order number badge — prominently displayed above meta */}
       {orderNumber != null && (
         <div className="text-center border border-black py-1 mb-2">
-          <p className="text-2xl font-bold tracking-widest">#{String(orderNumber).padStart(3, '0')}</p>
+          <p className="font-bold tracking-widest" style={{ fontSize: sizeLg }}>#{String(orderNumber).padStart(3, '0')}</p>
         </div>
       )}
 
       {/* 3. Bill meta */}
-      <div className="border-t border-b border-black py-1 mb-2 text-xs space-y-0.5">
+      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
         {billNumber && (
           <div className="flex justify-between">
             <span className="font-semibold">Bill No</span>
@@ -208,14 +225,14 @@ export default function BillPrintView({
 
       {/* COMPLIMENTARY banner for whole-order comp */}
       {orderComp && (
-        <div className="text-center border border-black py-1 mb-2 text-sm font-bold tracking-widest">
+        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
           ★ COMPLIMENTARY ★
         </div>
       )}
 
       {/* DUE / UNPAID banner — pre-payment bill copy (issue #370) */}
       {isDue && (
-        <div className="text-center border-2 border-black py-1 mb-2 text-sm font-bold tracking-widest">
+        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
           *** AMOUNT DUE — UNPAID ***
         </div>
       )}
@@ -223,7 +240,7 @@ export default function BillPrintView({
       {/* 4. Line items: S.No | Item name | Qty | Amount */}
       <div className="mb-2">
         {/* Header row */}
-        <div className="flex text-xs font-semibold border-b border-black pb-0.5 mb-0.5">
+        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5" style={{ fontSize: sizeXs }}>
           <span className="w-6 shrink-0">#</span>
           <span className="flex-1">Item</span>
           <span className="w-8 text-right shrink-0">Qty</span>
@@ -237,7 +254,7 @@ export default function BillPrintView({
           const hasItemDiscount = !isComp && itemDiscountCents > 0
           return (
             <div key={item.id} className="mb-0.5">
-              <div className="flex text-xs">
+              <div className="flex" style={{ fontSize: sizeXs }}>
                 <span className="w-6 shrink-0 text-zinc-600">{idx + 1}</span>
                 <span className="flex-1 truncate">
                   {item.name}
@@ -249,7 +266,7 @@ export default function BillPrintView({
                 </span>
               </div>
               {hasItemDiscount && (
-                <div className="pl-6 text-xs text-zinc-500">
+                <div className="pl-6 text-zinc-500" style={{ fontSize: sizeXs }}>
                   {item.item_discount_type === 'percent' && item.item_discount_value != null
                     ? `Discount: -${item.item_discount_value / 100}%`
                     : `Discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}`}
@@ -258,12 +275,12 @@ export default function BillPrintView({
               {item.modifier_names.length > 0 && (
                 <ul className="pl-6">
                   {item.modifier_names.map((mod) => (
-                    <li key={mod} className="text-xs text-zinc-600">+ {mod}</li>
+                    <li key={mod} className="text-zinc-600" style={{ fontSize: sizeXs }}>+ {mod}</li>
                   ))}
                 </ul>
               )}
               {item.notes && (
-                <p className="pl-6 text-xs text-zinc-500 italic">↳ {item.notes}</p>
+                <p className="pl-6 text-zinc-500 italic" style={{ fontSize: sizeXs }}>↳ {item.notes}</p>
               )}
             </div>
           )
@@ -271,7 +288,7 @@ export default function BillPrintView({
       </div>
 
       {/* 5. Sub total → Discount → Service Charge → VAT → Round off → Pay */}
-      <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
+      <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
         {!orderComp && (
           <>
             <div className="flex justify-between">
@@ -324,7 +341,7 @@ export default function BillPrintView({
 
       {/* 6. Payment breakdown — hidden on pre-payment due bills (issue #391) */}
       {!orderComp && !isDue && (
-        <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
           {splitPayments && splitPayments.length > 0 ? (
             // One line per payment method (single or split) — always shows amount (issue #391)
             <>
@@ -382,8 +399,8 @@ export default function BillPrintView({
 
       {/* 7. Customer details (delivery/takeaway) */}
       {isNonDineIn && (customerName || customerMobile || deliveryNote) && (
-        <div className="border-t border-black pt-1 mb-2 text-xs space-y-0.5">
-          <p className="font-semibold text-sm">{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
+          <p className="font-semibold" style={{ fontSize: sizeSm }}>{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
           {customerName && (
             <div className="flex justify-between">
               <span>Name</span>
@@ -406,7 +423,7 @@ export default function BillPrintView({
       )}
 
       {/* 8. Footer */}
-      <div className="border-t border-black mt-2 pt-1 text-center text-xs">
+      <div className="border-t border-black mt-2 pt-1 text-center" style={{ fontSize: sizeXs }}>
         Thank You!!!
       </div>
     </div>


### PR DESCRIPTION
## Problem

Thermal printer drivers ignore browser print Scale %, so changing scale had no effect on physical output size. The font on the 80mm thermal printer was too small.

## Solution

Add a configurable **Bill Print Font Size** setting (8–16pt, default **12pt**) that controls the actual physical font size on printed bills. CSS `pt` units map 1:1 to physical printer output size, making this a reliable fix.

## Changes

### `BillPrintView`
- New `fontSizePt` prop (default `12`)
- Removed Tailwind text-size classes (`text-xs/sm/base/2xl`) from all bill elements
- Replaced with inline `style={{ fontSize: '...pt' }}` using tiered sizes:
  - Restaurant name header: `fontSizePt + 2` pt
  - Order number badge: `fontSizePt + 4` pt  
  - Body / labels: `fontSizePt` pt
  - Meta / secondary text: `fontSizePt - 1` pt

### Admin → Settings → Restaurant
- New **Bill Print Font Size** number input (8–16pt, step 1) in the Bill/Receipt Settings section
- Stored as `bill_print_font_size` in the `config` key-value table (no migration needed)
- Default: 12pt

### `OrderDetailClient`
- Fetches `bill_print_font_size` from config alongside `bin_number`, `register_name` etc.
- Passes `fontSizePt` to `BillPrintView` (live order bill + pre-payment due bill)

### `billHistoryApi`
- Adds `billPrintFontSizePt` to `RestaurantConfig` interface
- Fetches `bill_print_font_size` config key

### `ReceiptsClient`
- Passes `config.billPrintFontSizePt` to `BillPrintView` in reprint modal

## How to change it

Admin → Settings → Restaurant → **Bill / Receipt Settings** → **Bill Print Font Size** input → adjust between 8–16pt → **Save Settings**.