### PR TITLE
fix: feedback API route — use SUPABASE_SECRET_KEY instead of service role key

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,7 +1,7 @@
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
-# Server-side service role key (bypasses RLS — never expose to client)
-SUPABASE_SERVICE_ROLE_KEY=
+# Server-side secret key (bypasses RLS — never expose to client)
+SUPABASE_SECRET_KEY=
 
 # Slack webhook for the feedback widget (server-side only — never add NEXT_PUBLIC_ prefix)
 SLACK_FEEDBACK_WEBHOOK=

--- a/apps/web/app/api/feedback/route.test.ts
+++ b/apps/web/app/api/feedback/route.test.ts
@@ -47,7 +47,7 @@ describe('POST /api/feedback', () => {
 
     vi.stubEnv('SLACK_FEEDBACK_WEBHOOK', WEBHOOK_URL)
     vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
-    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'fake-service-role-key')
+    vi.stubEnv('SUPABASE_SECRET_KEY', 'fake-secret-key')
 
     mockGetUser.mockResolvedValue({ data: { user: AUTHENTICATED_USER }, error: null })
 

--- a/apps/web/lib/supabase-admin.ts
+++ b/apps/web/lib/supabase-admin.ts
@@ -17,9 +17,11 @@ let _client: SupabaseClient | null = null
 
 export function getSupabaseAdmin(): SupabaseClient {
   if (_client) return _client
+  const secret = process.env.SUPABASE_SECRET_KEY
+  if (!secret) throw new Error('SUPABASE_SECRET_KEY is not set')
   _client = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SECRET_KEY!,
+    secret,
     { auth: { persistSession: false } }
   )
   return _client

--- a/apps/web/lib/supabase-admin.ts
+++ b/apps/web/lib/supabase-admin.ts
@@ -1,9 +1,12 @@
 /**
- * Supabase admin client (service-role key).
+ * Supabase admin client (secret key).
  *
  * This client bypasses Row Level Security and must ONLY be used in server-side
  * code (API routes, edge functions, server actions). Never import this from
  * any client-side component.
+ *
+ * Uses the new Supabase key format: SUPABASE_SECRET_KEY (replaces the legacy
+ * SUPABASE_SERVICE_ROLE_KEY).
  *
  * Follows the same "single shared client" pattern as @/lib/supabase, but for
  * server-side operations that require elevated privileges.
@@ -16,7 +19,7 @@ export function getSupabaseAdmin(): SupabaseClient {
   if (_client) return _client
   _client = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    process.env.SUPABASE_SECRET_KEY!,
     { auth: { persistSession: false } }
   )
   return _client

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -61,7 +61,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
   if (user !== null && pathname.startsWith('/admin')) {
     // Use the user's own session client — RLS on the users table ensures
     // each authenticated user can only read their own row, so no service
-    // role key is needed and Vercel does not require SUPABASE_SERVICE_ROLE_KEY.
+    // role key is needed and Vercel does not require SUPABASE_SECRET_KEY.
     // Fetch role and super-admin flag.  The is_super_admin column was added in
     // migration 20260327110000; if it doesn't exist yet (e.g. a migration hasn't
     // been applied) we fall back to a role-only query so that regular admin


### PR DESCRIPTION
## Summary

The feedback API route's `supabase-admin.ts` helper was using the legacy `SUPABASE_SERVICE_ROLE_KEY` environment variable. This project has migrated to the new Supabase key format:

- **Server-side (elevated):** `SUPABASE_SECRET_KEY`
- **Client-side:** `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`

## Changes

- `apps/web/lib/supabase-admin.ts` — updated `getSupabaseAdmin()` to read `SUPABASE_SECRET_KEY` instead of `SUPABASE_SERVICE_ROLE_KEY`
- `apps/web/app/api/feedback/route.test.ts` — updated `vi.stubEnv` to use `SUPABASE_SECRET_KEY`
- `apps/web/.env.example` — renamed variable and updated comment

## Testing

All 11 feedback route unit tests pass ✅

No new lint errors introduced (pre-existing errors are in unrelated files).