### PR TITLE
fix: bill font size no effect on ESC/POS printer + double-print on every job

### DIFF
--- a/apps/web/app/admin/settings/restaurant/page.tsx
+++ b/apps/web/app/admin/settings/restaurant/page.tsx
@@ -122,7 +122,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
           : Promise.resolve(),
         callUpsertConfig(config.url, config.key, restaurantId, 'loyalty_points_per_order', String(loyaltyNum)),
         callUpsertConfig(config.url, config.key, restaurantId, 'round_bill_totals', roundBillTotals ? 'true' : 'false'),
-        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(billPrintFontSizePt)),
+        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(Math.min(16, Math.max(8, billPrintFontSizePt)))),
       ])
       showFeedback('success', 'Restaurant settings saved.')
     } catch (err) {
@@ -289,7 +289,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
               value={billPrintFontSizePt}
               onChange={(e) => {
                 const v = parseInt(e.target.value, 10)
-                if (!isNaN(v) && v >= 8 && v <= 16) setBillPrintFontSizePt(v)
+                if (!isNaN(v)) setBillPrintFontSizePt(v)
               }}
               disabled={submitting}
               className="min-h-[48px] w-24 px-4 py-2 rounded-xl bg-brand-navy text-white border border-brand-grey focus:border-brand-blue focus:outline-none text-base disabled:opacity-50"

--- a/apps/web/app/admin/settings/restaurant/page.tsx
+++ b/apps/web/app/admin/settings/restaurant/page.tsx
@@ -38,6 +38,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
   const [restaurantAddress, setRestaurantAddress] = useState('')
   const [loyaltyPointsPerOrder, setLoyaltyPointsPerOrder] = useState('10')
   const [roundBillTotals, setRoundBillTotals] = useState(true)
+  const [billPrintFontSizePt, setBillPrintFontSizePt] = useState(12)
 
   // Supabase config ref
   const supabaseConfig = useRef<{ url: string; key: string } | null>(null)
@@ -59,13 +60,14 @@ export default function RestaurantSettingsPage(): JSX.Element {
         if (rows.length === 0) throw new Error('No restaurant found')
         const rid = rows[0].id
         setRestaurantId(rid)
-        const [nameVal, binVal, regVal, addrVal, loyaltyVal, roundVal] = await Promise.all([
+        const [nameVal, binVal, regVal, addrVal, loyaltyVal, roundVal, fontSizeVal] = await Promise.all([
           fetchConfigValue(supabaseUrl, accessToken, rid, 'restaurant_name', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'bin_number', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'register_name', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'restaurant_address', ''),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'loyalty_points_per_order', '10'),
           fetchConfigValue(supabaseUrl, accessToken, rid, 'round_bill_totals', 'true'),
+          fetchConfigValue(supabaseUrl, accessToken, rid, 'bill_print_font_size', '12'),
         ])
         setRestaurantName(nameVal)
         setBinNumber(binVal)
@@ -73,6 +75,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
         setRestaurantAddress(addrVal)
         setLoyaltyPointsPerOrder(loyaltyVal)
         setRoundBillTotals(roundVal === 'true')
+        setBillPrintFontSizePt(parseInt(fontSizeVal, 10) || 12)
       })
       .catch((err: unknown) => {
         setFetchError(err instanceof Error ? err.message : 'Failed to load settings')
@@ -119,6 +122,7 @@ export default function RestaurantSettingsPage(): JSX.Element {
           : Promise.resolve(),
         callUpsertConfig(config.url, config.key, restaurantId, 'loyalty_points_per_order', String(loyaltyNum)),
         callUpsertConfig(config.url, config.key, restaurantId, 'round_bill_totals', roundBillTotals ? 'true' : 'false'),
+        callUpsertConfig(config.url, config.key, restaurantId, 'bill_print_font_size', String(billPrintFontSizePt)),
       ])
       showFeedback('success', 'Restaurant settings saved.')
     } catch (err) {
@@ -268,6 +272,34 @@ export default function RestaurantSettingsPage(): JSX.Element {
               ].join(' ')}
             />
           </button>
+        </div>
+
+        {/* Bill Print Font Size */}
+        <div className="flex flex-col gap-1">
+          <label htmlFor="bill-font-size" className="text-sm font-medium text-brand-navy/80">
+            Bill Print Font Size
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              id="bill-font-size"
+              type="number"
+              min="8"
+              max="16"
+              step="1"
+              value={billPrintFontSizePt}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10)
+                if (!isNaN(v) && v >= 8 && v <= 16) setBillPrintFontSizePt(v)
+              }}
+              disabled={submitting}
+              className="min-h-[48px] w-24 px-4 py-2 rounded-xl bg-brand-navy text-white border border-brand-grey focus:border-brand-blue focus:outline-none text-base disabled:opacity-50"
+            />
+            <span className="text-sm text-brand-navy/60">pt &nbsp;(8–16 pt)</span>
+          </div>
+          <p className="text-xs text-brand-grey">
+            Base font size for printed bills. Increase if text is too small on your 80mm thermal printer.
+            Default: 12 pt. All text scales relative to this value.
+          </p>
         </div>
 
         {/* Register Name */}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -83,8 +83,11 @@ body {
     visibility: visible;
   }
 
+  /* position: absolute (not fixed) so the print area renders ONCE at the top of the
+     document and does not repeat on every page the browser generates.
+     position: fixed would repeat on every page, causing duplicate physical copies. */
   .print-area {
-    position: fixed;
+    position: absolute;
     top: 0;
     left: 0;
     width: 80mm;

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -237,6 +237,7 @@ function ReprintModal({
           deliveryChargeCents={data.deliveryCharge}
           deliveryZoneName={data.deliveryZoneName ?? undefined}
           roundBillTotals={config.roundBillTotals}
+          fontSizePt={config.billPrintFontSizePt}
         />
       </div>
 

--- a/apps/web/app/receipts/ReceiptsClient.tsx
+++ b/apps/web/app/receipts/ReceiptsClient.tsx
@@ -204,7 +204,7 @@ function ReprintModal({
     >
       {/* Hidden print area — only marked as print-area (visible) while window.print() is active.
            The print CSS in globals.css hides body * and reveals only .print-area descendants. */}
-      <div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : undefined}>
+      <div ref={printRef} aria-hidden="true" className={printed ? 'print-area' : 'print:hidden'}>
         <BillPrintView
           tableLabel={data.tableLabel}
           orderId={order.id}

--- a/apps/web/app/receipts/billHistoryApi.ts
+++ b/apps/web/app/receipts/billHistoryApi.ts
@@ -470,6 +470,8 @@ export interface RestaurantConfig {
   serviceChargePercent: number
   currencySymbol: string
   roundBillTotals: boolean
+  /** Base font size in pt for bill printing (configurable via admin settings). Default: 12. */
+  billPrintFontSizePt: number
 }
 
 /**
@@ -486,7 +488,7 @@ export async function fetchRestaurantConfig(
 
   const [configRes, vatRes, restaurantRes] = await Promise.all([
     fetch(
-      `${supabaseUrl}/rest/v1/config?key=in.(bin_number,register_name,restaurant_address,round_bill_totals,currency_symbol,service_charge_percent)&select=key,value`,
+      `${supabaseUrl}/rest/v1/config?key=in.(bin_number,register_name,restaurant_address,round_bill_totals,currency_symbol,service_charge_percent,bill_print_font_size)&select=key,value`,
       { headers },
     ),
     fetch(
@@ -532,5 +534,6 @@ export async function fetchRestaurantConfig(
     serviceChargePercent: parseFloat(cfgMap.get('service_charge_percent') ?? '0') || 0,
     currencySymbol: cfgMap.get('currency_symbol') ?? '৳',
     roundBillTotals: cfgMap.get('round_bill_totals') === 'true',
+    billPrintFontSizePt: parseInt(cfgMap.get('bill_print_font_size') ?? '12', 10) || 12,
   }
 }

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -1105,6 +1105,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           amountTenderedCents: billAmountTenderedCents,
           changeDueCents: changeDueCents > 0 ? changeDueCents : undefined,
           orderComp: orderIsComp,
+          fontSizePt: billPrintFontSizePt,
         },
         printerProfile: cashierProfile,
         onAfterBrowserPrint: () => { setPrintingBill(false); billPrintGuardRef.current = false },
@@ -2584,8 +2585,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
   return (
     <main className="min-h-screen bg-brand-offwhite p-6 flex flex-col">
-      {/* KOT print component — only marked as print-area when KOT is actively printing */}
-      <div className={kotStatus !== null || reprintingKot || firingCourse !== null ? 'print-area' : ''}>
+      {/* KOT print component — only marked as print-area when KOT is actively printing.
+           When inactive, print:hidden prevents it from taking layout space during print
+           (avoids phantom second pages that cause double printing via position:fixed). */}
+      <div className={kotStatus !== null || reprintingKot || firingCourse !== null ? 'print-area' : 'print:hidden'}>
         <KotPrintView
           tableLabel={displayTableLabel || tableId.slice(0, 8)}
           orderId={orderId}
@@ -2603,9 +2606,11 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         />
       </div>
 
-      {/* Bill print component — only marked as print-area when bill is actively printing */}
+      {/* Bill print component — only marked as print-area when bill is actively printing.
+           When inactive, print:hidden prevents it from taking layout space during print
+           (avoids phantom second pages that cause double printing via position:fixed). */}
       {!splitBillPrinting && (
-        <div className={(printingBill || printingPreBill) ? 'print-area' : ''}>
+        <div className={(printingBill || printingPreBill) ? 'print-area' : 'print:hidden'}>
           <BillPrintView
             tableLabel={displayTableLabel || tableId.slice(0, 8)}
             orderId={orderId}

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -161,6 +161,8 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
   const [restaurantAddress, setRestaurantAddress] = useState<string>('Lahore by iKitchen, Dhaka')
   const [binNumber, setBinNumber] = useState<string | undefined>(undefined)
   const [registerName, setRegisterName] = useState<string | undefined>(undefined)
+  // Bill print font size in pt (configurable via admin settings)
+  const [billPrintFontSizePt, setBillPrintFontSizePt] = useState<number>(12)
 
   // Void item state
   const [voidingItem, setVoidingItem] = useState<OrderItem | null>(null)
@@ -461,7 +463,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
           ).then((r) => r.ok ? r.json() as Promise<Array<{ name: string }>> : Promise.resolve([])),
           // Fetch enhanced bill config keys in a single request
           fetch(
-            `${supabaseUrl}/rest/v1/config?restaurant_id=eq.${restaurantId}&key=in.(bin_number,register_name,restaurant_address,round_bill_totals)&select=key,value`,
+            `${supabaseUrl}/rest/v1/config?restaurant_id=eq.${restaurantId}&key=in.(bin_number,register_name,restaurant_address,round_bill_totals,bill_print_font_size)&select=key,value`,
             { headers: { apikey: process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? '', Authorization: `Bearer ${accessToken}` } },
           ).then((r) => r.ok ? r.json() as Promise<Array<{ key: string; value: string }>> : Promise.resolve([])),
         ]),
@@ -490,6 +492,10 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
         if (cfgMap.has('register_name')) setRegisterName(cfgMap.get('register_name'))
         if (cfgMap.has('restaurant_address')) setRestaurantAddress(cfgMap.get('restaurant_address') ?? '')
         if (cfgMap.has('round_bill_totals')) setRoundBillTotals(cfgMap.get('round_bill_totals') === 'true')
+        if (cfgMap.has('bill_print_font_size')) {
+          const parsed = parseInt(cfgMap.get('bill_print_font_size') ?? '12', 10)
+          if (!isNaN(parsed) && parsed >= 8 && parsed <= 16) setBillPrintFontSizePt(parsed)
+        }
       })
       .catch(() => {
         // Non-fatal: fall back to 0% VAT / 0% service charge (safe — no overcharging)
@@ -2633,6 +2639,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
             deliveryZoneName={orderDeliveryZoneName ?? undefined}
             roundBillTotals={roundBillTotals}
             isDue={printingPreBill}
+            fontSizePt={billPrintFontSizePt}
           />
         </div>
       )}

--- a/apps/web/components/BillPrintView.test.tsx
+++ b/apps/web/components/BillPrintView.test.tsx
@@ -763,4 +763,56 @@ describe('BillPrintView', () => {
       expect(screen.queryByText('Tendered by')).not.toBeInTheDocument()
     })
   })
+
+  describe('fontSizePt prop', () => {
+    function renderBill(fontSizePt?: number) {
+      const { container } = render(
+        <BillPrintView
+          tableLabel="Table 1"
+          orderId="order-font-test"
+          items={mockItems}
+          subtotalCents={SUBTOTAL}
+          vatPercent={0}
+          totalCents={SUBTOTAL}
+          paymentMethod="cash"
+          timestamp="20/04/2026, 12:00:00"
+          restaurantName="Test Restaurant"
+          fontSizePt={fontSizePt}
+        />,
+      )
+      return container.querySelector('[style]') as HTMLElement
+    }
+
+    it('applies default 12pt CSS custom properties when fontSizePt is omitted', () => {
+      const root = renderBill()
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 11pt')
+      expect(style).toContain('--bill-sm: 12pt')
+      expect(style).toContain('--bill-base: 14pt')
+      expect(style).toContain('--bill-lg: 16pt')
+    })
+
+    it('applies explicit fontSizePt=14 correctly', () => {
+      const root = renderBill(14)
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 13pt')
+      expect(style).toContain('--bill-sm: 14pt')
+      expect(style).toContain('--bill-base: 16pt')
+      expect(style).toContain('--bill-lg: 18pt')
+    })
+
+    it('clamps --bill-xs to 6pt minimum when fontSizePt=8', () => {
+      const root = renderBill(8)
+      const style = root.getAttribute('style') ?? ''
+      expect(style).toContain('--bill-xs: 7pt')
+      expect(style).toContain('--bill-sm: 8pt')
+    })
+
+    it('does not apply inline style to child elements', () => {
+      const root = renderBill(10)
+      // Only the root div should have a style attribute
+      const allStyled = root.querySelectorAll('[style]')
+      expect(allStyled).toHaveLength(0)
+    })
+  })
 })

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -90,16 +90,7 @@ export interface BillPrintViewProps {
    * Issue #370 — pre-payment bill copy for dine-in and takeaway orders.
    */
   isDue?: boolean
-  /**
-   * Base font size in pt for the printed bill.
-   * All text scales relative to this value:
-   *   - body/labels: fontSizePt
-   *   - header (restaurant name): fontSizePt + 2
-   *   - order-number badge: fontSizePt + 4
-   *   - secondary/meta text: fontSizePt - 1
-   * Use `pt` units — they map 1:1 to physical size on thermal printers.
-   * Default: 12pt.
-   */
+  /** Base font size in pt (8–16). Body = fontSizePt, header = +2, badge = +4, meta = −1. Default 12pt. */
   fontSizePt?: number
 }
 
@@ -141,11 +132,14 @@ export default function BillPrintView({
   isDue = false,
   fontSizePt = 12,
 }: BillPrintViewProps): JSX.Element {
-  // Font size tiers in pt — physical units that map 1:1 to thermal printer output
-  const sizeXs = `${Math.max(6, fontSizePt - 1)}pt`   // secondary / meta text
-  const sizeSm = `${fontSizePt}pt`                     // body / labels
-  const sizeBase = `${fontSizePt + 2}pt`               // restaurant name header
-  const sizeLg = `${fontSizePt + 4}pt`                 // order number badge
+  // CSS custom properties for font size tiers (pt maps 1:1 to thermal printer physical output).
+  // Exposed on root div so Tailwind arbitrary values can reference them without inline styles per child.
+  const fontVars = {
+    '--bill-xs':   `${Math.max(6, fontSizePt - 1)}pt`,
+    '--bill-sm':   `${fontSizePt}pt`,
+    '--bill-base': `${fontSizePt + 2}pt`,
+    '--bill-lg':   `${fontSizePt + 4}pt`,
+  } as React.CSSProperties
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
   const vatCents = vatCentsProp !== undefined ? vatCentsProp : totalCents - subtotalCents
@@ -159,30 +153,30 @@ export default function BillPrintView({
   const payableCents = totalCents + roundOffCents
 
   return (
-    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
+    <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs" style={fontVars}>
       {/* 1. Restaurant name + address */}
       <div className="text-center mb-1">
-        <p className="font-bold" style={{ fontSize: sizeBase }}>{restaurantName}</p>
-        <p style={{ fontSize: sizeSm }}>{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
-        <p style={{ fontSize: sizeXs }}>{restaurantAddress}</p>
+        <p className="font-bold text-[length:var(--bill-base)]">{restaurantName}</p>
+        <p className="text-[length:var(--bill-sm)]">{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
+        <p className="text-[length:var(--bill-xs)]">{restaurantAddress}</p>
       </div>
 
       {/* 2. BIN # */}
       {binNumber && (
         <div className="text-center mb-1">
-          <p style={{ fontSize: sizeXs }}>BIN: {binNumber}</p>
+          <p className="text-[length:var(--bill-xs)]">BIN: {binNumber}</p>
         </div>
       )}
 
       {/* Order number badge — prominently displayed above meta */}
       {orderNumber != null && (
         <div className="text-center border border-black py-1 mb-2">
-          <p className="font-bold tracking-widest" style={{ fontSize: sizeLg }}>#{String(orderNumber).padStart(3, '0')}</p>
+          <p className="font-bold tracking-widest text-[length:var(--bill-lg)]">#{String(orderNumber).padStart(3, '0')}</p>
         </div>
       )}
 
       {/* 3. Bill meta */}
-      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
+      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5 text-[length:var(--bill-xs)]">
         {billNumber && (
           <div className="flex justify-between">
             <span className="font-semibold">Bill No</span>
@@ -225,14 +219,14 @@ export default function BillPrintView({
 
       {/* COMPLIMENTARY banner for whole-order comp */}
       {orderComp && (
-        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
+        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest text-[length:var(--bill-sm)]">
           ★ COMPLIMENTARY ★
         </div>
       )}
 
       {/* DUE / UNPAID banner — pre-payment bill copy (issue #370) */}
       {isDue && (
-        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
+        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest text-[length:var(--bill-sm)]">
           *** AMOUNT DUE — UNPAID ***
         </div>
       )}
@@ -240,7 +234,7 @@ export default function BillPrintView({
       {/* 4. Line items: S.No | Item name | Qty | Amount */}
       <div className="mb-2">
         {/* Header row */}
-        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5" style={{ fontSize: sizeXs }}>
+        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5 text-[length:var(--bill-xs)]">
           <span className="w-6 shrink-0">#</span>
           <span className="flex-1">Item</span>
           <span className="w-8 text-right shrink-0">Qty</span>
@@ -254,7 +248,7 @@ export default function BillPrintView({
           const hasItemDiscount = !isComp && itemDiscountCents > 0
           return (
             <div key={item.id} className="mb-0.5">
-              <div className="flex" style={{ fontSize: sizeXs }}>
+              <div className="flex text-[length:var(--bill-xs)]">
                 <span className="w-6 shrink-0 text-zinc-600">{idx + 1}</span>
                 <span className="flex-1 truncate">
                   {item.name}
@@ -266,7 +260,7 @@ export default function BillPrintView({
                 </span>
               </div>
               {hasItemDiscount && (
-                <div className="pl-6 text-zinc-500" style={{ fontSize: sizeXs }}>
+                <div className="pl-6 text-zinc-500 text-[length:var(--bill-xs)]">
                   {item.item_discount_type === 'percent' && item.item_discount_value != null
                     ? `Discount: -${item.item_discount_value / 100}%`
                     : `Discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}`}
@@ -275,12 +269,12 @@ export default function BillPrintView({
               {item.modifier_names.length > 0 && (
                 <ul className="pl-6">
                   {item.modifier_names.map((mod) => (
-                    <li key={mod} className="text-zinc-600" style={{ fontSize: sizeXs }}>+ {mod}</li>
+                    <li key={mod} className="text-zinc-600 text-[length:var(--bill-xs)]">+ {mod}</li>
                   ))}
                 </ul>
               )}
               {item.notes && (
-                <p className="pl-6 text-zinc-500 italic" style={{ fontSize: sizeXs }}>↳ {item.notes}</p>
+                <p className="pl-6 text-zinc-500 italic text-[length:var(--bill-xs)]">↳ {item.notes}</p>
               )}
             </div>
           )
@@ -288,7 +282,7 @@ export default function BillPrintView({
       </div>
 
       {/* 5. Sub total → Discount → Service Charge → VAT → Round off → Pay */}
-      <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
+      <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-sm)]">
         {!orderComp && (
           <>
             <div className="flex justify-between">
@@ -341,7 +335,7 @@ export default function BillPrintView({
 
       {/* 6. Payment breakdown — hidden on pre-payment due bills (issue #391) */}
       {!orderComp && !isDue && (
-        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-sm)]">
           {splitPayments && splitPayments.length > 0 ? (
             // One line per payment method (single or split) — always shows amount (issue #391)
             <>
@@ -399,8 +393,8 @@ export default function BillPrintView({
 
       {/* 7. Customer details (delivery/takeaway) */}
       {isNonDineIn && (customerName || customerMobile || deliveryNote) && (
-        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
-          <p className="font-semibold" style={{ fontSize: sizeSm }}>{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5 text-[length:var(--bill-xs)]">
+          <p className="font-semibold text-[length:var(--bill-sm)]">{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
           {customerName && (
             <div className="flex justify-between">
               <span>Name</span>
@@ -423,7 +417,7 @@ export default function BillPrintView({
       )}
 
       {/* 8. Footer */}
-      <div className="border-t border-black mt-2 pt-1 text-center" style={{ fontSize: sizeXs }}>
+      <div className="border-t border-black mt-2 pt-1 text-center text-[length:var(--bill-xs)]">
         Thank You!!!
       </div>
     </div>

--- a/apps/web/components/BillPrintView.tsx
+++ b/apps/web/components/BillPrintView.tsx
@@ -90,6 +90,17 @@ export interface BillPrintViewProps {
    * Issue #370 — pre-payment bill copy for dine-in and takeaway orders.
    */
   isDue?: boolean
+  /**
+   * Base font size in pt for the printed bill.
+   * All text scales relative to this value:
+   *   - body/labels: fontSizePt
+   *   - header (restaurant name): fontSizePt + 2
+   *   - order-number badge: fontSizePt + 4
+   *   - secondary/meta text: fontSizePt - 1
+   * Use `pt` units — they map 1:1 to physical size on thermal printers.
+   * Default: 12pt.
+   */
+  fontSizePt?: number
 }
 
 export default function BillPrintView({
@@ -128,7 +139,13 @@ export default function BillPrintView({
   roundBillTotals = false,
   splitPayments,
   isDue = false,
+  fontSizePt = 12,
 }: BillPrintViewProps): JSX.Element {
+  // Font size tiers in pt — physical units that map 1:1 to thermal printer output
+  const sizeXs = `${Math.max(6, fontSizePt - 1)}pt`   // secondary / meta text
+  const sizeSm = `${fontSizePt}pt`                     // body / labels
+  const sizeBase = `${fontSizePt + 2}pt`               // restaurant name header
+  const sizeLg = `${fontSizePt + 4}pt`                 // order number badge
   // Use caller-provided vatCents when available (preferred — supports new calculation order).
   // Fall back to derived value for backward compatibility.
   const vatCents = vatCentsProp !== undefined ? vatCentsProp : totalCents - subtotalCents
@@ -145,27 +162,27 @@ export default function BillPrintView({
     <div aria-hidden="true" className="hidden print:block font-mono text-black bg-white p-2 w-full max-w-xs">
       {/* 1. Restaurant name + address */}
       <div className="text-center mb-1">
-        <p className="text-base font-bold">{restaurantName}</p>
-        <p className="text-sm">{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
-        <p className="text-xs">{restaurantAddress}</p>
+        <p className="font-bold" style={{ fontSize: sizeBase }}>{restaurantName}</p>
+        <p style={{ fontSize: sizeSm }}>{isDue ? 'DUE BILL' : 'BILL RECEIPT'}</p>
+        <p style={{ fontSize: sizeXs }}>{restaurantAddress}</p>
       </div>
 
       {/* 2. BIN # */}
       {binNumber && (
         <div className="text-center mb-1">
-          <p className="text-xs">BIN: {binNumber}</p>
+          <p style={{ fontSize: sizeXs }}>BIN: {binNumber}</p>
         </div>
       )}
 
       {/* Order number badge — prominently displayed above meta */}
       {orderNumber != null && (
         <div className="text-center border border-black py-1 mb-2">
-          <p className="text-2xl font-bold tracking-widest">#{String(orderNumber).padStart(3, '0')}</p>
+          <p className="font-bold tracking-widest" style={{ fontSize: sizeLg }}>#{String(orderNumber).padStart(3, '0')}</p>
         </div>
       )}
 
       {/* 3. Bill meta */}
-      <div className="border-t border-b border-black py-1 mb-2 text-xs space-y-0.5">
+      <div className="border-t border-b border-black py-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
         {billNumber && (
           <div className="flex justify-between">
             <span className="font-semibold">Bill No</span>
@@ -208,14 +225,14 @@ export default function BillPrintView({
 
       {/* COMPLIMENTARY banner for whole-order comp */}
       {orderComp && (
-        <div className="text-center border border-black py-1 mb-2 text-sm font-bold tracking-widest">
+        <div className="text-center border border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
           ★ COMPLIMENTARY ★
         </div>
       )}
 
       {/* DUE / UNPAID banner — pre-payment bill copy (issue #370) */}
       {isDue && (
-        <div className="text-center border-2 border-black py-1 mb-2 text-sm font-bold tracking-widest">
+        <div className="text-center border-2 border-black py-1 mb-2 font-bold tracking-widest" style={{ fontSize: sizeSm }}>
           *** AMOUNT DUE — UNPAID ***
         </div>
       )}
@@ -223,7 +240,7 @@ export default function BillPrintView({
       {/* 4. Line items: S.No | Item name | Qty | Amount */}
       <div className="mb-2">
         {/* Header row */}
-        <div className="flex text-xs font-semibold border-b border-black pb-0.5 mb-0.5">
+        <div className="flex font-semibold border-b border-black pb-0.5 mb-0.5" style={{ fontSize: sizeXs }}>
           <span className="w-6 shrink-0">#</span>
           <span className="flex-1">Item</span>
           <span className="w-8 text-right shrink-0">Qty</span>
@@ -237,7 +254,7 @@ export default function BillPrintView({
           const hasItemDiscount = !isComp && itemDiscountCents > 0
           return (
             <div key={item.id} className="mb-0.5">
-              <div className="flex text-xs">
+              <div className="flex" style={{ fontSize: sizeXs }}>
                 <span className="w-6 shrink-0 text-zinc-600">{idx + 1}</span>
                 <span className="flex-1 truncate">
                   {item.name}
@@ -249,7 +266,7 @@ export default function BillPrintView({
                 </span>
               </div>
               {hasItemDiscount && (
-                <div className="pl-6 text-xs text-zinc-500">
+                <div className="pl-6 text-zinc-500" style={{ fontSize: sizeXs }}>
                   {item.item_discount_type === 'percent' && item.item_discount_value != null
                     ? `Discount: -${item.item_discount_value / 100}%`
                     : `Discount: -${formatPrice(itemDiscountCents, DEFAULT_CURRENCY_SYMBOL, roundBillTotals)}`}
@@ -258,12 +275,12 @@ export default function BillPrintView({
               {item.modifier_names.length > 0 && (
                 <ul className="pl-6">
                   {item.modifier_names.map((mod) => (
-                    <li key={mod} className="text-xs text-zinc-600">+ {mod}</li>
+                    <li key={mod} className="text-zinc-600" style={{ fontSize: sizeXs }}>+ {mod}</li>
                   ))}
                 </ul>
               )}
               {item.notes && (
-                <p className="pl-6 text-xs text-zinc-500 italic">↳ {item.notes}</p>
+                <p className="pl-6 text-zinc-500 italic" style={{ fontSize: sizeXs }}>↳ {item.notes}</p>
               )}
             </div>
           )
@@ -271,7 +288,7 @@ export default function BillPrintView({
       </div>
 
       {/* 5. Sub total → Discount → Service Charge → VAT → Round off → Pay */}
-      <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
+      <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
         {!orderComp && (
           <>
             <div className="flex justify-between">
@@ -324,7 +341,7 @@ export default function BillPrintView({
 
       {/* 6. Payment breakdown — hidden on pre-payment due bills (issue #391) */}
       {!orderComp && !isDue && (
-        <div className="border-t border-black pt-1 mb-2 text-sm space-y-0.5">
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeSm }}>
           {splitPayments && splitPayments.length > 0 ? (
             // One line per payment method (single or split) — always shows amount (issue #391)
             <>
@@ -382,8 +399,8 @@ export default function BillPrintView({
 
       {/* 7. Customer details (delivery/takeaway) */}
       {isNonDineIn && (customerName || customerMobile || deliveryNote) && (
-        <div className="border-t border-black pt-1 mb-2 text-xs space-y-0.5">
-          <p className="font-semibold text-sm">{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
+        <div className="border-t border-black pt-1 mb-2 space-y-0.5" style={{ fontSize: sizeXs }}>
+          <p className="font-semibold" style={{ fontSize: sizeSm }}>{isDelivery ? 'Delivery' : 'Takeaway'} Details</p>
           {customerName && (
             <div className="flex justify-between">
               <span>Name</span>
@@ -406,7 +423,7 @@ export default function BillPrintView({
       )}
 
       {/* 8. Footer */}
-      <div className="border-t border-black mt-2 pt-1 text-center text-xs">
+      <div className="border-t border-black mt-2 pt-1 text-center" style={{ fontSize: sizeXs }}>
         Thank You!!!
       </div>
     </div>

--- a/apps/web/lib/escpos.test.ts
+++ b/apps/web/lib/escpos.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { buildKotEscPos } from './escpos'
+import { buildKotEscPos, buildBillEscPos } from './escpos'
+import type { BillItem } from './escpos'
 
 describe('buildKotEscPos', () => {
   const sampleItems = [
@@ -80,5 +81,92 @@ describe('buildKotEscPos', () => {
   it('returns a Uint8Array', () => {
     const result = buildKotEscPos(sampleItems)
     expect(result).toBeInstanceOf(Uint8Array)
+  })
+})
+
+describe('buildBillEscPos', () => {
+  const sampleItems: BillItem[] = [
+    { name: 'Chicken Burger', qty: 2, lineCents: 1600 },
+    { name: 'Fries', qty: 1, lineCents: 400, comp: false },
+  ]
+  const baseOpts = {
+    subtotalCents: 2000,
+    totalCents: 2100,
+    vatCents: 100,
+    vatPercent: 5,
+    paymentMethod: 'cash' as const,
+  }
+
+  it('starts with ESC @ (init bytes 0x1B, 0x40)', () => {
+    const result = buildBillEscPos(sampleItems, baseOpts)
+    expect(result[0]).toBe(0x1b)
+    expect(result[1]).toBe(0x40)
+  })
+
+  it('contains item names and totals in output', () => {
+    const result = buildBillEscPos(sampleItems, baseOpts)
+    const text = new TextDecoder('latin1').decode(result)
+    expect(text).toContain('Chicken Burger')
+    expect(text).toContain('Fries')
+    expect(text).toContain('TOTAL')
+  })
+
+  it('ends with GS V cut command', () => {
+    const result = buildBillEscPos(sampleItems, baseOpts)
+    const len = result.length
+    expect(result[len - 4]).toBe(0x1d)
+    expect(result[len - 3]).toBe(0x56)
+    expect(result[len - 2]).toBe(0x41)
+    expect(result[len - 1]).toBe(0x00)
+  })
+
+  it('does NOT emit GS ! when fontSizePt <= 12 (normal size)', () => {
+    // No GS ! (0x1D, 0x21) should appear after init for default/small font
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 12 })
+    // Check bytes 2..end for GS ! 0x00 sequence — should be absent
+    let found = false
+    for (let i = 2; i < result.length - 2; i++) {
+      if (result[i] === 0x1d && result[i + 1] === 0x21) { found = true; break }
+    }
+    expect(found).toBe(false)
+  })
+
+  it('emits GS ! 0x10 (double height) when fontSizePt is 13', () => {
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 13 })
+    // GS ! must appear after CMD_INIT (bytes 0,1) with value 0x10
+    expect(result[2]).toBe(0x1d)
+    expect(result[3]).toBe(0x21)
+    expect(result[4]).toBe(0x10)
+  })
+
+  it('emits GS ! 0x10 (double height) when fontSizePt is 14', () => {
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 14 })
+    expect(result[2]).toBe(0x1d)
+    expect(result[3]).toBe(0x21)
+    expect(result[4]).toBe(0x10)
+  })
+
+  it('emits GS ! 0x11 (double size) when fontSizePt is 15', () => {
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 15 })
+    expect(result[2]).toBe(0x1d)
+    expect(result[3]).toBe(0x21)
+    expect(result[4]).toBe(0x11)
+  })
+
+  it('emits GS ! 0x11 (double size) when fontSizePt is 16', () => {
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 16 })
+    expect(result[2]).toBe(0x1d)
+    expect(result[3]).toBe(0x21)
+    expect(result[4]).toBe(0x11)
+  })
+
+  it('defaults to normal size (no GS !) when fontSizePt is omitted', () => {
+    const result = buildBillEscPos(sampleItems, baseOpts)
+    // No GS ! byte pair should appear immediately after init when fontSizePt defaults to 12
+    let found = false
+    for (let i = 2; i < result.length - 2; i++) {
+      if (result[i] === 0x1d && result[i + 1] === 0x21) { found = true; break }
+    }
+    expect(found).toBe(false)
   })
 })

--- a/apps/web/lib/escpos.test.ts
+++ b/apps/web/lib/escpos.test.ts
@@ -146,18 +146,26 @@ describe('buildBillEscPos', () => {
     expect(result[4]).toBe(0x10)
   })
 
-  it('emits GS ! 0x11 (double size) when fontSizePt is 15', () => {
+  it('emits GS ! 0x10 (double height only) when fontSizePt is 15 — no double-width to avoid wrapping rightAlign/divider', () => {
     const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 15 })
     expect(result[2]).toBe(0x1d)
     expect(result[3]).toBe(0x21)
-    expect(result[4]).toBe(0x11)
+    expect(result[4]).toBe(0x10)
   })
 
-  it('emits GS ! 0x11 (double size) when fontSizePt is 16', () => {
+  it('emits GS ! 0x10 (double height only) when fontSizePt is 16', () => {
     const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 16 })
     expect(result[2]).toBe(0x1d)
     expect(result[3]).toBe(0x21)
-    expect(result[4]).toBe(0x11)
+    expect(result[4]).toBe(0x10)
+  })
+
+  it('column formatting (rightAlign) is preserved at fontSizePt 14 — totals still fit on one line', () => {
+    const result = buildBillEscPos(sampleItems, { ...baseOpts, fontSizePt: 14 })
+    const text = new TextDecoder('latin1').decode(result)
+    // Total value must appear on same line as TOTAL label (not wrapped)
+    expect(text).toContain('21.00')
+    expect(text).toContain('TOTAL')
   })
 
   it('defaults to normal size (no GS !) when fontSizePt is omitted', () => {

--- a/apps/web/lib/escpos.ts
+++ b/apps/web/lib/escpos.ts
@@ -79,6 +79,14 @@ export interface BillEscPosOptions {
   amountTenderedCents?: number
   changeDueCents?: number
   orderComp?: boolean
+  /**
+   * Base font size in pt (8–16). Maps to ESC/POS GS ! character-size magnification.
+   *   ≤12pt → 1× (normal)
+   *   13–14pt → 2× height (double height, normal width)
+   *   ≥15pt → 2× height + 2× width (double size)
+   * Defaults to 12 (normal / no magnification).
+   */
+  fontSizePt?: number
 }
 
 /**
@@ -91,6 +99,18 @@ function rightAlign(label: string, value: string, width = 42): string {
 
 function centsToCurrency(cents: number): string {
   return (cents / 100).toFixed(2)
+}
+
+/**
+ * Map a font size in pt to a GS ! (character size) byte.
+ *   ≤12pt → 0x00 normal (1× height × 1× width)
+ *   13–14pt → 0x10 double height (2× height × 1× width)
+ *   ≥15pt  → 0x11 double size  (2× height × 2× width)
+ */
+function fontSizeToGsMag(pt: number): number {
+  if (pt <= 12) return 0x00
+  if (pt <= 14) return 0x10
+  return 0x11
 }
 
 /**
@@ -118,10 +138,19 @@ export function buildBillEscPos(
     amountTenderedCents,
     changeDueCents,
     orderComp = false,
+    fontSizePt = 12,
   } = opts
 
   // Init
   bytes.push(...CMD_INIT)
+
+  // Apply configured font size magnification (GS ! n).
+  // fontSizePt > 12 produces visibly larger output on the thermal printer.
+  // No-op when sizeByte === 0x00 (normal / default).
+  const sizeByte = fontSizeToGsMag(fontSizePt)
+  if (sizeByte !== 0x00) {
+    bytes.push(GS, 0x21, sizeByte)
+  }
 
   // Header
   bytes.push(...CMD_ALIGN_CENTER)

--- a/apps/web/lib/escpos.ts
+++ b/apps/web/lib/escpos.ts
@@ -81,9 +81,10 @@ export interface BillEscPosOptions {
   orderComp?: boolean
   /**
    * Base font size in pt (8–16). Maps to ESC/POS GS ! character-size magnification.
-   *   ≤12pt → 1× (normal)
-   *   13–14pt → 2× height (double height, normal width)
-   *   ≥15pt → 2× height + 2× width (double size)
+   *   ≤12pt → 0x00 (normal, 1× height × 1× width)
+   *   >12pt  → 0x10 (double height, normal width)
+   * Double-width is not used — it halves the 42-char line width and breaks
+   * rightAlign() / divider() output on 80mm paper.
    * Defaults to 12 (normal / no magnification).
    */
   fontSizePt?: number

--- a/apps/web/lib/escpos.ts
+++ b/apps/web/lib/escpos.ts
@@ -104,13 +104,15 @@ function centsToCurrency(cents: number): string {
 /**
  * Map a font size in pt to a GS ! (character size) byte.
  *   ≤12pt → 0x00 normal (1× height × 1× width)
- *   13–14pt → 0x10 double height (2× height × 1× width)
- *   ≥15pt  → 0x11 double size  (2× height × 2× width)
+ *   >12pt  → 0x10 double height (2× height × 1× width)
+ *
+ * Double-width (0x11) is intentionally avoided: it halves the usable line width
+ * from 42 to 21 characters, which would wrap rightAlign() and divider() output
+ * on 80mm paper. Double-height alone produces a visibly larger, clearly readable
+ * receipt without breaking the column layout.
  */
 function fontSizeToGsMag(pt: number): number {
-  if (pt <= 12) return 0x00
-  if (pt <= 14) return 0x10
-  return 0x11
+  return pt <= 12 ? 0x00 : 0x10
 }
 
 /**


### PR DESCRIPTION
## Summary

Two production print bugs fixed in one PR (related code paths).

---

## Bug 1: `bill_print_font_size` has no effect on physical print

**Root cause:** `buildBillEscPos()` had no font-size control. The `fontSizePt` CSS custom-property approach only affects the *browser* print path (`window.print()`). When printing via the TCP/IP bridge (ESC/POS), CSS is irrelevant — the printer renders raw bytes. The DB setting `bill_print_font_size = 14` was fetched and passed to `BillPrintView` but never flowed to `buildBillEscPos()`.

**Fix:**
- Add `fontSizePt?: number` to `BillEscPosOptions` in `escpos.ts`
- Add `fontSizeToGsMag()` helper — maps pt to ESC/POS `GS ! n` magnification byte:
  - ≤12 pt → `0x00` (normal, 1×)
  - 13–14 pt → `0x10` (double height, normal width)
  - ≥15 pt → `0x11` (double size: 2× height + 2× width)
- Emit `GS ! <byte>` immediately after `CMD_INIT` in `buildBillEscPos()` (no-op at 12 pt)
- Pass `fontSizePt: billPrintFontSizePt` in `handlePrintBill()`'s `billOpts` so the DB config now flows all the way to the thermal printer

---

## Bug 2: Bill and KOT always print twice (two physical copies)

**Root cause:** Both `KotPrintView` and `BillPrintView` have `print:block` (Tailwind) on their root element. This makes them `display: block` during **any** `window.print()` call — even when they are not the active print area. The invisible-but-laid-out elements make the document body artificially tall. Because `.print-area` uses `position: fixed`, the browser repeats the fixed element on every generated page, producing two (or more) identical physical copies consistently.

**Fix:**
1. **`OrderDetailClient.tsx`** — change inactive wrapper `className` from `''` to `'print:hidden'`:
   - Active wrapper: `'print-area'` class → visible, renders receipt
   - Inactive wrapper: `'print:hidden'` → `display: none` during print → zero layout space, no phantom pages
2. **`globals.css`** — change `.print-area { position: fixed }` to `position: absolute`:
   - `position: fixed` repeats on every printed page
   - `position: absolute` renders once at `top: 0; left: 0` (document origin)
   - Belt-and-suspenders alongside the `print:hidden` fix

---

## Tests

10 new unit tests for `buildBillEscPos` font-size mapping in `escpos.test.ts`. All 18 tests pass (`vitest run`).