### PR TITLE
fix(#418): bill page stuck on Loading — resolve hanging state

### DIFF
--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -132,6 +132,26 @@ describe('OrderDetailClient', () => {
     expect(screen.getByText(/timed out/i)).toBeInTheDocument()
   })
 
+  it('does not overwrite the timeout error when fetchOrderItems rejects after the timeout', async (): Promise<void> => {
+    // Simulate a request that hangs then rejects after the safety timeout has fired.
+    let rejectFn!: (err: Error) => void
+    const { fetchOrderItems } = await import('./orderData')
+    vi.mocked(fetchOrderItems).mockReturnValue(
+      new Promise<import('./orderData').OrderItem[]>((_resolve, rej) => { rejectFn = rej }),
+    )
+
+    render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+
+    // Fire the 10-second safety timeout
+    await act(async (): Promise<void> => { vi.advanceTimersByTime(10001) })
+    expect(screen.getByText(/timed out/i)).toBeInTheDocument()
+
+    // Late rejection — the if(timedOut) guard should swallow it
+    await act(async (): Promise<void> => { rejectFn(new Error('TCP timeout')) })
+    expect(screen.getByText(/timed out/i)).toBeInTheDocument()
+    expect(screen.queryByText(/TCP timeout/i)).not.toBeInTheDocument()
+  })
+
   it('renders all item names after loading', async (): Promise<void> => {
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.test.tsx
@@ -112,6 +112,26 @@ describe('OrderDetailClient', () => {
     expect(screen.getByText('Loading items…')).toBeInTheDocument()
   })
 
+  it('clears the loading state and shows a timeout error when fetchOrderItems never resolves', async (): Promise<void> => {
+    // Simulate a hung network request — the promise never settles.
+    const { fetchOrderItems } = await import('./orderData')
+    vi.mocked(fetchOrderItems).mockReturnValue(new Promise(() => { /* never resolves */ }))
+
+    render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
+
+    // Loading spinner visible initially
+    expect(screen.getByText('Loading items…')).toBeInTheDocument()
+
+    // Advance timers past the 10-second safety timeout
+    await act(async (): Promise<void> => {
+      vi.advanceTimersByTime(10001)
+    })
+
+    // Loading should be cleared and a timeout error message shown
+    expect(screen.queryByText('Loading items…')).not.toBeInTheDocument()
+    expect(screen.getByText(/timed out/i)).toBeInTheDocument()
+  })
+
   it('renders all item names after loading', async (): Promise<void> => {
     render(<OrderDetailClient tableId="5" orderId="order-abc-123" />)
 

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -342,10 +342,7 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
     setLoading(true)
     setFetchError(null)
-    // Safety net: if the network request hangs (e.g. spotty WiFi on a restaurant
-    // tablet), clear the loading state after 10 s so the bill and action buttons
-    // remain accessible and staff can still proceed with the transaction.
-    // Mirrors the same pattern used in loadOrderStatus().
+    // Safety net: clear loading after 10 s if the fetch hangs (mirrors loadOrderStatus()).
     let timedOut = false
     const loadingTimeout = setTimeout(() => {
       timedOut = true

--- a/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
+++ b/apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx
@@ -342,14 +342,27 @@ export default function OrderDetailClient({ tableId, orderId, currencySymbol = D
 
     setLoading(true)
     setFetchError(null)
+    // Safety net: if the network request hangs (e.g. spotty WiFi on a restaurant
+    // tablet), clear the loading state after 10 s so the bill and action buttons
+    // remain accessible and staff can still proceed with the transaction.
+    // Mirrors the same pattern used in loadOrderStatus().
+    let timedOut = false
+    const loadingTimeout = setTimeout(() => {
+      timedOut = true
+      setLoading(false)
+      setFetchError('Loading items timed out — check your network connection and refresh to try again.')
+    }, 10000)
     fetchOrderItems(supabaseUrl, accessToken, orderId)
       .then((data) => {
+        if (timedOut) return
         setItems(data)
       })
       .catch((err: unknown) => {
+        if (timedOut) return
         setFetchError(err instanceof Error ? err.message : 'Failed to load order items')
       })
       .finally(() => {
+        clearTimeout(loadingTimeout)
         setLoading(false)
       })
   }


### PR DESCRIPTION
## Summary

Fixes #418 — **Bill/payment page stuck on 'Loading items…' indefinitely.**

## Root cause

`loadItems()` in `OrderDetailClient.tsx` had **no safety timeout** for its loading state, unlike `loadOrderStatus()` which already guards against hanging network requests with a 10-second `setTimeout` + `timedOut` flag.

When `fetchOrderItems()` is called on mount and the network request never settles (spotty restaurant WiFi), the promise chain's `.finally(() => setLoading(false))` never runs. The `loading` flag stays `true` indefinitely, and the page renders `'Loading items…'` with no way to proceed — blocking the bill preview and payment flow.

## Fix

Added the same `timedOut + loadingTimeout` guard pattern already used in `loadOrderStatus()`:

- A `setTimeout(10_000)` fires if the fetch hasn't resolved, sets `loading = false`, and shows an actionable error message
- The `.then()` and `.catch()` handlers bail out early if `timedOut` is already true (stale response guard)
- The `.finally()` still calls `clearTimeout` + `setLoading(false)` for the normal fast-path

## Tests

Added one Vitest test: `'clears the loading state and shows a timeout error when fetchOrderItems never resolves'`

## Affected file
- `apps/web/app/tables/[id]/order/[order_id]/OrderDetailClient.tsx` — `loadItems()` only