### PR TITLE
feat: voice recording + Whisper transcription in feedback widget

### DIFF
--- a/apps/web/app/api/feedback/transcribe/route.test.ts
+++ b/apps/web/app/api/feedback/transcribe/route.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// ── Mock @supabase/ssr createServerClient ─────────────────────────────────────
+const mockGetUser = vi.fn()
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn().mockReturnValue({
+    auth: { getUser: (...args: unknown[]) => mockGetUser(...args) },
+  }),
+}))
+
+// ── Mock @/lib/logger (suppress output in tests) ──────────────────────────────
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+const SUPABASE_URL = 'https://dmaogdwtgohrhbytxjqu.supabase.co'
+const AUTHENTICATED_USER = {
+  id: 'u1',
+  email: 'test@example.com',
+  user_metadata: { full_name: 'Test User' },
+}
+
+/** A minimal valid audio blob for test purposes. */
+const DUMMY_AUDIO = new Blob(['fake-audio-data'], { type: 'audio/webm;codecs=opus' })
+
+/**
+ * Build a NextRequest with a mocked formData() method.
+ *
+ * Node.js / Vitest do not support multipart/form-data serialisation through
+ * the `Request` constructor, so we stub `formData()` directly on the request
+ * instance to return a real `FormData` object. This is the standard approach
+ * for unit-testing Next.js API routes that call `request.formData()`.
+ */
+function makeFormRequest(
+  audioBlob: Blob | null,
+  language: string | null,
+  token?: string,
+  /** If true, make formData() throw (simulates a bad body). */
+  throwOnParse = false
+): NextRequest {
+  const req = new NextRequest('http://localhost/api/feedback/transcribe', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'multipart/form-data; boundary=test-boundary',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    // We never actually read this body — formData() is mocked below.
+    body: 'placeholder',
+  })
+
+  if (throwOnParse) {
+    req.formData = vi.fn().mockRejectedValue(new Error('Failed to parse body'))
+  } else {
+    const form = new FormData()
+    if (audioBlob !== null) form.append('audio', audioBlob, 'recording.webm')
+    if (language !== null) form.append('language', language)
+    req.formData = vi.fn().mockResolvedValue(form)
+  }
+
+  return req
+}
+
+describe('POST /api/feedback/transcribe', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.resetModules()
+
+    vi.stubEnv('OPENAI_API_KEY', 'sk-test-key')
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', SUPABASE_URL)
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', 'fake-publishable-key')
+
+    mockGetUser.mockResolvedValue({ data: { user: AUTHENTICATED_USER }, error: null })
+
+    mockFetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ text: 'Hello world' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', mockFetch)
+  })
+
+  // ── Configuration guards ───────────────────────────────────────────────────
+
+  it('returns 503 when OPENAI_API_KEY is not set', async () => {
+    vi.stubEnv('OPENAI_API_KEY', '')
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/not configured/i)
+  })
+
+  it('returns 503 when NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY is not set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY', '')
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/not configured/i)
+  })
+
+  // ── Auth guards ────────────────────────────────────────────────────────────
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en') // no token
+    const res = await POST(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 401 when token is invalid', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('Invalid JWT') })
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'bad-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(401)
+  })
+
+  // ── Body parse error ───────────────────────────────────────────────────────
+
+  it('returns 400 when formData() throws', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(null, null, 'valid-token', /* throwOnParse */ true)
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/multipart/i)
+  })
+
+  // ── Validation ─────────────────────────────────────────────────────────────
+
+  it('returns 400 when audio field is missing', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(null, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/audio/i)
+  })
+
+  it('returns 400 when language is missing', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, null, 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/language/i)
+  })
+
+  it('returns 400 when language is unsupported', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'fr', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/language/i)
+  })
+
+  it('returns 400 when audio exceeds 25 MB', async () => {
+    // Create a blob slightly over the 25MB limit
+    const bigBlob = new Blob([new Uint8Array(25 * 1024 * 1024 + 1)], { type: 'audio/webm' })
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(bigBlob, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/too large/i)
+  })
+
+  // ── Whisper calls ──────────────────────────────────────────────────────────
+
+  it('calls /v1/audio/transcriptions for English and returns text', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+    const json = await res.json() as { text: string }
+    expect(json.text).toBe('Hello world')
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url] = mockFetch.mock.calls[0] as [string]
+    expect(url).toBe('https://api.openai.com/v1/audio/transcriptions')
+  })
+
+  it('calls /v1/audio/translations for Bangla', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'bn', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(200)
+
+    expect(mockFetch).toHaveBeenCalledOnce()
+    const [url] = mockFetch.mock.calls[0] as [string]
+    expect(url).toBe('https://api.openai.com/v1/audio/translations')
+  })
+
+  it('sends model=whisper-1 in the Whisper request', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    await POST(req)
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const bodyForm = opts.body as FormData
+    expect(bodyForm.get('model')).toBe('whisper-1')
+  })
+
+  it('sends language=en for English transcription', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    await POST(req)
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const bodyForm = opts.body as FormData
+    expect(bodyForm.get('language')).toBe('en')
+  })
+
+  it('does NOT send language field for Bangla translation', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'bn', 'valid-token')
+    await POST(req)
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const bodyForm = opts.body as FormData
+    // /v1/audio/translations doesn't use the `language` parameter
+    expect(bodyForm.get('language')).toBeNull()
+  })
+
+  it('sends Bearer OPENAI_API_KEY in Authorization header', async () => {
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    await POST(req)
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit]
+    const headers = opts.headers as Record<string, string>
+    expect(headers['Authorization']).toBe('Bearer sk-test-key')
+  })
+
+  // ── Error paths ────────────────────────────────────────────────────────────
+
+  it('returns 502 when OpenAI fetch throws a network error', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'))
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(502)
+  })
+
+  it('returns 502 when Whisper responds with non-2xx status', async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: 'Invalid file format' } }), { status: 400 })
+    )
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(502)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/transcription failed/i)
+  })
+})

--- a/apps/web/app/api/feedback/transcribe/route.test.ts
+++ b/apps/web/app/api/feedback/transcribe/route.test.ts
@@ -113,6 +113,18 @@ describe('POST /api/feedback/transcribe', () => {
     expect(json.error).toMatch(/not configured/i)
   })
 
+  it('returns 503 when NEXT_PUBLIC_SUPABASE_URL is not set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_SUPABASE_URL', '')
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(503)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/not configured/i)
+  })
+
   // ── Auth guards ────────────────────────────────────────────────────────────
 
   it('returns 401 when Authorization header is missing', async () => {
@@ -155,6 +167,30 @@ describe('POST /api/feedback/transcribe', () => {
     expect(res.status).toBe(400)
     const json = await res.json() as { error: string }
     expect(json.error).toMatch(/audio/i)
+  })
+
+  it('returns 400 when audio file is empty (0 bytes)', async () => {
+    const emptyBlob = new Blob([], { type: 'audio/webm' })
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(emptyBlob, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/empty/i)
+  })
+
+  it('returns 400 when audio MIME type is not audio', async () => {
+    const pdfBlob = new Blob(['%PDF-1.4'], { type: 'application/pdf' })
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(pdfBlob, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(400)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/unsupported/i)
   })
 
   it('returns 400 when language is missing', async () => {
@@ -274,6 +310,21 @@ describe('POST /api/feedback/transcribe', () => {
   it('returns 502 when Whisper responds with non-2xx status', async () => {
     mockFetch.mockResolvedValue(
       new Response(JSON.stringify({ error: { message: 'Invalid file format' } }), { status: 400 })
+    )
+
+    const { POST } = await import('./route')
+    const req = makeFormRequest(DUMMY_AUDIO, 'en', 'valid-token')
+    const res = await POST(req)
+
+    expect(res.status).toBe(502)
+    const json = await res.json() as { error: string }
+    expect(json.error).toMatch(/transcription failed/i)
+  })
+
+  it('returns 502 when Whisper responds with non-JSON body', async () => {
+    // Whisper 2xx but body is not valid JSON
+    mockFetch.mockResolvedValue(
+      new Response('not json', { status: 200, headers: { 'Content-Type': 'text/plain' } })
     )
 
     const { POST } = await import('./route')

--- a/apps/web/app/api/feedback/transcribe/route.ts
+++ b/apps/web/app/api/feedback/transcribe/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerClient } from '@supabase/ssr'
+import { logger } from '@/lib/logger'
+
+/** Maximum audio file size accepted (25 MB — Whisper API hard limit). */
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024
+
+/** Supported language codes. */
+const SUPPORTED_LANGUAGES = ['en', 'bn'] as const
+type Language = (typeof SUPPORTED_LANGUAGES)[number]
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    // ── Guard: OPENAI_API_KEY must be present ─────────────────────────────────
+    const openAiKey = process.env.OPENAI_API_KEY
+    if (!openAiKey) {
+      logger.error('feedback/transcribe', 'OPENAI_API_KEY is not set')
+      return NextResponse.json({ error: 'Transcription service is not configured' }, { status: 503 })
+    }
+
+    // ── Guard: Supabase env vars must be present ───────────────────────────────
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY) {
+      logger.error('feedback/transcribe', 'Supabase env vars are not set')
+      return NextResponse.json({ error: 'Transcription service is not configured' }, { status: 503 })
+    }
+
+    // ── Auth: validate the bearer token via publishable-key client ────────────
+    const authHeader = request.headers.get('Authorization')
+    const token = authHeader?.replace(/^Bearer\s+/i, '').trim()
+
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const supabaseAuth = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY,
+      { cookies: { getAll: () => [], setAll: () => {} } }
+    )
+
+    const { data: { user }, error: authError } = await supabaseAuth.auth.getUser(token)
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // ── Parse multipart/form-data ─────────────────────────────────────────────
+    let formData: FormData
+    try {
+      formData = await request.formData()
+    } catch {
+      return NextResponse.json({ error: 'Invalid multipart/form-data body' }, { status: 400 })
+    }
+
+    const audioFile = formData.get('audio')
+    const language = formData.get('language')
+
+    // Validate audio field
+    if (!audioFile || !(audioFile instanceof Blob)) {
+      return NextResponse.json({ error: 'audio field is required and must be a file' }, { status: 400 })
+    }
+
+    // Validate file size
+    if (audioFile.size > MAX_AUDIO_BYTES) {
+      return NextResponse.json(
+        { error: `Audio file too large. Maximum size is ${MAX_AUDIO_BYTES / (1024 * 1024)} MB.` },
+        { status: 400 }
+      )
+    }
+
+    // Validate language field
+    if (typeof language !== 'string' || !(SUPPORTED_LANGUAGES as readonly string[]).includes(language)) {
+      return NextResponse.json(
+        { error: `language must be one of: ${SUPPORTED_LANGUAGES.join(', ')}` },
+        { status: 400 }
+      )
+    }
+
+    const lang = language as Language
+
+    // ── Call OpenAI Whisper ───────────────────────────────────────────────────
+    // English  → /v1/audio/transcriptions (preserves original language)
+    // Bangla   → /v1/audio/translations   (transcribes + translates to English)
+    const endpoint =
+      lang === 'bn'
+        ? 'https://api.openai.com/v1/audio/translations'
+        : 'https://api.openai.com/v1/audio/transcriptions'
+
+    const whisperForm = new FormData()
+
+    // Determine MIME type from the Blob; fall back to webm/opus (most common browser output)
+    const mimeType = audioFile.type || 'audio/webm;codecs=opus'
+    // Derive a file extension from MIME; Whisper accepts webm, mp4, ogg, wav, etc.
+    const ext = mimeType.startsWith('audio/ogg') ? 'ogg' : 'webm'
+    // Pass the audio file directly to avoid an unnecessary arrayBuffer() round-trip.
+    // Use the original File name if available, otherwise derive from MIME type.
+    const fileName = audioFile instanceof File && audioFile.name ? audioFile.name : `recording.${ext}`
+    whisperForm.append('file', audioFile, fileName)
+    whisperForm.append('model', 'whisper-1')
+    if (lang === 'en') {
+      whisperForm.append('language', 'en')
+    }
+
+    let whisperResponse: Response
+    try {
+      whisperResponse = await fetch(endpoint, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${openAiKey}` },
+        body: whisperForm,
+      })
+    } catch (err) {
+      logger.error('feedback/transcribe', 'OpenAI Whisper fetch threw', { err: String(err) })
+      return NextResponse.json({ error: 'Failed to reach transcription service' }, { status: 502 })
+    }
+
+    if (!whisperResponse.ok) {
+      const body = await whisperResponse.text()
+      logger.error('feedback/transcribe', 'Whisper returned non-2xx', {
+        status: whisperResponse.status,
+        body,
+      })
+      return NextResponse.json(
+        { error: 'Transcription failed' },
+        { status: 502 }
+      )
+    }
+
+    const whisperJson = await whisperResponse.json() as { text?: string }
+    const text = whisperJson.text ?? ''
+
+    return NextResponse.json({ text })
+  } catch (err) {
+    logger.error('feedback/transcribe', 'Unhandled error in POST /api/feedback/transcribe', { err: String(err) })
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/apps/web/app/api/feedback/transcribe/route.ts
+++ b/apps/web/app/api/feedback/transcribe/route.ts
@@ -9,6 +9,13 @@ const MAX_AUDIO_BYTES = 25 * 1024 * 1024
 const SUPPORTED_LANGUAGES = ['en', 'bn'] as const
 type Language = (typeof SUPPORTED_LANGUAGES)[number]
 
+/**
+ * MIME type prefixes accepted by Whisper. We fail-fast on obviously wrong types
+ * (e.g. images, PDFs) to avoid a round-trip to the OpenAI API.
+ * Whisper supports: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, webm.
+ */
+const ALLOWED_AUDIO_MIME_PREFIXES = ['audio/', 'video/webm', 'video/mp4'] as const
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     // ── Guard: OPENAI_API_KEY must be present ─────────────────────────────────
@@ -57,6 +64,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Validate audio field
     if (!audioFile || !(audioFile instanceof Blob)) {
       return NextResponse.json({ error: 'audio field is required and must be a file' }, { status: 400 })
+    }
+
+    // Validate file is not empty
+    if (audioFile.size === 0) {
+      return NextResponse.json({ error: 'Audio file is empty' }, { status: 400 })
+    }
+
+    // Validate MIME type (fail-fast before calling Whisper API)
+    const audioMime = audioFile.type || ''
+    if (audioMime && !ALLOWED_AUDIO_MIME_PREFIXES.some((p) => audioMime.startsWith(p))) {
+      return NextResponse.json({ error: 'Unsupported audio format' }, { status: 400 })
     }
 
     // Validate file size
@@ -124,7 +142,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       )
     }
 
-    const whisperJson = await whisperResponse.json() as { text?: string }
+    let whisperJson: { text?: string }
+    try {
+      whisperJson = await whisperResponse.json() as { text?: string }
+    } catch (err) {
+      logger.error('feedback/transcribe', 'Whisper returned non-JSON body', { err: String(err) })
+      return NextResponse.json({ error: 'Transcription failed' }, { status: 502 })
+    }
     const text = whisperJson.text ?? ''
 
     return NextResponse.json({ text })

--- a/apps/web/components/FeedbackWidget.tsx
+++ b/apps/web/components/FeedbackWidget.tsx
@@ -376,13 +376,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
 
                   {/* Voice recording toolbar */}
                   <div className="mt-1.5 flex items-center gap-2">
-                    {/* Language toggle — min-h-[44px] / min-w touch targets for mobile */}
+                    {/* Language toggle — min-h-[48px] touch targets per project standard (CLAUDE.md) */}
                     <div className="flex rounded-lg border border-gray-200 overflow-hidden text-xs">
                       <button
                         type="button"
                         onClick={() => setVoiceLang('en')}
                         disabled={isRecording || isTranscribing}
-                        className={`min-h-[44px] px-3 py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                        className={`min-h-[48px] px-3 py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                           voiceLang === 'en'
                             ? 'bg-indigo-600 text-white'
                             : 'bg-white text-gray-600 hover:bg-gray-50'
@@ -396,7 +396,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
                         type="button"
                         onClick={() => setVoiceLang('bn')}
                         disabled={isRecording || isTranscribing}
-                        className={`min-h-[44px] px-3 py-2 transition-colors border-l border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                        className={`min-h-[48px] px-3 py-2 transition-colors border-l border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed ${
                           voiceLang === 'bn'
                             ? 'bg-indigo-600 text-white'
                             : 'bg-white text-gray-600 hover:bg-gray-50'
@@ -408,13 +408,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
                       </button>
                     </div>
 
-                    {/* Mic button — min-h-[44px] touch target for mobile */}
+                    {/* Mic button — min-h-[48px] touch target per project standard (CLAUDE.md) */}
                     <button
                       type="button"
                       onClick={handleMicClick}
                       disabled={isTranscribing}
                       aria-label={isRecording ? 'Stop recording' : 'Start voice recording'}
-                      className={`flex items-center gap-1.5 rounded-lg px-3 min-h-[44px] text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+                      className={`flex items-center gap-1.5 rounded-lg px-3 min-h-[48px] text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed ${
                         isRecording
                           ? 'bg-red-600 text-white hover:bg-red-700'
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'

--- a/apps/web/components/FeedbackWidget.tsx
+++ b/apps/web/components/FeedbackWidget.tsx
@@ -14,6 +14,8 @@ interface UploadedFile {
   url: string
 }
 
+type VoiceLanguage = 'en' | 'bn'
+
 export default function FeedbackWidget(): React.ReactElement | null {
   const { role, loading, userId, accessToken } = useUser()
   const [isOpen, setIsOpen] = useState(false)
@@ -26,16 +28,33 @@ export default function FeedbackWidget(): React.ReactElement | null {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  // Clear any pending auto-close timer when the component unmounts.
+  // ── Voice recording state ──────────────────────────────────────────────────
+  const [voiceLang, setVoiceLang] = useState<VoiceLanguage>('en')
+  const [isRecording, setIsRecording] = useState(false)
+  const [isTranscribing, setIsTranscribing] = useState(false)
+  const [voiceError, setVoiceError] = useState<string | null>(null)
+  const [recordingSeconds, setRecordingSeconds] = useState(0)
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null)
+  const audioChunksRef = useRef<Blob[]>([])
+  const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Clear any pending timers when the component unmounts.
   useEffect(() => {
     return () => {
-      if (closeTimerRef.current !== null) {
-        clearTimeout(closeTimerRef.current)
-      }
+      if (closeTimerRef.current !== null) clearTimeout(closeTimerRef.current)
+      if (recordingTimerRef.current !== null) clearInterval(recordingTimerRef.current)
     }
   }, [])
 
   const handleClose = useCallback(() => {
+    // Stop recording if active
+    if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+      mediaRecorderRef.current.stop()
+    }
+    if (recordingTimerRef.current !== null) {
+      clearInterval(recordingTimerRef.current)
+      recordingTimerRef.current = null
+    }
     if (closeTimerRef.current !== null) {
       clearTimeout(closeTimerRef.current)
       closeTimerRef.current = null
@@ -46,6 +65,11 @@ export default function FeedbackWidget(): React.ReactElement | null {
     setFileError(null)
     setError(null)
     setSubmitted(false)
+    setIsRecording(false)
+    setIsTranscribing(false)
+    setVoiceError(null)
+    setRecordingSeconds(0)
+    audioChunksRef.current = []
   }, [])
 
   const handleOpen = useCallback(() => {
@@ -75,6 +99,119 @@ export default function FeedbackWidget(): React.ReactElement | null {
 
     setFiles(selected)
   }, [])
+
+  // ── Voice recording logic ──────────────────────────────────────────────────
+
+  const startRecording = useCallback(async () => {
+    setVoiceError(null)
+    audioChunksRef.current = []
+
+    let stream: MediaStream
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+    } catch {
+      setVoiceError('Microphone access denied. Please allow microphone access and try again.')
+      return
+    }
+
+    const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? 'audio/webm;codecs=opus'
+      : MediaRecorder.isTypeSupported('audio/ogg;codecs=opus')
+        ? 'audio/ogg;codecs=opus'
+        : ''
+
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
+    mediaRecorderRef.current = recorder
+
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) audioChunksRef.current.push(e.data)
+    }
+
+    recorder.start(100) // collect chunks every 100ms
+    setIsRecording(true)
+    setRecordingSeconds(0)
+
+    recordingTimerRef.current = setInterval(() => {
+      setRecordingSeconds((s) => s + 1)
+    }, 1000)
+  }, [])
+
+  const stopRecordingAndTranscribe = useCallback(() => {
+    const recorder = mediaRecorderRef.current
+    if (!recorder || recorder.state === 'inactive') return
+
+    // Stop the timer
+    if (recordingTimerRef.current !== null) {
+      clearInterval(recordingTimerRef.current)
+      recordingTimerRef.current = null
+    }
+
+    recorder.onstop = async () => {
+      // Stop all tracks to release the microphone
+      recorder.stream.getTracks().forEach((t) => t.stop())
+
+      setIsRecording(false)
+      setIsTranscribing(true)
+      setVoiceError(null)
+
+      const mimeType = recorder.mimeType || 'audio/webm;codecs=opus'
+      const audioBlob = new Blob(audioChunksRef.current, { type: mimeType })
+      audioChunksRef.current = []
+
+      const formData = new FormData()
+      formData.append('audio', audioBlob, 'recording.webm')
+      formData.append('language', voiceLang)
+
+      try {
+        const response = await fetch('/api/feedback/transcribe', {
+          method: 'POST',
+          headers: {
+            ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+          },
+          body: formData,
+        })
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}))
+          throw new Error(
+            (body as { error?: string }).error ?? `Transcription failed (${response.status})`
+          )
+        }
+
+        const { text } = await response.json() as { text: string }
+
+        if (text.trim()) {
+          setDescription((prev) => {
+            const trimmed = prev.trim()
+            return trimmed ? `${trimmed}\n${text.trim()}` : text.trim()
+          })
+        }
+      } catch (err) {
+        setVoiceError(
+          err instanceof Error ? err.message : 'Transcription failed. Please try again.'
+        )
+      } finally {
+        setIsTranscribing(false)
+        setRecordingSeconds(0)
+      }
+    }
+
+    recorder.stop()
+  }, [voiceLang, accessToken])
+
+  const handleMicClick = useCallback(() => {
+    if (isRecording) {
+      stopRecordingAndTranscribe()
+    } else {
+      void startRecording()
+    }
+  }, [isRecording, startRecording, stopRecordingAndTranscribe])
+
+  const formatDuration = (seconds: number): string => {
+    const m = Math.floor(seconds / 60).toString().padStart(2, '0')
+    const s = (seconds % 60).toString().padStart(2, '0')
+    return `${m}:${s}`
+  }
 
   const handleSubmit = useCallback(async (e: React.FormEvent) => {
     e.preventDefault()
@@ -208,6 +345,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
                   <label className="block text-xs font-medium text-gray-700 mb-1" htmlFor="feedback-description">
                     Description <span className="text-red-500">*</span>
                   </label>
+
                   <textarea
                     id="feedback-description"
                     value={description}
@@ -217,6 +355,81 @@ export default function FeedbackWidget(): React.ReactElement | null {
                     rows={5}
                     className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 resize-none"
                   />
+
+                  {/* Voice recording toolbar */}
+                  <div className="mt-1.5 flex items-center gap-2">
+                    {/* Language toggle */}
+                    <div className="flex rounded-lg border border-gray-200 overflow-hidden text-xs">
+                      <button
+                        type="button"
+                        onClick={() => setVoiceLang('en')}
+                        disabled={isRecording || isTranscribing}
+                        className={`px-2.5 py-1 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                          voiceLang === 'en'
+                            ? 'bg-indigo-600 text-white'
+                            : 'bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                        aria-pressed={voiceLang === 'en'}
+                        aria-label="Record in English"
+                      >
+                        English
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setVoiceLang('bn')}
+                        disabled={isRecording || isTranscribing}
+                        className={`px-2.5 py-1 transition-colors border-l border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                          voiceLang === 'bn'
+                            ? 'bg-indigo-600 text-white'
+                            : 'bg-white text-gray-600 hover:bg-gray-50'
+                        }`}
+                        aria-pressed={voiceLang === 'bn'}
+                        aria-label="Record in Bangla"
+                      >
+                        বাংলা
+                      </button>
+                    </div>
+
+                    {/* Mic button */}
+                    <button
+                      type="button"
+                      onClick={handleMicClick}
+                      disabled={isTranscribing}
+                      aria-label={isRecording ? 'Stop recording' : 'Start voice recording'}
+                      className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+                        isRecording
+                          ? 'bg-red-600 text-white hover:bg-red-700'
+                          : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                      }`}
+                    >
+                      {isRecording ? (
+                        <>
+                          <span className="inline-flex h-2 w-2 rounded-full bg-white animate-pulse" />
+                          <span>Stop {formatDuration(recordingSeconds)}</span>
+                        </>
+                      ) : isTranscribing ? (
+                        <>
+                          <svg className="h-3.5 w-3.5 animate-spin text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                          </svg>
+                          <span>Transcribing…</span>
+                        </>
+                      ) : (
+                        <>
+                          <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 016 0v6a3 3 0 01-3 3z" />
+                          </svg>
+                          <span>Dictate</span>
+                        </>
+                      )}
+                    </button>
+                  </div>
+
+                  {/* Voice error */}
+                  {voiceError && (
+                    <p className="mt-1 text-xs text-red-600">{voiceError}</p>
+                  )}
                 </div>
 
                 {/* Screenshots */}

--- a/apps/web/components/FeedbackWidget.tsx
+++ b/apps/web/components/FeedbackWidget.tsx
@@ -37,6 +37,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
   const mediaRecorderRef = useRef<MediaRecorder | null>(null)
   const audioChunksRef = useRef<Blob[]>([])
   const recordingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  // Set to true by handleClose so any in-flight onstop callback aborts before
+  // touching state (prevents state updates on a closed/unmounted modal).
+  const transcribeCancelledRef = useRef(false)
 
   // Clear any pending timers when the component unmounts.
   useEffect(() => {
@@ -47,7 +50,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
   }, [])
 
   const handleClose = useCallback(() => {
-    // Stop recording if active
+    // Cancel any in-flight transcription before stopping the recorder so
+    // the onstop callback does not attempt state updates on a closed modal.
+    transcribeCancelledRef.current = true
     if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
       mediaRecorderRef.current.stop()
     }
@@ -103,6 +108,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
   // ── Voice recording logic ──────────────────────────────────────────────────
 
   const startRecording = useCallback(async () => {
+    transcribeCancelledRef.current = false
     setVoiceError(null)
     audioChunksRef.current = []
 
@@ -150,6 +156,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
       // Stop all tracks to release the microphone
       recorder.stream.getTracks().forEach((t) => t.stop())
 
+      // Modal was closed before recording finished — abort silently.
+      if (transcribeCancelledRef.current) return
+
       setIsRecording(false)
       setIsTranscribing(true)
       setVoiceError(null)
@@ -158,8 +167,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
       const audioBlob = new Blob(audioChunksRef.current, { type: mimeType })
       audioChunksRef.current = []
 
+      // Derive a filename from the actual MIME type so the server extension
+      // and Content-Type are consistent (avoids a .webm filename on an ogg blob).
+      const audioExt = mimeType.startsWith('audio/ogg') ? 'ogg' : 'webm'
+      const audioFileName = `recording.${audioExt}`
+
       const formData = new FormData()
-      formData.append('audio', audioBlob, 'recording.webm')
+      formData.append('audio', audioBlob, audioFileName)
       formData.append('language', voiceLang)
 
       try {
@@ -180,19 +194,23 @@ export default function FeedbackWidget(): React.ReactElement | null {
 
         const { text } = await response.json() as { text: string }
 
-        if (text.trim()) {
+        if (!transcribeCancelledRef.current && text.trim()) {
           setDescription((prev) => {
             const trimmed = prev.trim()
             return trimmed ? `${trimmed}\n${text.trim()}` : text.trim()
           })
         }
       } catch (err) {
-        setVoiceError(
-          err instanceof Error ? err.message : 'Transcription failed. Please try again.'
-        )
+        if (!transcribeCancelledRef.current) {
+          setVoiceError(
+            err instanceof Error ? err.message : 'Transcription failed. Please try again.'
+          )
+        }
       } finally {
-        setIsTranscribing(false)
-        setRecordingSeconds(0)
+        if (!transcribeCancelledRef.current) {
+          setIsTranscribing(false)
+          setRecordingSeconds(0)
+        }
       }
     }
 
@@ -358,13 +376,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
 
                   {/* Voice recording toolbar */}
                   <div className="mt-1.5 flex items-center gap-2">
-                    {/* Language toggle */}
+                    {/* Language toggle — min-h-[44px] / min-w touch targets for mobile */}
                     <div className="flex rounded-lg border border-gray-200 overflow-hidden text-xs">
                       <button
                         type="button"
                         onClick={() => setVoiceLang('en')}
                         disabled={isRecording || isTranscribing}
-                        className={`px-2.5 py-1 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                        className={`min-h-[44px] px-3 py-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
                           voiceLang === 'en'
                             ? 'bg-indigo-600 text-white'
                             : 'bg-white text-gray-600 hover:bg-gray-50'
@@ -378,7 +396,7 @@ export default function FeedbackWidget(): React.ReactElement | null {
                         type="button"
                         onClick={() => setVoiceLang('bn')}
                         disabled={isRecording || isTranscribing}
-                        className={`px-2.5 py-1 transition-colors border-l border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed ${
+                        className={`min-h-[44px] px-3 py-2 transition-colors border-l border-gray-200 disabled:opacity-50 disabled:cursor-not-allowed ${
                           voiceLang === 'bn'
                             ? 'bg-indigo-600 text-white'
                             : 'bg-white text-gray-600 hover:bg-gray-50'
@@ -390,13 +408,13 @@ export default function FeedbackWidget(): React.ReactElement | null {
                       </button>
                     </div>
 
-                    {/* Mic button */}
+                    {/* Mic button — min-h-[44px] touch target for mobile */}
                     <button
                       type="button"
                       onClick={handleMicClick}
                       disabled={isTranscribing}
                       aria-label={isRecording ? 'Stop recording' : 'Start voice recording'}
-                      className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed ${
+                      className={`flex items-center gap-1.5 rounded-lg px-3 min-h-[44px] text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed ${
                         isRecording
                           ? 'bg-red-600 text-white hover:bg-red-700'
                           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
@@ -426,9 +444,9 @@ export default function FeedbackWidget(): React.ReactElement | null {
                     </button>
                   </div>
 
-                  {/* Voice error */}
+                  {/* Voice error — role=alert ensures screen readers announce it */}
                   {voiceError && (
-                    <p className="mt-1 text-xs text-red-600">{voiceError}</p>
+                    <p role="alert" className="mt-1 text-xs text-red-600">{voiceError}</p>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary

Adds voice dictation to the FeedbackWidget so staff can speak their feedback instead of typing it.

## What's new

### Client-side (FeedbackWidget.tsx)
- **Microphone button** next to the description textarea — click to start, click again to stop
- **Language toggle**: English / বাংলা
- Uses the browser `MediaRecorder` API (webm/opus or ogg/opus — whatever the browser supports)
- **Recording state**: red button with animated dot + elapsed timer (MM:SS)
- **Transcribing state**: spinner while waiting for the server
- On success: transcribed text is appended to the existing description (or replaces empty field)
- Language toggle is disabled while recording/transcribing to prevent accidental changes
- Errors shown inline below the toolbar; never break the form

### Server-side (new: `/api/feedback/transcribe`)
- Auth: Bearer token validated via publishable-key Supabase client — **same pattern as `/api/feedback`**
- Accepts `multipart/form-data` with `audio` (Blob/File) + `language` (`en` | `bn`)
- Validation: audio required, language must be `en` or `bn`, max 25 MB (Whisper hard limit)
- **English** → `POST /v1/audio/transcriptions` with `model=whisper-1`, `language=en`
- **Bangla** → `POST /v1/audio/translations` with `model=whisper-1` (transcribes + translates to English in one call)
- Returns `{ text: string }`
- Returns 503 if `OPENAI_API_KEY` is not set
- No new npm packages — uses native `fetch`

### Tests
17 unit tests for the new transcription route — all passing.

## ⚠️ Vercel env var required

**Lidia, please add `OPENAI_API_KEY` to the Vercel project environment variables** (Production + Preview).

The key value is already in `.env.secrets` for local dev. Do **not** commit it to the repo.

Until this is added, the route will return `503 Transcription service is not configured` (graceful — the rest of the feedback form still works normally).

## Checklist
- [x] No `SUPABASE_SERVICE_ROLE_KEY` or `SUPABASE_ANON_KEY`
- [x] No `getSupabaseAdmin`
- [x] Auth validated before data access (publishable-key Bearer token pattern)
- [x] Identity derived from verified JWT, not request body
- [x] Lint clean (no new errors)
- [x] Typecheck clean (no new errors)
- [x] 17 unit tests written and passing
- [x] No new npm packages