### PR TITLE
feat: feedback widget — floating button + Slack integration

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -3,6 +3,9 @@ NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 # Server-side service role key (bypasses RLS — never expose to client)
 SUPABASE_SERVICE_ROLE_KEY=
 
+# Slack webhook for the feedback widget (server-side only — never add NEXT_PUBLIC_ prefix)
+SLACK_FEEDBACK_WEBHOOK=
+
 # E2E test credentials (used by global-setup.ts — never commit real passwords)
 E2E_ADMIN_EMAIL=admin@lahore.ikitchen.com.bd
 E2E_ADMIN_PASSWORD=

--- a/apps/web/app/api/feedback/route.test.ts
+++ b/apps/web/app/api/feedback/route.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ── Mock @supabase/supabase-js ────────────────────────────────────────────────
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+const SUPABASE_URL = 'https://dmaogdwtgohrhbytxjqu.supabase.co'
+const WEBHOOK_URL = 'https://hooks.slack.com/services/fake'
+
+function makeRequest(body: unknown, token?: string): NextRequest {
+  return new NextRequest('http://localhost/api/feedback', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/feedback', () => {
+  let mockGetUser: ReturnType<typeof vi.fn>
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+
+    // Provide required env vars
+    vi.stubEnv('SLACK_FEEDBACK_WEBHOOK', WEBHOOK_URL)
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'fake-service-role-key')
+
+    // Set up the Supabase admin mock
+    mockGetUser = vi.fn()
+    const { createClient } = await import('@supabase/supabase-js')
+    vi.mocked(createClient).mockReturnValue({
+      auth: { getUser: mockGetUser },
+    } as unknown as ReturnType<typeof createClient>)
+
+    // Mock global fetch (used for the Slack webhook call)
+    mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  it('returns 503 when SLACK_FEEDBACK_WEBHOOK is not set', async () => {
+    vi.unstubAllEnvs()
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'key')
+
+    const { POST } = await import('./route')
+    const req = makeRequest({ description: 'test' }, 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/not configured/i)
+  })
+
+  it('returns 401 when Authorization header is missing', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('No token') })
+
+    const { POST } = await import('./route')
+    const req = makeRequest({ description: 'test' }) // no token
+    const res = await POST(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('Invalid JWT') })
+
+    const { POST } = await import('./route')
+    const req = makeRequest({ description: 'test' }, 'bad-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when description is empty', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
+      error: null,
+    })
+
+    const { POST } = await import('./route')
+    const req = makeRequest({ description: '   ', pageUrl: 'http://x', userAgent: 'ua', screenshots: [] }, 'valid')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/description/i)
+  })
+
+  it('returns 400 when screenshots is not an array', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
+      error: null,
+    })
+
+    const { POST } = await import('./route')
+    const req = makeRequest({ description: 'bug', pageUrl: 'http://x', userAgent: 'ua', screenshots: 'not-array' }, 'valid')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/array/i)
+  })
+
+  it('posts to Slack and returns 200 on success', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'test@example.com', user_metadata: { full_name: 'Test User' } } },
+      error: null,
+    })
+
+    const { POST } = await import('./route')
+    const req = makeRequest({
+      description: 'Checkout button broken',
+      pageUrl: 'http://pos/tables',
+      userAgent: 'Mozilla/5.0',
+      screenshots: [],
+    }, 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as { ok: boolean }
+    expect(json.ok).toBe(true)
+
+    // Verify Slack was called
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [slackUrl, slackOpts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(slackUrl).toBe(WEBHOOK_URL)
+    const slackBody = JSON.parse(slackOpts.body as string) as { text: string }
+    expect(slackBody.text).toContain('Test User')
+    expect(slackBody.text).toContain('test@example.com')
+    expect(slackBody.text).toContain('Checkout button broken')
+  })
+
+  it('filters out non-Supabase screenshot URLs', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
+      error: null,
+    })
+
+    const validUrl = `${SUPABASE_URL}/storage/v1/object/public/feedback-screenshots/u1/shot.png`
+    const evilUrl = 'https://evil.com/xss.png'
+
+    const { POST } = await import('./route')
+    const req = makeRequest({
+      description: 'bug',
+      pageUrl: 'http://x',
+      userAgent: 'ua',
+      screenshots: [validUrl, evilUrl],
+    }, 'valid')
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    const [, slackOpts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const slackBody = JSON.parse(slackOpts.body as string) as { text: string }
+    expect(slackBody.text).toContain(validUrl)
+    expect(slackBody.text).not.toContain(evilUrl)
+  })
+
+  it('returns 502 when Slack fetch throws a network error', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
+      error: null,
+    })
+    mockFetch.mockRejectedValue(new Error('Network error'))
+
+    const { POST } = await import('./route')
+    const req = makeRequest({
+      description: 'crash',
+      pageUrl: 'http://x',
+      userAgent: 'ua',
+      screenshots: [],
+    }, 'valid')
+    const res = await POST(req)
+
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 502 when Slack responds with non-2xx status', async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
+      error: null,
+    })
+    mockFetch.mockResolvedValue(new Response('channel_not_found', { status: 400 }))
+
+    const { POST } = await import('./route')
+    const req = makeRequest({
+      description: 'crash',
+      pageUrl: 'http://x',
+      userAgent: 'ua',
+      screenshots: [],
+    }, 'valid')
+    const res = await POST(req)
+
+    expect(res.status).toBe(502)
+  })
+})

--- a/apps/web/app/api/feedback/route.test.ts
+++ b/apps/web/app/api/feedback/route.test.ts
@@ -1,14 +1,32 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
 
-// ── Mock @supabase/supabase-js ────────────────────────────────────────────────
-vi.mock('@supabase/supabase-js', () => ({
-  createClient: vi.fn(),
+// ── Mock @/lib/supabase-admin ─────────────────────────────────────────────────
+const mockGetUser = vi.fn()
+vi.mock('@/lib/supabase-admin', () => ({
+  getSupabaseAdmin: vi.fn().mockReturnValue({
+    auth: { getUser: (...args: unknown[]) => mockGetUser(...args) },
+  }),
 }))
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+// ── Mock @/lib/logger (suppress output in tests) ──────────────────────────────
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// ── Constants ─────────────────────────────────────────────────────────────────
 const SUPABASE_URL = 'https://dmaogdwtgohrhbytxjqu.supabase.co'
 const WEBHOOK_URL = 'https://hooks.slack.com/services/fake'
+
+const AUTHENTICATED_USER = {
+  id: 'u1',
+  email: 'test@example.com',
+  user_metadata: { full_name: 'Test User' },
+}
 
 function makeRequest(body: unknown, token?: string): NextRequest {
   return new NextRequest('http://localhost/api/feedback', {
@@ -22,33 +40,23 @@ function makeRequest(body: unknown, token?: string): NextRequest {
 }
 
 describe('POST /api/feedback', () => {
-  let mockGetUser: ReturnType<typeof vi.fn>
   let mockFetch: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
     vi.resetModules()
 
-    // Provide required env vars
     vi.stubEnv('SLACK_FEEDBACK_WEBHOOK', WEBHOOK_URL)
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
     vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'fake-service-role-key')
 
-    // Set up the Supabase admin mock
-    mockGetUser = vi.fn()
-    const { createClient } = await import('@supabase/supabase-js')
-    vi.mocked(createClient).mockReturnValue({
-      auth: { getUser: mockGetUser },
-    } as unknown as ReturnType<typeof createClient>)
+    mockGetUser.mockResolvedValue({ data: { user: AUTHENTICATED_USER }, error: null })
 
-    // Mock global fetch (used for the Slack webhook call)
     mockFetch = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
     vi.stubGlobal('fetch', mockFetch)
   })
 
   it('returns 503 when SLACK_FEEDBACK_WEBHOOK is not set', async () => {
-    vi.unstubAllEnvs()
-    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
-    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'key')
+    vi.stubEnv('SLACK_FEEDBACK_WEBHOOK', '')
 
     const { POST } = await import('./route')
     const req = makeRequest({ description: 'test' }, 'valid-token')
@@ -60,8 +68,6 @@ describe('POST /api/feedback', () => {
   })
 
   it('returns 401 when Authorization header is missing', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('No token') })
-
     const { POST } = await import('./route')
     const req = makeRequest({ description: 'test' }) // no token
     const res = await POST(req)
@@ -80,11 +86,6 @@ describe('POST /api/feedback', () => {
   })
 
   it('returns 400 when description is empty', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
-      error: null,
-    })
-
     const { POST } = await import('./route')
     const req = makeRequest({ description: '   ', pageUrl: 'http://x', userAgent: 'ua', screenshots: [] }, 'valid')
     const res = await POST(req)
@@ -94,12 +95,29 @@ describe('POST /api/feedback', () => {
     expect(json.error).toMatch(/description/i)
   })
 
-  it('returns 400 when screenshots is not an array', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
-      error: null,
-    })
+  it('returns 400 when description is missing', async () => {
+    const { POST } = await import('./route')
+    const req = makeRequest({ pageUrl: 'http://x', userAgent: 'ua', screenshots: [] }, 'valid')
+    const res = await POST(req)
 
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when body is not valid JSON', async () => {
+    const { POST } = await import('./route')
+    const req = new NextRequest('http://localhost/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid' },
+      body: 'not json{',
+    })
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/invalid json/i)
+  })
+
+  it('returns 400 when screenshots is not an array', async () => {
     const { POST } = await import('./route')
     const req = makeRequest({ description: 'bug', pageUrl: 'http://x', userAgent: 'ua', screenshots: 'not-array' }, 'valid')
     const res = await POST(req)
@@ -110,11 +128,6 @@ describe('POST /api/feedback', () => {
   })
 
   it('posts to Slack and returns 200 on success', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'test@example.com', user_metadata: { full_name: 'Test User' } } },
-      error: null,
-    })
-
     const { POST } = await import('./route')
     const req = makeRequest({
       description: 'Checkout button broken',
@@ -128,26 +141,20 @@ describe('POST /api/feedback', () => {
     const json = await res.json() as { ok: boolean }
     expect(json.ok).toBe(true)
 
-    // Verify Slack was called
     expect(mockFetch).toHaveBeenCalledOnce()
     const [slackUrl, slackOpts] = mockFetch.mock.calls[0] as [string, RequestInit]
     expect(slackUrl).toBe(WEBHOOK_URL)
     const slackBody = JSON.parse(slackOpts.body as string) as { text: string }
+    // Identity is derived from server-verified user, not client body
     expect(slackBody.text).toContain('Test User')
     expect(slackBody.text).toContain('test@example.com')
     expect(slackBody.text).toContain('Checkout button broken')
   })
 
   it('filters out non-Supabase screenshot URLs', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
-      error: null,
-    })
-
+    const { POST } = await import('./route')
     const validUrl = `${SUPABASE_URL}/storage/v1/object/public/feedback-screenshots/u1/shot.png`
     const evilUrl = 'https://evil.com/xss.png'
-
-    const { POST } = await import('./route')
     const req = makeRequest({
       description: 'bug',
       pageUrl: 'http://x',
@@ -164,10 +171,6 @@ describe('POST /api/feedback', () => {
   })
 
   it('returns 502 when Slack fetch throws a network error', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
-      error: null,
-    })
     mockFetch.mockRejectedValue(new Error('Network error'))
 
     const { POST } = await import('./route')
@@ -183,10 +186,6 @@ describe('POST /api/feedback', () => {
   })
 
   it('returns 502 when Slack responds with non-2xx status', async () => {
-    mockGetUser.mockResolvedValue({
-      data: { user: { id: 'u1', email: 'a@b.com', user_metadata: {} } },
-      error: null,
-    })
     mockFetch.mockResolvedValue(new Response('channel_not_found', { status: 400 }))
 
     const { POST } = await import('./route')

--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -1,12 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+/** Max screenshot URLs we accept from the client. */
+const MAX_SCREENSHOTS = 10
+
+/** Expected Supabase Storage host for screenshot URL validation. */
+function isValidScreenshotUrl(url: unknown): url is string {
+  if (typeof url !== 'string') return false
+  try {
+    const parsed = new URL(url)
+    const storageHost = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').hostname
+    return parsed.protocol === 'https:' && parsed.hostname === storageHost
+  } catch {
+    return false
+  }
+}
 
 interface FeedbackPayload {
   description: string
   pageUrl: string
   userAgent: string
-  userEmail: string
-  userName: string
-  screenshots: string[]
+  screenshots: unknown[]
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -17,6 +31,30 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Feedback service is not configured' }, { status: 503 })
   }
 
+  // ── Auth: validate the bearer token via the admin client ──────────────────
+  const authHeader = request.headers.get('Authorization')
+  const token = authHeader?.replace(/^Bearer\s+/i, '').trim()
+
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const supabaseAdmin = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  )
+
+  const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token)
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Derive identity from the server-verified user — never trust the client.
+  const userEmail = user.email ?? 'unknown'
+  const userName = (user.user_metadata?.full_name as string | undefined) ?? user.email ?? 'unknown'
+
+  // ── Parse body ────────────────────────────────────────────────────────────
   let body: FeedbackPayload
   try {
     body = await request.json() as FeedbackPayload
@@ -24,41 +62,52 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  const { description, pageUrl, userAgent, userEmail, userName, screenshots } = body
+  const { description, pageUrl, userAgent, screenshots: rawScreenshots } = body
 
   if (!description?.trim()) {
     return NextResponse.json({ error: 'Description is required' }, { status: 400 })
   }
 
+  // Runtime-validate screenshots (must be an array of valid Supabase Storage URLs)
+  if (!Array.isArray(rawScreenshots)) {
+    return NextResponse.json({ error: 'screenshots must be an array' }, { status: 400 })
+  }
+
+  const screenshots = rawScreenshots
+    .slice(0, MAX_SCREENSHOTS)
+    .filter(isValidScreenshotUrl)
+
+  // ── Format and send Slack message ─────────────────────────────────────────
   const timestamp = new Date().toISOString()
 
   const screenshotsText =
-    screenshots && screenshots.length > 0
+    screenshots.length > 0
       ? screenshots.map((url) => `• ${url}`).join('\n')
       : 'None'
 
   const slackText =
     `🐛 *New Feedback from ${userName} (${userEmail})*\n\n` +
     `📝 *Description:*\n${description.trim()}\n\n` +
-    `📍 *Page:* ${pageUrl}\n` +
+    `📍 *Page:* ${pageUrl ?? 'unknown'}\n` +
     `🕐 *Time:* ${timestamp}\n` +
-    `🖥️ *User Agent:* ${userAgent}\n\n` +
+    `🖥️ *User Agent:* ${userAgent ?? 'unknown'}\n\n` +
     `📸 *Screenshots:*\n${screenshotsText}`
 
-  const slackPayload = {
-    text: slackText,
-  }
+  try {
+    const slackResponse = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: slackText }),
+    })
 
-  const slackResponse = await fetch(webhookUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(slackPayload),
-  })
-
-  if (!slackResponse.ok) {
-    const slackBody = await slackResponse.text()
-    console.error('[feedback] Slack webhook error:', slackResponse.status, slackBody)
-    return NextResponse.json({ error: 'Failed to send to Slack' }, { status: 502 })
+    if (!slackResponse.ok) {
+      const slackBody = await slackResponse.text()
+      console.error('[feedback] Slack webhook error:', slackResponse.status, slackBody)
+      return NextResponse.json({ error: 'Failed to send to Slack' }, { status: 502 })
+    }
+  } catch (err) {
+    console.error('[feedback] Slack fetch threw:', err)
+    return NextResponse.json({ error: 'Failed to reach Slack' }, { status: 502 })
   }
 
   return NextResponse.json({ ok: true })

--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -1,15 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
+import { getSupabaseAdmin } from '@/lib/supabase-admin'
+import { logger } from '@/lib/logger'
 
 /** Max screenshot URLs we accept from the client. */
-const MAX_SCREENSHOTS = 10
+const MAX_SCREENSHOTS = 5
 
-/** Expected Supabase Storage host for screenshot URL validation. */
+/** Validate that a URL is a public Supabase Storage URL on our own project. */
 function isValidScreenshotUrl(url: unknown): url is string {
   if (typeof url !== 'string') return false
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  if (!supabaseUrl) return false
   try {
     const parsed = new URL(url)
-    const storageHost = new URL(process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').hostname
+    const storageHost = new URL(supabaseUrl).hostname
     return parsed.protocol === 'https:' && parsed.hostname === storageHost
   } catch {
     return false
@@ -27,7 +30,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK
 
   if (!webhookUrl) {
-    console.error('[feedback] SLACK_FEEDBACK_WEBHOOK is not set')
+    logger.error('feedback', 'SLACK_FEEDBACK_WEBHOOK is not set')
     return NextResponse.json({ error: 'Feedback service is not configured' }, { status: 503 })
   }
 
@@ -39,13 +42,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const supabaseAdmin = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    { auth: { persistSession: false } }
-  )
-
-  const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token)
+  const { data: { user }, error: authError } = await getSupabaseAdmin().auth.getUser(token)
   if (authError || !user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -102,11 +99,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     if (!slackResponse.ok) {
       const slackBody = await slackResponse.text()
-      console.error('[feedback] Slack webhook error:', slackResponse.status, slackBody)
+      logger.error('feedback', 'Slack webhook returned non-2xx', { status: slackResponse.status, body: slackBody })
       return NextResponse.json({ error: 'Failed to send to Slack' }, { status: 502 })
     }
   } catch (err) {
-    console.error('[feedback] Slack fetch threw:', err)
+    logger.error('feedback', 'Slack fetch threw', { err: String(err) })
     return NextResponse.json({ error: 'Failed to reach Slack' }, { status: 502 })
   }
 

--- a/apps/web/app/api/feedback/route.ts
+++ b/apps/web/app/api/feedback/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+interface FeedbackPayload {
+  description: string
+  pageUrl: string
+  userAgent: string
+  userEmail: string
+  userName: string
+  screenshots: string[]
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const webhookUrl = process.env.SLACK_FEEDBACK_WEBHOOK
+
+  if (!webhookUrl) {
+    console.error('[feedback] SLACK_FEEDBACK_WEBHOOK is not set')
+    return NextResponse.json({ error: 'Feedback service is not configured' }, { status: 503 })
+  }
+
+  let body: FeedbackPayload
+  try {
+    body = await request.json() as FeedbackPayload
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { description, pageUrl, userAgent, userEmail, userName, screenshots } = body
+
+  if (!description?.trim()) {
+    return NextResponse.json({ error: 'Description is required' }, { status: 400 })
+  }
+
+  const timestamp = new Date().toISOString()
+
+  const screenshotsText =
+    screenshots && screenshots.length > 0
+      ? screenshots.map((url) => `• ${url}`).join('\n')
+      : 'None'
+
+  const slackText =
+    `🐛 *New Feedback from ${userName} (${userEmail})*\n\n` +
+    `📝 *Description:*\n${description.trim()}\n\n` +
+    `📍 *Page:* ${pageUrl}\n` +
+    `🕐 *Time:* ${timestamp}\n` +
+    `🖥️ *User Agent:* ${userAgent}\n\n` +
+    `📸 *Screenshots:*\n${screenshotsText}`
+
+  const slackPayload = {
+    text: slackText,
+  }
+
+  const slackResponse = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(slackPayload),
+  })
+
+  if (!slackResponse.ok) {
+    const slackBody = await slackResponse.text()
+    console.error('[feedback] Slack webhook error:', slackResponse.status, slackBody)
+    return NextResponse.json({ error: 'Failed to send to Slack' }, { status: 502 })
+  }
+
+  return NextResponse.json({ ok: true })
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import AppHeader from "@/components/AppHeader";
 import { UserProvider } from "@/lib/user-context";
 import OfflineIndicator from "@/components/OfflineIndicator";
 import ServiceWorkerRegistration from "@/components/ServiceWorkerRegistration";
+import FeedbackWidget from "@/components/FeedbackWidget";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -44,6 +45,7 @@ export default function RootLayout({
         <UserProvider>
           <AppHeader />
           {children}
+          <FeedbackWidget />
         </UserProvider>
         <OfflineIndicator />
         <ServiceWorkerRegistration />

--- a/apps/web/components/FeedbackWidget.test.tsx
+++ b/apps/web/components/FeedbackWidget.test.tsx
@@ -169,6 +169,6 @@ describe('FeedbackWidget', () => {
     const bigFile = new File([bigContent], 'huge.png', { type: 'image/png' })
     fireEvent.change(input, { target: { files: [bigFile] } })
 
-    expect(await screen.findByText(/5 mb/i)).toBeInTheDocument()
+    expect(await screen.findByText(/each file must be under 5 mb/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/components/FeedbackWidget.test.tsx
+++ b/apps/web/components/FeedbackWidget.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FeedbackWidget from './FeedbackWidget'
 
@@ -9,23 +9,21 @@ vi.mock('@/lib/user-context', () => ({
   useUser: (): ReturnType<typeof mockUseUser> => mockUseUser(),
 }))
 
-// ── Mock @/lib/supabase ────────────────────────────────────────────────────────
+// ── Mock @/lib/supabase (storage upload only — identity NOT fetched client-side) ─
 vi.mock('@/lib/supabase', () => ({
   supabase: {
     storage: {
       from: vi.fn().mockReturnValue({
         upload: vi.fn().mockResolvedValue({ error: null }),
-        getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://supabase.co/storage/shot.png' } }),
+        getPublicUrl: vi.fn().mockReturnValue({
+          data: { publicUrl: 'https://dmaogdwtgohrhbytxjqu.supabase.co/storage/shot.png' },
+        }),
       }),
     },
     auth: {
-      getSession: vi.fn().mockResolvedValue({
-        data: {
-          session: {
-            user: { email: 'tester@example.com', user_metadata: { full_name: 'Tester' } },
-          },
-        },
-      }),
+      // getSession is no longer called in FeedbackWidget; kept here in case
+      // other paths need it, but it should not be invoked during these tests.
+      getSession: vi.fn().mockRejectedValue(new Error('getSession should not be called')),
     },
   },
 }))
@@ -39,6 +37,7 @@ beforeEach(() => {
     json: async () => ({ ok: true }),
   })
   vi.stubGlobal('fetch', mockFetch)
+  mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
 })
 
 describe('FeedbackWidget', () => {
@@ -55,13 +54,11 @@ describe('FeedbackWidget', () => {
   })
 
   it('renders the floating Feedback button when user is authenticated', () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
     expect(screen.getByRole('button', { name: /open feedback form/i })).toBeInTheDocument()
   })
 
   it('opens the modal when the Feedback button is clicked', async () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -70,7 +67,6 @@ describe('FeedbackWidget', () => {
   })
 
   it('closes the modal when Cancel is clicked', async () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -80,8 +76,19 @@ describe('FeedbackWidget', () => {
     expect(screen.queryByRole('heading', { name: /send feedback/i })).not.toBeInTheDocument()
   })
 
+  it('closes the modal when backdrop is clicked', async () => {
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    expect(screen.getByRole('heading', { name: /send feedback/i })).toBeInTheDocument()
+
+    // The backdrop is the fixed overlay div — click it directly
+    const backdrop = screen.getByRole('heading', { name: /send feedback/i }).closest('.fixed')!
+    fireEvent.click(backdrop)
+    expect(screen.queryByRole('heading', { name: /send feedback/i })).not.toBeInTheDocument()
+  })
+
   it('disables Submit when description is empty', async () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -89,7 +96,6 @@ describe('FeedbackWidget', () => {
   })
 
   it('enables Submit and calls /api/feedback when form is filled', async () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -105,12 +111,14 @@ describe('FeedbackWidget', () => {
     expect(url).toBe('/api/feedback')
     expect(opts.method).toBe('POST')
 
-    const body = JSON.parse(opts.body as string) as { description: string }
+    const body = JSON.parse(opts.body as string) as { description: string; userEmail?: string; userName?: string }
     expect(body.description).toBe('Checkout is broken')
+    // Identity must NOT be sent from the client
+    expect(body.userEmail).toBeUndefined()
+    expect(body.userName).toBeUndefined()
   })
 
   it('shows success state after successful submission', async () => {
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -126,7 +134,6 @@ describe('FeedbackWidget', () => {
       json: async () => ({ error: 'Unauthorized' }),
     })
 
-    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
     render(<FeedbackWidget />)
 
     await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
@@ -134,5 +141,34 @@ describe('FeedbackWidget', () => {
     await userEvent.click(screen.getByRole('button', { name: /send feedback/i }))
 
     expect(await screen.findByText(/unauthorized/i)).toBeInTheDocument()
+  })
+
+  it('shows file error when too many files are selected', async () => {
+    render(<FeedbackWidget />)
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    // Simulate selecting 6 files (over the MAX_FILES=5 limit)
+    const files = Array.from({ length: 6 }, (_, i) =>
+      new File(['data'], `shot${i}.png`, { type: 'image/png' })
+    )
+    fireEvent.change(input, { target: { files } })
+
+    expect(await screen.findByText(/maximum 5 files/i)).toBeInTheDocument()
+  })
+
+  it('shows file error when a file exceeds the size limit', async () => {
+    render(<FeedbackWidget />)
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    // Simulate a 6 MB file (over MAX_FILE_SIZE_BYTES = 5 MB)
+    const bigContent = new Uint8Array(6 * 1024 * 1024)
+    const bigFile = new File([bigContent], 'huge.png', { type: 'image/png' })
+    fireEvent.change(input, { target: { files: [bigFile] } })
+
+    expect(await screen.findByText(/5 mb/i)).toBeInTheDocument()
   })
 })

--- a/apps/web/components/FeedbackWidget.test.tsx
+++ b/apps/web/components/FeedbackWidget.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FeedbackWidget from './FeedbackWidget'
+
+// ── Mock @/lib/user-context ────────────────────────────────────────────────────
+const mockUseUser = vi.fn()
+vi.mock('@/lib/user-context', () => ({
+  useUser: (): ReturnType<typeof mockUseUser> => mockUseUser(),
+}))
+
+// ── Mock @/lib/supabase ────────────────────────────────────────────────────────
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    storage: {
+      from: vi.fn().mockReturnValue({
+        upload: vi.fn().mockResolvedValue({ error: null }),
+        getPublicUrl: vi.fn().mockReturnValue({ data: { publicUrl: 'https://supabase.co/storage/shot.png' } }),
+      }),
+    },
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: {
+          session: {
+            user: { email: 'tester@example.com', user_metadata: { full_name: 'Tester' } },
+          },
+        },
+      }),
+    },
+  },
+}))
+
+// ── Mock global fetch ─────────────────────────────────────────────────────────
+const mockFetch = vi.fn()
+
+beforeEach(() => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ ok: true }),
+  })
+  vi.stubGlobal('fetch', mockFetch)
+})
+
+describe('FeedbackWidget', () => {
+  it('renders nothing while loading', () => {
+    mockUseUser.mockReturnValue({ role: null, loading: true, userId: null, accessToken: null })
+    const { container } = render(<FeedbackWidget />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when user is not authenticated', () => {
+    mockUseUser.mockReturnValue({ role: null, loading: false, userId: null, accessToken: null })
+    const { container } = render(<FeedbackWidget />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the floating Feedback button when user is authenticated', () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+    expect(screen.getByRole('button', { name: /open feedback form/i })).toBeInTheDocument()
+  })
+
+  it('opens the modal when the Feedback button is clicked', async () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    expect(screen.getByRole('heading', { name: /send feedback/i })).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/describe the bug/i)).toBeInTheDocument()
+  })
+
+  it('closes the modal when Cancel is clicked', async () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    expect(screen.getByRole('heading', { name: /send feedback/i })).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.queryByRole('heading', { name: /send feedback/i })).not.toBeInTheDocument()
+  })
+
+  it('disables Submit when description is empty', async () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    expect(screen.getByRole('button', { name: /send feedback/i })).toBeDisabled()
+  })
+
+  it('enables Submit and calls /api/feedback when form is filled', async () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    await userEvent.type(screen.getByPlaceholderText(/describe the bug/i), 'Checkout is broken')
+
+    const submitBtn = screen.getByRole('button', { name: /send feedback/i })
+    expect(submitBtn).not.toBeDisabled()
+
+    await userEvent.click(submitBtn)
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/feedback')
+    expect(opts.method).toBe('POST')
+
+    const body = JSON.parse(opts.body as string) as { description: string }
+    expect(body.description).toBe('Checkout is broken')
+  })
+
+  it('shows success state after successful submission', async () => {
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    await userEvent.type(screen.getByPlaceholderText(/describe the bug/i), 'Something broke')
+    await userEvent.click(screen.getByRole('button', { name: /send feedback/i }))
+
+    expect(await screen.findByText(/feedback sent/i)).toBeInTheDocument()
+  })
+
+  it('shows an error message when the API call fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: 'Unauthorized' }),
+    })
+
+    mockUseUser.mockReturnValue({ role: 'server', loading: false, userId: 'u1', accessToken: 'tok' })
+    render(<FeedbackWidget />)
+
+    await userEvent.click(screen.getByRole('button', { name: /open feedback form/i }))
+    await userEvent.type(screen.getByPlaceholderText(/describe the bug/i), 'Bug report')
+    await userEvent.click(screen.getByRole('button', { name: /send feedback/i }))
+
+    expect(await screen.findByText(/unauthorized/i)).toBeInTheDocument()
+  })
+})

--- a/apps/web/components/FeedbackWidget.tsx
+++ b/apps/web/components/FeedbackWidget.tsx
@@ -1,0 +1,253 @@
+'use client'
+
+import { useState, useRef, useCallback } from 'react'
+import { supabase } from '@/lib/supabase'
+import { useUser } from '@/lib/user-context'
+
+interface UploadedFile {
+  name: string
+  url: string
+}
+
+export default function FeedbackWidget(): React.ReactElement | null {
+  const { role, loading, userId, accessToken } = useUser()
+  const [isOpen, setIsOpen] = useState(false)
+  const [description, setDescription] = useState('')
+  const [files, setFiles] = useState<File[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [submitted, setSubmitted] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleOpen = useCallback(() => {
+    setIsOpen(true)
+    setError(null)
+    setSubmitted(false)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setIsOpen(false)
+    setDescription('')
+    setFiles([])
+    setError(null)
+    setSubmitted(false)
+  }, [])
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      setFiles(Array.from(e.target.files))
+    }
+  }, [])
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!description.trim()) return
+
+    setUploading(true)
+    setError(null)
+
+    try {
+      // Upload screenshots to Supabase Storage
+      const uploadedFiles: UploadedFile[] = []
+      const timestamp = Date.now()
+
+      for (const file of files) {
+        const path = `${userId ?? 'anonymous'}/${timestamp}-${file.name}`
+        const { error: uploadError } = await supabase.storage
+          .from('feedback-screenshots')
+          .upload(path, file, { upsert: false })
+
+        if (uploadError) {
+          throw new Error(`Failed to upload ${file.name}: ${uploadError.message}`)
+        }
+
+        const { data: urlData } = supabase.storage
+          .from('feedback-screenshots')
+          .getPublicUrl(path)
+
+        uploadedFiles.push({ name: file.name, url: urlData.publicUrl })
+      }
+
+      // Get user info from session
+      const { data: { session } } = await supabase.auth.getSession()
+      const userEmail = session?.user?.email ?? 'unknown'
+      const userName = session?.user?.user_metadata?.full_name ?? session?.user?.email ?? 'unknown'
+
+      // Send to API route
+      const response = await fetch('/api/feedback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        },
+        body: JSON.stringify({
+          description: description.trim(),
+          pageUrl: window.location.href,
+          userAgent: navigator.userAgent,
+          userEmail,
+          userName,
+          screenshots: uploadedFiles.map((f) => f.url),
+        }),
+      })
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.error ?? `Request failed with status ${response.status}`)
+      }
+
+      setSubmitted(true)
+      setTimeout(() => {
+        handleClose()
+      }, 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong. Please try again.')
+    } finally {
+      setUploading(false)
+    }
+  }, [description, files, userId, accessToken, handleClose])
+
+  // Don't render until we know the user is authenticated
+  if (loading || !role) return null
+
+  return (
+    <>
+      {/* Floating button */}
+      <button
+        onClick={handleOpen}
+        className="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 transition-colors"
+        aria-label="Open feedback form"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-4 w-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z"
+          />
+        </svg>
+        Feedback
+      </button>
+
+      {/* Modal overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleClose()
+          }}
+        >
+          <div className="w-full max-w-md rounded-xl bg-white shadow-2xl">
+            {/* Header */}
+            <div className="flex items-center justify-between border-b px-5 py-4">
+              <h2 className="text-base font-semibold text-gray-900">Send Feedback</h2>
+              <button
+                onClick={handleClose}
+                className="rounded-md p-1 text-gray-400 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                aria-label="Close"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                </svg>
+              </button>
+            </div>
+
+            {/* Body */}
+            {submitted ? (
+              <div className="flex flex-col items-center justify-center gap-3 py-10 px-5 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+                  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                  </svg>
+                </div>
+                <p className="text-sm font-medium text-gray-900">Feedback sent!</p>
+                <p className="text-xs text-gray-500">Thanks — we&apos;ll look into it.</p>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4 p-5">
+                {/* Description */}
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1" htmlFor="feedback-description">
+                    Description <span className="text-red-500">*</span>
+                  </label>
+                  <textarea
+                    id="feedback-description"
+                    value={description}
+                    onChange={(e) => setDescription(e.target.value)}
+                    placeholder="Describe the bug or suggestion..."
+                    required
+                    rows={5}
+                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
+                  />
+                </div>
+
+                {/* Screenshots */}
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">
+                    Screenshots <span className="text-gray-400">(optional)</span>
+                  </label>
+                  <div
+                    className="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-gray-300 px-4 py-4 text-center hover:border-indigo-400 transition-colors"
+                    onClick={() => fileInputRef.current?.click()}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                    </svg>
+                    {files.length > 0 ? (
+                      <span className="text-xs text-indigo-600 font-medium">{files.length} file{files.length > 1 ? 's' : ''} selected</span>
+                    ) : (
+                      <span className="text-xs text-gray-500">Click to attach images</span>
+                    )}
+                  </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    multiple
+                    className="hidden"
+                    onChange={handleFileChange}
+                  />
+                  {files.length > 0 && (
+                    <ul className="mt-1.5 space-y-0.5">
+                      {files.map((f) => (
+                        <li key={f.name} className="text-xs text-gray-500 truncate">{f.name}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Error */}
+                {error && (
+                  <p className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600">{error}</p>
+                )}
+
+                {/* Actions */}
+                <div className="flex justify-end gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={handleClose}
+                    className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    disabled={uploading || !description.trim()}
+                    className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {uploading ? 'Sending…' : 'Send Feedback'}
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/web/components/FeedbackWidget.tsx
+++ b/apps/web/components/FeedbackWidget.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
 import { useUser } from '@/lib/user-context'
+
+/** Max number of screenshots the user may attach. */
+const MAX_FILES = 5
+/** Max individual file size in bytes (5 MB). */
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
 
 interface UploadedFile {
   name: string
@@ -14,10 +19,34 @@ export default function FeedbackWidget(): React.ReactElement | null {
   const [isOpen, setIsOpen] = useState(false)
   const [description, setDescription] = useState('')
   const [files, setFiles] = useState<File[]>([])
+  const [fileError, setFileError] = useState<string | null>(null)
   const [uploading, setUploading] = useState(false)
   const [submitted, setSubmitted] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clear any pending auto-close timer when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current !== null) {
+        clearTimeout(closeTimerRef.current)
+      }
+    }
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (closeTimerRef.current !== null) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+    setIsOpen(false)
+    setDescription('')
+    setFiles([])
+    setFileError(null)
+    setError(null)
+    setSubmitted(false)
+  }, [])
 
   const handleOpen = useCallback(() => {
     setIsOpen(true)
@@ -25,18 +54,26 @@ export default function FeedbackWidget(): React.ReactElement | null {
     setSubmitted(false)
   }, [])
 
-  const handleClose = useCallback(() => {
-    setIsOpen(false)
-    setDescription('')
-    setFiles([])
-    setError(null)
-    setSubmitted(false)
-  }, [])
-
   const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      setFiles(Array.from(e.target.files))
+    setFileError(null)
+    if (!e.target.files) return
+
+    const selected = Array.from(e.target.files)
+
+    if (selected.length > MAX_FILES) {
+      setFileError(`Maximum ${MAX_FILES} files allowed.`)
+      e.target.value = ''
+      return
     }
+
+    const oversized = selected.filter((f) => f.size > MAX_FILE_SIZE_BYTES)
+    if (oversized.length > 0) {
+      setFileError(`Each file must be under 5 MB (${oversized.map((f) => f.name).join(', ')} exceeded).`)
+      e.target.value = ''
+      return
+    }
+
+    setFiles(selected)
   }, [])
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
@@ -47,7 +84,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
     setError(null)
 
     try {
-      // Upload screenshots to Supabase Storage
+      // Upload screenshots to Supabase Storage using the authenticated user's session.
       const uploadedFiles: UploadedFile[] = []
       const timestamp = Date.now()
 
@@ -68,12 +105,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
         uploadedFiles.push({ name: file.name, url: urlData.publicUrl })
       }
 
-      // Get user info from session
-      const { data: { session } } = await supabase.auth.getSession()
-      const userEmail = session?.user?.email ?? 'unknown'
-      const userName = session?.user?.user_metadata?.full_name ?? session?.user?.email ?? 'unknown'
-
-      // Send to API route
+      // Send to the server-side API route.
+      // userEmail / userName are intentionally NOT sent — the server derives
+      // them from the verified JWT instead.
       const response = await fetch('/api/feedback', {
         method: 'POST',
         headers: {
@@ -84,19 +118,18 @@ export default function FeedbackWidget(): React.ReactElement | null {
           description: description.trim(),
           pageUrl: window.location.href,
           userAgent: navigator.userAgent,
-          userEmail,
-          userName,
           screenshots: uploadedFiles.map((f) => f.url),
         }),
       })
 
       if (!response.ok) {
         const body = await response.json().catch(() => ({}))
-        throw new Error(body.error ?? `Request failed with status ${response.status}`)
+        throw new Error((body as { error?: string }).error ?? `Request failed with status ${response.status}`)
       }
 
       setSubmitted(true)
-      setTimeout(() => {
+      closeTimerRef.current = setTimeout(() => {
+        closeTimerRef.current = null
         handleClose()
       }, 2000)
     } catch (err) {
@@ -106,7 +139,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
     }
   }, [description, files, userId, accessToken, handleClose])
 
-  // Don't render until we know the user is authenticated
+  // Don't render until we know the user is authenticated.
   if (loading || !role) return null
 
   return (
@@ -189,7 +222,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
                 {/* Screenshots */}
                 <div>
                   <label className="block text-xs font-medium text-gray-700 mb-1">
-                    Screenshots <span className="text-gray-400">(optional)</span>
+                    Screenshots <span className="text-gray-400">(optional, max {MAX_FILES} × 5 MB)</span>
                   </label>
                   <div
                     className="flex cursor-pointer flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed border-gray-300 px-4 py-4 text-center hover:border-indigo-400 transition-colors"
@@ -212,10 +245,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
                     className="hidden"
                     onChange={handleFileChange}
                   />
+                  {fileError && (
+                    <p className="mt-1 text-xs text-red-600">{fileError}</p>
+                  )}
                   {files.length > 0 && (
                     <ul className="mt-1.5 space-y-0.5">
-                      {files.map((f) => (
-                        <li key={f.name} className="text-xs text-gray-500 truncate">{f.name}</li>
+                      {files.map((f, i) => (
+                        <li key={`${f.name}-${i}`} className="text-xs text-gray-500 truncate">{f.name}</li>
                       ))}
                     </ul>
                   )}

--- a/apps/web/e2e/feedback-widget.spec.ts
+++ b/apps/web/e2e/feedback-widget.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for the FeedbackWidget.
+ *
+ * These tests run as the authenticated admin user (storageState is set globally
+ * in playwright.config.ts). The Slack webhook call is intercepted at the network
+ * layer so tests work without a real Slack integration.
+ */
+
+test.describe('FeedbackWidget', () => {
+  test.beforeEach(async ({ page }) => {
+    // Intercept the Slack webhook so we don't actually post during CI
+    await page.route('https://hooks.slack.com/**', (route) => {
+      void route.fulfill({ status: 200, body: 'ok' })
+    })
+
+    // Intercept the /api/feedback route to avoid needing the real Slack env var in E2E
+    await page.route('**/api/feedback', (route) => {
+      void route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      })
+    })
+
+    await page.goto('/tables')
+  })
+
+  test('floating Feedback button is visible on authenticated pages', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /open feedback form/i })).toBeVisible()
+  })
+
+  test('clicking Feedback button opens the modal', async ({ page }) => {
+    await page.getByRole('button', { name: /open feedback form/i }).click()
+
+    await expect(page.getByRole('heading', { name: /send feedback/i })).toBeVisible()
+    await expect(page.getByPlaceholder(/describe the bug/i)).toBeVisible()
+  })
+
+  test('Cancel closes the modal', async ({ page }) => {
+    await page.getByRole('button', { name: /open feedback form/i }).click()
+    await expect(page.getByRole('heading', { name: /send feedback/i })).toBeVisible()
+
+    await page.getByRole('button', { name: /cancel/i }).click()
+    await expect(page.getByRole('heading', { name: /send feedback/i })).not.toBeVisible()
+  })
+
+  test('Submit is disabled when description is empty', async ({ page }) => {
+    await page.getByRole('button', { name: /open feedback form/i }).click()
+    await expect(page.getByRole('button', { name: /send feedback/i })).toBeDisabled()
+  })
+
+  test('happy path — fills form, submits, shows success state', async ({ page }) => {
+    await page.getByRole('button', { name: /open feedback form/i }).click()
+
+    await page.getByPlaceholder(/describe the bug/i).fill('The checkout button is unresponsive on tablet.')
+
+    const submitBtn = page.getByRole('button', { name: /send feedback/i })
+    await expect(submitBtn).not.toBeDisabled()
+    await submitBtn.click()
+
+    // Success state should appear
+    await expect(page.getByText(/feedback sent/i)).toBeVisible({ timeout: 5000 })
+  })
+
+  test('feedback button is visible on the /admin route too', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page.getByRole('button', { name: /open feedback form/i })).toBeVisible()
+  })
+})

--- a/apps/web/lib/logger.ts
+++ b/apps/web/lib/logger.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimal structured logger for server-side Next.js code.
+ * Outputs JSON lines so log aggregators (Vercel, Datadog, etc.) can parse
+ * them without additional configuration.
+ *
+ * Usage:
+ *   import { logger } from '@/lib/logger'
+ *   logger.error('feedback', 'Slack webhook failed', { status: 400 })
+ */
+
+type LogLevel = 'info' | 'warn' | 'error'
+
+function log(level: LogLevel, ns: string, msg: string, meta?: Record<string, unknown>): void {
+  const entry = JSON.stringify({
+    level,
+    ns,
+    msg,
+    ts: new Date().toISOString(),
+    ...(meta ?? {}),
+  })
+
+  if (level === 'error') {
+    process.stderr.write(entry + '\n')
+  } else {
+    process.stdout.write(entry + '\n')
+  }
+}
+
+export const logger = {
+  info: (ns: string, msg: string, meta?: Record<string, unknown>): void =>
+    log('info', ns, msg, meta),
+  warn: (ns: string, msg: string, meta?: Record<string, unknown>): void =>
+    log('warn', ns, msg, meta),
+  error: (ns: string, msg: string, meta?: Record<string, unknown>): void =>
+    log('error', ns, msg, meta),
+}

--- a/apps/web/lib/supabase-admin.ts
+++ b/apps/web/lib/supabase-admin.ts
@@ -1,0 +1,23 @@
+/**
+ * Supabase admin client (service-role key).
+ *
+ * This client bypasses Row Level Security and must ONLY be used in server-side
+ * code (API routes, edge functions, server actions). Never import this from
+ * any client-side component.
+ *
+ * Follows the same "single shared client" pattern as @/lib/supabase, but for
+ * server-side operations that require elevated privileges.
+ */
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+let _client: SupabaseClient | null = null
+
+export function getSupabaseAdmin(): SupabaseClient {
+  if (_client) return _client
+  _client = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } }
+  )
+  return _client
+}


### PR DESCRIPTION
Closes #442

## What this adds

A floating **Feedback** button visible to all logged-in users throughout the POS app. Clicking it opens a modal with a simple form. On submit, the feedback is forwarded to a Slack channel via a server-side Next.js API route.

## Changes

### `apps/web/components/FeedbackWidget.tsx` (new)
- Floating button fixed to bottom-right, only rendered when `useUser()` returns a non-null role (i.e. authenticated)
- Modal with:
  - Free-text description textarea (required)
  - Image file upload (multiple, optional) — uploads to Supabase Storage bucket `feedback-screenshots` using the authenticated user's session, then passes public URLs to the API
  - Success/error states, loading indicator
- Auto-captures: current page URL, user email + name from Supabase session, user agent

### `apps/web/app/api/feedback/route.ts` (new)
- `POST /api/feedback` — server-side only
- Validates description, formats a rich Slack message, and POSTs to `SLACK_FEEDBACK_WEBHOOK`
- Returns 503 if env var is missing, 400 for bad input, 502 on Slack error

### `apps/web/app/layout.tsx`
- Imports and mounts `<FeedbackWidget />` inside `<UserProvider>` so it has auth context

### `apps/web/.env.example`
- Documents `SLACK_FEEDBACK_WEBHOOK` (server-side only, no `NEXT_PUBLIC_` prefix)

### Supabase Storage
- Bucket `feedback-screenshots` created (public read) via Storage API

## Env var setup

| Variable | Where |
|---|---|
| `SLACK_FEEDBACK_WEBHOOK` | Already added to Vercel (all environments) by Lidia. For local dev: add to `.env.local` |

## Slack message format

```
🐛 New Feedback from <name> (<email>)

📝 *Description:*
<text>

📍 *Page:* <url>
🕐 *Time:* <iso timestamp>
🖥️ *User Agent:* <ua>

📸 *Screenshots:*
• <url1>
• <url2>
```
