### PR TITLE
fix: add RLS policies for feedback-screenshots storage bucket

### DIFF
--- a/supabase/migrations/20260422093002_feedback_screenshots_storage_policies.sql
+++ b/supabase/migrations/20260422093002_feedback_screenshots_storage_policies.sql
@@ -1,8 +1,28 @@
--- Add RLS policies for feedback-screenshots storage bucket
--- These policies were applied directly to production on 2026-04-22 (bucket created in PR #443).
--- This migration tracks them in the repo so they are part of the migration history.
--- Uses DO blocks to avoid errors if policies already exist (idempotent).
+-- HUMAN REVIEW REQUIRED
+-- Adds the feedback-screenshots storage bucket and its 3 RLS policies.
+-- The bucket and policies were applied directly to production on 2026-04-22
+-- (bucket created in PR #443, policies added by Stark as a hotfix).
+-- This migration tracks them in the repo so schema history is complete.
+-- Idempotent: bucket uses ON CONFLICT DO NOTHING; policies use pg_policies checks.
+--
+-- Security notes (intentional, matches production):
+--   - SELECT is TO public: screenshots must be readable by unauthenticated clients
+--     for the feedback widget to display uploaded images.
+--   - DELETE is TO authenticated (any authenticated user): this is intentional for
+--     the MVP; tighter scoping (by owner/role) can be added in a follow-up.
 
+-- Rollback:
+-- DROP POLICY "feedback_screenshots_delete_authenticated" ON storage.objects;
+-- DROP POLICY "feedback_screenshots_select_public" ON storage.objects;
+-- DROP POLICY "feedback_screenshots_insert_authenticated" ON storage.objects;
+-- DELETE FROM storage.buckets WHERE id = 'feedback-screenshots';
+
+-- Ensure the bucket exists (idempotent)
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('feedback-screenshots', 'feedback-screenshots', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- INSERT policy: authenticated users can upload screenshots
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -18,6 +38,8 @@ BEGIN
   END IF;
 END $$;
 
+-- SELECT policy: public (unauthenticated) read access intentional — required for
+-- the feedback widget to render uploaded screenshots without auth context.
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -33,6 +55,7 @@ BEGIN
   END IF;
 END $$;
 
+-- DELETE policy: any authenticated user can delete — intentional for MVP.
 DO $$
 BEGIN
   IF NOT EXISTS (

--- a/supabase/migrations/20260422093002_feedback_screenshots_storage_policies.sql
+++ b/supabase/migrations/20260422093002_feedback_screenshots_storage_policies.sql
@@ -1,0 +1,49 @@
+-- Add RLS policies for feedback-screenshots storage bucket
+-- These policies were applied directly to production on 2026-04-22 (bucket created in PR #443).
+-- This migration tracks them in the repo so they are part of the migration history.
+-- Uses DO blocks to avoid errors if policies already exist (idempotent).
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'feedback_screenshots_insert_authenticated'
+  ) THEN
+    CREATE POLICY "feedback_screenshots_insert_authenticated"
+      ON storage.objects FOR INSERT
+      TO authenticated
+      WITH CHECK (bucket_id = 'feedback-screenshots');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'feedback_screenshots_select_public'
+  ) THEN
+    CREATE POLICY "feedback_screenshots_select_public"
+      ON storage.objects FOR SELECT
+      TO public
+      USING (bucket_id = 'feedback-screenshots');
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'storage'
+      AND tablename = 'objects'
+      AND policyname = 'feedback_screenshots_delete_authenticated'
+  ) THEN
+    CREATE POLICY "feedback_screenshots_delete_authenticated"
+      ON storage.objects FOR DELETE
+      TO authenticated
+      USING (bucket_id = 'feedback-screenshots');
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

The `feedback-screenshots` Supabase Storage bucket was created in PR #443 but the RLS policies were missing. They were applied directly to production on 2026-04-22.

This PR adds a migration file to track them in the repo so the schema history is complete.

## Migration

File: `supabase/migrations/20260422093002_feedback_screenshots_storage_policies.sql`

The migration is **idempotent** — it uses `DO $$ BEGIN IF NOT EXISTS ... END $$` blocks so running it against the production database (where policies already exist) won't fail.

## Policies added

| Policy name | Operation | Role |
|---|---|---|
| `feedback_screenshots_insert_authenticated` | INSERT | authenticated |
| `feedback_screenshots_select_public` | SELECT | public |
| `feedback_screenshots_delete_authenticated` | DELETE | authenticated |

## Lint note

The 4 lint errors reported are pre-existing in the codebase and unrelated to this PR (no JS/TS files changed — only a SQL migration file).