### PR TITLE
feat(#449): printable shift close report

### DIFF
--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -1,14 +1,17 @@
 'use client'
 
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import type { JSX } from 'react'
-import { Building2, Download } from 'lucide-react'
+import { Download, Printer } from 'lucide-react'
 import { useUser } from '@/lib/user-context'
 import { callGetReports, callExportOrders } from './reportsApi'
 import type { ReportData, ReportPeriod, CompDetailItem, CompByItem, StaffPerformanceRow } from './reportsApi'
+import { callGetShiftReport } from './shiftReportApi'
+import type { ShiftReportData } from './shiftReportApi'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
 import { PAYMENT_METHOD_LABELS } from '@/lib/paymentMethods'
 import type { PaymentMethod } from '@/lib/paymentMethods'
+import ShiftReportPrintView from '@/components/ShiftReportPrintView'
 import {
   exportRevenueByDay,
   exportTopItems,
@@ -18,6 +21,58 @@ import {
   exportAccountingCSV,
   exportDailySummary,
 } from './csvExport'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a Date as a "YYYY-MM-DDTHH:mm" string in the browser's local time
+ * (the format expected by <input type="datetime-local">).
+ */
+function toDatetimeLocal(date: Date): string {
+  const pad = (n: number): string => String(n).padStart(2, '0')
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  )
+}
+
+/** Returns today at local midnight. */
+function localMidnight(): Date {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  return d
+}
+
+/**
+ * Format a Date as a human-readable string for the printed report header.
+ * e.g. "24 Apr 2026, 14:30"
+ */
+function formatDateTimeLabel(date: Date): string {
+  return date.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
+/**
+ * Decode the email claim from a JWT access token without any crypto verification.
+ * Used only for display purposes ("Printed By" line on the shift report).
+ * Returns 'Admin' as a safe fallback if decoding fails.
+ */
+function emailFromToken(token: string): string {
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]!)) as Record<string, unknown>
+    return typeof payload['email'] === 'string' ? payload['email'] : 'Admin'
+  } catch {
+    return 'Admin'
+  }
+}
 
 const PERIOD_LABELS: { value: ReportPeriod; label: string }[] = [
   { value: 'today', label: 'Today' },
@@ -294,6 +349,16 @@ export default function ReportsDashboard(): JSX.Element {
   const [exportingOrders, setExportingOrders] = useState(false)
   const [exportOrdersError, setExportOrdersError] = useState<string | null>(null)
 
+  // Shift report state
+  const [shiftFrom, setShiftFrom] = useState(() => toDatetimeLocal(localMidnight()))
+  const [shiftTo, setShiftTo] = useState(() => toDatetimeLocal(new Date()))
+  const [shiftData, setShiftData] = useState<ShiftReportData | null>(null)
+  const [shiftLoading, setShiftLoading] = useState(false)
+  const [shiftError, setShiftError] = useState<string | null>(null)
+  const [isPrintingShift, setIsPrintingShift] = useState(false)
+  // Snapshot of labels/time captured at print time to avoid stale display values
+  const shiftPrintMetaRef = useRef<{ fromLabel: string; toLabel: string; printedAt: string; printedBy: string } | null>(null)
+
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
 
   const fetchReports = useCallback(async (
@@ -345,6 +410,43 @@ export default function ReportsDashboard(): JSX.Element {
     }
   }
 
+  async function handlePrintShiftReport(): Promise<void> {
+    if (!accessToken) return
+    setShiftLoading(true)
+    setShiftError(null)
+    try {
+      // Convert datetime-local values (local time strings) to UTC ISO strings
+      const fromUtc = new Date(shiftFrom).toISOString()
+      const toUtc = new Date(shiftTo).toISOString()
+
+      const result = await callGetShiftReport(supabaseUrl, accessToken, fromUtc, toUtc)
+      setShiftData(result)
+
+      // Snapshot display labels before printing
+      shiftPrintMetaRef.current = {
+        fromLabel: formatDateTimeLabel(new Date(shiftFrom)),
+        toLabel: formatDateTimeLabel(new Date(shiftTo)),
+        printedAt: formatDateTimeLabel(new Date()),
+        printedBy: emailFromToken(accessToken),
+      }
+
+      // Mark as printing — gives React a tick to flush print-area class onto the wrapper
+      setIsPrintingShift(true)
+      await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+      await new Promise<void>(resolve => {
+        const timeoutId = setTimeout(resolve, 15000)
+        window.addEventListener('afterprint', () => { clearTimeout(timeoutId); resolve() }, { once: true })
+        window.print()
+      })
+    } catch (err) {
+      setShiftError(err instanceof Error ? err.message : 'Failed to generate shift report')
+    } finally {
+      setIsPrintingShift(false)
+      setShiftLoading(false)
+    }
+  }
+
   const totalRevenue = data ? formatPrice(data.summary.total_revenue_cents, DEFAULT_CURRENCY_SYMBOL) : '—'
   const avgOrder = data ? formatPrice(data.summary.avg_order_cents, DEFAULT_CURRENCY_SYMBOL) : '—'
   const totalServiceCharge = data && (data.summary.total_service_charge_cents ?? 0) > 0
@@ -356,8 +458,92 @@ export default function ReportsDashboard(): JSX.Element {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Shift Close Report                                                   */}
+      {/* ------------------------------------------------------------------ */}
+      <div className="bg-white border border-brand-grey rounded-2xl p-6">
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-base font-semibold text-brand-navy">Print Shift Report</h2>
+            <p className="text-sm text-brand-navy/60 mt-0.5">
+              Generate a printable end-of-shift summary for the selected date/time range.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handlePrintShiftReport()}
+            disabled={shiftLoading || !accessToken}
+            className="flex items-center gap-2 px-4 py-2 rounded-xl bg-amber-500 hover:bg-amber-400 text-black font-medium text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[40px] shrink-0"
+            aria-label="Print shift close report"
+          >
+            {shiftLoading ? (
+              <svg className="animate-spin w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+              </svg>
+            ) : (
+              <Printer className="w-4 h-4 shrink-0" aria-hidden="true" />
+            )}
+            {shiftLoading ? 'Generating…' : 'Print Shift Report'}
+          </button>
+        </div>
+
+        {/* Date/time pickers */}
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <label htmlFor="shift-from" className="text-xs text-brand-navy/60 font-medium">From</label>
+            <input
+              id="shift-from"
+              type="datetime-local"
+              value={shiftFrom}
+              onChange={e => setShiftFrom(e.target.value)}
+              className="bg-white text-gray-900 rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="shift-to" className="text-xs text-brand-navy/60 font-medium">To</label>
+            <input
+              id="shift-to"
+              type="datetime-local"
+              value={shiftTo}
+              onChange={e => setShiftTo(e.target.value)}
+              className="bg-white text-gray-900 rounded-xl px-3 py-2 text-sm border border-brand-grey focus:outline-none focus:border-amber-500"
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setShiftFrom(toDatetimeLocal(localMidnight()))
+              setShiftTo(toDatetimeLocal(new Date()))
+            }}
+            className="px-3 py-2 rounded-xl bg-white border border-brand-grey text-brand-navy/70 hover:bg-brand-offwhite text-sm font-medium transition-colors min-h-[40px]"
+          >
+            Reset to Today
+          </button>
+        </div>
+
+        {shiftError && (
+          <p className="mt-3 text-sm text-red-400">{shiftError}</p>
+        )}
+      </div>
+
+      {/* Shift report print view — only marked as print-area while actively printing */}
+      <div className={isPrintingShift ? 'print-area' : 'print:hidden'}>
+        {shiftData && shiftPrintMetaRef.current && (
+          <ShiftReportPrintView
+            data={shiftData}
+            restaurantName="Lahore by iKitchen"
+            printedBy={shiftPrintMetaRef.current.printedBy}
+            printedAt={shiftPrintMetaRef.current.printedAt}
+            fromLabel={shiftPrintMetaRef.current.fromLabel}
+            toLabel={shiftPrintMetaRef.current.toLabel}
+          />
+        )}
+      </div>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Header */}      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <h1 className="text-2xl font-bold text-brand-navy font-heading">Reports</h1>
         <div className="flex flex-wrap items-center gap-2">
           {PERIOD_LABELS.map(({ value, label }) => (

--- a/apps/web/app/admin/reports/ReportsDashboard.tsx
+++ b/apps/web/app/admin/reports/ReportsDashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import type { JSX } from 'react'
 import { Download, Printer } from 'lucide-react'
 import { useUser } from '@/lib/user-context'
+import { useActiveRestaurant } from '@/lib/useActiveRestaurant'
 import { callGetReports, callExportOrders } from './reportsApi'
 import type { ReportData, ReportPeriod, CompDetailItem, CompByItem, StaffPerformanceRow } from './reportsApi'
 import { callGetShiftReport } from './shiftReportApi'
@@ -339,6 +340,7 @@ function StaffPerformanceTable({ rows }: StaffPerformanceTableProps): JSX.Elemen
 
 export default function ReportsDashboard(): JSX.Element {
   const { accessToken: _at } = useUser(); const accessToken = _at ?? ''
+  const { restaurantName } = useActiveRestaurant()
   const [period, setPeriod] = useState<ReportPeriod>('today')
   const [customFrom, setCustomFrom] = useState('')
   const [customTo, setCustomTo] = useState('')
@@ -356,8 +358,9 @@ export default function ReportsDashboard(): JSX.Element {
   const [shiftLoading, setShiftLoading] = useState(false)
   const [shiftError, setShiftError] = useState<string | null>(null)
   const [isPrintingShift, setIsPrintingShift] = useState(false)
-  // Snapshot of labels/time captured at print time to avoid stale display values
   const shiftPrintMetaRef = useRef<{ fromLabel: string; toLabel: string; printedAt: string; printedBy: string } | null>(null)
+
+  const shiftRangeInvalid = Boolean(shiftFrom && shiftTo && new Date(shiftFrom) >= new Date(shiftTo))
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
 
@@ -473,7 +476,7 @@ export default function ReportsDashboard(): JSX.Element {
           <button
             type="button"
             onClick={() => void handlePrintShiftReport()}
-            disabled={shiftLoading || !accessToken}
+            disabled={shiftLoading || !accessToken || shiftRangeInvalid}
             className="flex items-center gap-2 px-4 py-2 rounded-xl bg-amber-500 hover:bg-amber-400 text-black font-medium text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[40px] shrink-0"
             aria-label="Print shift close report"
           >
@@ -523,6 +526,9 @@ export default function ReportsDashboard(): JSX.Element {
           </button>
         </div>
 
+        {shiftRangeInvalid && (
+          <p className="mt-3 text-sm text-amber-600">&ldquo;From&rdquo; must be before &ldquo;To&rdquo;</p>
+        )}
         {shiftError && (
           <p className="mt-3 text-sm text-red-400">{shiftError}</p>
         )}
@@ -533,7 +539,7 @@ export default function ReportsDashboard(): JSX.Element {
         {shiftData && shiftPrintMetaRef.current && (
           <ShiftReportPrintView
             data={shiftData}
-            restaurantName="Lahore by iKitchen"
+            restaurantName={restaurantName ?? ''}
             printedBy={shiftPrintMetaRef.current.printedBy}
             printedAt={shiftPrintMetaRef.current.printedAt}
             fromLabel={shiftPrintMetaRef.current.fromLabel}

--- a/apps/web/app/admin/reports/shiftReportApi.test.ts
+++ b/apps/web/app/admin/reports/shiftReportApi.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for shiftReportApi — issue #449 shift close report.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { callGetShiftReport } from './shiftReportApi'
+import type { ShiftReportData } from './shiftReportApi'
+
+const BASE_URL = 'https://test.supabase.co'
+const TOKEN = 'test-token'
+
+const FROM = '2026-04-24T00:00:00.000Z'
+const TO = '2026-04-24T14:30:00.000Z'
+
+function makeShiftReportData(overrides: Partial<ShiftReportData> = {}): ShiftReportData {
+  return {
+    from: FROM,
+    to: TO,
+    total_orders: 12,
+    total_covers: 36,
+    avg_order_value_cents: 85000,
+    gross_sales_cents: 1100000,
+    discounts_cents: 50000,
+    complimentary_cents: 30000,
+    net_sales_cents: 1020000,
+    subtotal_excl_vat_cents: 886957,
+    vat_amount_cents: 133043,
+    total_incl_vat_cents: 1020000,
+    cash_cents: 600000,
+    card_cents: 420000,
+    mobile_cents: 0,
+    other_cents: 0,
+    total_collected_cents: 1020000,
+    ...overrides,
+  }
+}
+
+describe('callGetShiftReport', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns ShiftReportData on success', async () => {
+    const mockData = makeShiftReportData()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: mockData }),
+    }))
+
+    const result = await callGetShiftReport(BASE_URL, TOKEN, FROM, TO)
+
+    expect(result).toEqual(mockData)
+    expect(fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/functions/v1/get_shift_report`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ from: FROM, to: TO }),
+      }),
+    )
+  })
+
+  it('throws when the HTTP response is not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'Unauthorized',
+    }))
+
+    await expect(callGetShiftReport(BASE_URL, TOKEN, FROM, TO)).rejects.toThrow(
+      /get_shift_report failed: 401/,
+    )
+  })
+
+  it('throws when success is false', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: false, error: 'No data for range' }),
+    }))
+
+    await expect(callGetShiftReport(BASE_URL, TOKEN, FROM, TO)).rejects.toThrow('No data for range')
+  })
+
+  it('throws a fallback error when success is false and no error message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: false }),
+    }))
+
+    await expect(callGetShiftReport(BASE_URL, TOKEN, FROM, TO)).rejects.toThrow(
+      'Failed to fetch shift report',
+    )
+  })
+
+  it('passes from/to correctly in the request body', async () => {
+    const customFrom = '2026-04-20T18:00:00.000Z'
+    const customTo = '2026-04-21T17:59:59.999Z'
+    const mockData = makeShiftReportData({ from: customFrom, to: customTo })
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true, data: mockData }),
+    }))
+
+    const result = await callGetShiftReport(BASE_URL, TOKEN, customFrom, customTo)
+    expect(result.from).toBe(customFrom)
+    expect(result.to).toBe(customTo)
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ from: customFrom, to: customTo }),
+      }),
+    )
+  })
+})

--- a/apps/web/app/admin/reports/shiftReportApi.ts
+++ b/apps/web/app/admin/reports/shiftReportApi.ts
@@ -1,10 +1,4 @@
-/**
- * API types and fetch helper for the shift close report (issue #449).
- *
- * The shift report uses an explicit ISO datetime range (from/to) rather than
- * named periods, allowing local-midnight precision (e.g. today 00:00 in the
- * user's timezone rather than UTC midnight).
- */
+/** API types and fetch helper for the shift close report (issue #449). */
 
 export interface ShiftReportData {
   /** UTC ISO datetime strings for the queried range */
@@ -41,14 +35,7 @@ interface GetShiftReportResponse {
   error?: string
 }
 
-/**
- * Fetch shift report data from the get_shift_report edge function.
- *
- * @param supabaseUrl  - The Supabase project URL.
- * @param accessToken  - The authenticated user's JWT.
- * @param from         - UTC ISO datetime string for the range start.
- * @param to           - UTC ISO datetime string for the range end.
- */
+/** Fetch shift report data from the get_shift_report edge function. */
 export async function callGetShiftReport(
   supabaseUrl: string,
   accessToken: string,

--- a/apps/web/app/admin/reports/shiftReportApi.ts
+++ b/apps/web/app/admin/reports/shiftReportApi.ts
@@ -1,0 +1,77 @@
+/**
+ * API types and fetch helper for the shift close report (issue #449).
+ *
+ * The shift report uses an explicit ISO datetime range (from/to) rather than
+ * named periods, allowing local-midnight precision (e.g. today 00:00 in the
+ * user's timezone rather than UTC midnight).
+ */
+
+export interface ShiftReportData {
+  /** UTC ISO datetime strings for the queried range */
+  from: string
+  to: string
+
+  /** Orders summary */
+  total_orders: number
+  total_covers: number
+  avg_order_value_cents: number
+
+  /** Sales breakdown (all in cents) */
+  gross_sales_cents: number
+  discounts_cents: number
+  complimentary_cents: number
+  net_sales_cents: number
+
+  /** VAT summary (all in cents) */
+  subtotal_excl_vat_cents: number
+  vat_amount_cents: number
+  total_incl_vat_cents: number
+
+  /** Payment method breakdown (all in cents) */
+  cash_cents: number
+  card_cents: number
+  mobile_cents: number
+  other_cents: number
+  total_collected_cents: number
+}
+
+interface GetShiftReportResponse {
+  success: boolean
+  data?: ShiftReportData
+  error?: string
+}
+
+/**
+ * Fetch shift report data from the get_shift_report edge function.
+ *
+ * @param supabaseUrl  - The Supabase project URL.
+ * @param accessToken  - The authenticated user's JWT.
+ * @param from         - UTC ISO datetime string for the range start.
+ * @param to           - UTC ISO datetime string for the range end.
+ */
+export async function callGetShiftReport(
+  supabaseUrl: string,
+  accessToken: string,
+  from: string,
+  to: string,
+): Promise<ShiftReportData> {
+  const res = await fetch(`${supabaseUrl}/functions/v1/get_shift_report`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ from, to }),
+  })
+
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`get_shift_report failed: ${res.status} ${res.statusText} — ${text}`)
+  }
+
+  const json = (await res.json()) as GetShiftReportResponse
+  if (!json.success || !json.data) {
+    throw new Error(json.error ?? 'Failed to fetch shift report')
+  }
+  return json.data
+}

--- a/apps/web/components/ShiftReportPrintView.tsx
+++ b/apps/web/components/ShiftReportPrintView.tsx
@@ -1,0 +1,145 @@
+/**
+ * ShiftReportPrintView — 80mm thermal print component for the shift close report.
+ *
+ * Rendered hidden in the DOM (print:block) like BillPrintView / SplitBillPrintView.
+ * The parent wraps this in a `.print-area` container so global print CSS applies.
+ *
+ * Issue #449 — printable shift close report.
+ */
+
+import type { JSX } from 'react'
+import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
+import type { ShiftReportData } from '@/app/admin/reports/shiftReportApi'
+
+export interface ShiftReportPrintViewProps {
+  data: ShiftReportData
+  restaurantName: string
+  /** Display name of the staff member who triggered the print. */
+  printedBy: string
+  /** ISO string of when the print was triggered. */
+  printedAt: string
+  /** Human-readable "from" label (local time). */
+  fromLabel: string
+  /** Human-readable "to" label (local time). */
+  toLabel: string
+}
+
+/** Thin separator line used between report sections. */
+function Dashes(): JSX.Element {
+  return <p className="text-center tracking-widest">{'- '.repeat(20)}</p>
+}
+
+/** A key/value row on the thermal receipt. */
+function Row({ label, value, bold = false }: { label: string; value: string; bold?: boolean }): JSX.Element {
+  return (
+    <div className={['flex justify-between text-xs leading-snug', bold ? 'font-bold' : ''].join(' ').trim()}>
+      <span>{label}</span>
+      <span>{value}</span>
+    </div>
+  )
+}
+
+/** Section header — centred, separated by dashes. */
+function SectionHeader({ title }: { title: string }): JSX.Element {
+  return (
+    <div className="text-center my-1">
+      <p className="font-semibold text-xs uppercase tracking-wide">{title}</p>
+    </div>
+  )
+}
+
+export default function ShiftReportPrintView({
+  data,
+  restaurantName,
+  printedBy,
+  printedAt,
+  fromLabel,
+  toLabel,
+}: ShiftReportPrintViewProps): JSX.Element {
+  const sym = DEFAULT_CURRENCY_SYMBOL
+  const fmt = (cents: number): string => formatPrice(cents, sym)
+
+  return (
+    <div
+      aria-hidden="true"
+      className="hidden print:block font-mono text-black bg-white p-2 w-full text-xs"
+    >
+      {/* ---- HEADER ---- */}
+      <div className="text-center mb-1">
+        {restaurantName && (
+          <p className="font-bold text-sm">{restaurantName}</p>
+        )}
+        <p className="font-semibold">SHIFT CLOSE REPORT</p>
+      </div>
+
+      <div className="space-y-0.5 mb-1">
+        <Row label="From" value={fromLabel} />
+        <Row label="To" value={toLabel} />
+        <Row label="Printed By" value={printedBy} />
+        <Row label="Printed At" value={printedAt} />
+      </div>
+
+      <Dashes />
+
+      {/* ---- ORDERS SUMMARY ---- */}
+      <SectionHeader title="Orders Summary" />
+      <div className="space-y-0.5 mb-1">
+        <Row label="Total Orders" value={String(data.total_orders)} />
+        <Row label="Total Covers" value={String(data.total_covers)} />
+        <Row label="Avg Order Value" value={fmt(data.avg_order_value_cents)} />
+      </div>
+
+      <Dashes />
+
+      {/* ---- SALES BREAKDOWN ---- */}
+      <SectionHeader title="Sales Breakdown" />
+      <div className="space-y-0.5 mb-1">
+        <Row label="Gross Sales" value={fmt(data.gross_sales_cents)} />
+        {data.discounts_cents > 0 && (
+          <Row label="Discounts" value={`-${fmt(data.discounts_cents)}`} />
+        )}
+        {data.complimentary_cents > 0 && (
+          <Row label="Complimentary" value={`-${fmt(data.complimentary_cents)}`} />
+        )}
+        <Row label="Net Sales" value={fmt(data.net_sales_cents)} bold />
+      </div>
+
+      <Dashes />
+
+      {/* ---- VAT SUMMARY ---- */}
+      <SectionHeader title="VAT Summary" />
+      <div className="space-y-0.5 mb-1">
+        <Row label="Subtotal (excl. VAT)" value={fmt(data.subtotal_excl_vat_cents)} />
+        <Row label="VAT" value={fmt(data.vat_amount_cents)} />
+        <Row label="Total (incl. VAT)" value={fmt(data.total_incl_vat_cents)} bold />
+      </div>
+
+      <Dashes />
+
+      {/* ---- PAYMENT METHOD BREAKDOWN ---- */}
+      <SectionHeader title="Payment Methods" />
+      <div className="space-y-0.5 mb-1">
+        {data.cash_cents > 0 && (
+          <Row label="Cash" value={fmt(data.cash_cents)} />
+        )}
+        {data.card_cents > 0 && (
+          <Row label="Card / POS" value={fmt(data.card_cents)} />
+        )}
+        {data.mobile_cents > 0 && (
+          <Row label="Mobile" value={fmt(data.mobile_cents)} />
+        )}
+        {data.other_cents > 0 && (
+          <Row label="Other" value={fmt(data.other_cents)} />
+        )}
+        {data.complimentary_cents > 0 && (
+          <Row label="Complimentary" value={fmt(data.complimentary_cents)} />
+        )}
+        <Row label="Total Collected" value={fmt(data.total_collected_cents)} bold />
+      </div>
+
+      {/* ---- FOOTER ---- */}
+      <Dashes />
+      <p className="text-center font-semibold mt-1">End of Shift Report</p>
+    </div>
+  )
+}

--- a/apps/web/components/ShiftReportPrintView.tsx
+++ b/apps/web/components/ShiftReportPrintView.tsx
@@ -1,11 +1,4 @@
-/**
- * ShiftReportPrintView — 80mm thermal print component for the shift close report.
- *
- * Rendered hidden in the DOM (print:block) like BillPrintView / SplitBillPrintView.
- * The parent wraps this in a `.print-area` container so global print CSS applies.
- *
- * Issue #449 — printable shift close report.
- */
+/** 80mm thermal print component for the shift close report (issue #449). */
 
 import type { JSX } from 'react'
 import { formatPrice, DEFAULT_CURRENCY_SYMBOL } from '@/lib/formatPrice'
@@ -24,7 +17,7 @@ export interface ShiftReportPrintViewProps {
   toLabel: string
 }
 
-/** Thin separator line used between report sections. */
+/** Separator line between sections. */
 function Dashes(): JSX.Element {
   return <p className="text-center tracking-widest">{'- '.repeat(20)}</p>
 }

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -494,6 +494,9 @@ verify_jwt = false
 [functions.reopen_order_for_items]
 verify_jwt = false
 
+[functions.get_shift_report]
+verify_jwt = false
+
 [edge_runtime]
 enabled = true
 # Supported request policies: `oneshot`, `per_worker`.

--- a/supabase/functions/get_shift_report/index.test.ts
+++ b/supabase/functions/get_shift_report/index.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi } from 'vitest'
+import { handler, corsHeaders } from './index'
+import type { FetchFn, HandlerEnv, ShiftReportData } from './index'
+
+const TEST_ENV: HandlerEnv = {
+  supabaseUrl: 'http://test-supabase.local',
+  serviceKey: 'test-service-key',
+}
+
+const ACTOR_ID = '11111111-1111-1111-1111-111111111111'
+const FROM = '2026-04-24T00:00:00.000Z'
+const TO = '2026-04-24T14:30:00.000Z'
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/functions/v1/get_shift_report', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-jwt',
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+function makeOrders(overrides: Array<Record<string, unknown>> = []) {
+  return overrides.length > 0 ? overrides : [
+    {
+      id: 'order-1',
+      final_total_cents: 100000,
+      covers: 2,
+      discount_amount_cents: 10000,
+      order_comp: false,
+      vat_cents: 13000,
+      service_charge_cents: 0,
+    },
+  ]
+}
+
+function buildMockFetch(opts: {
+  orders?: Array<Record<string, unknown>>
+  compOrders?: Array<Record<string, unknown>>
+  compItems?: Array<Record<string, unknown>>
+  payments?: Array<Record<string, unknown>>
+  ordersStatus?: number
+  compOrdersStatus?: number
+  compItemsStatus?: number
+  paymentsStatus?: number
+} = {}): FetchFn {
+  const {
+    orders = makeOrders(),
+    compOrders = [],
+    compItems = [],
+    payments = [{ order_id: 'order-1', method: 'cash', amount_cents: 100000 }],
+    ordersStatus = 200,
+    compOrdersStatus = 200,
+    compItemsStatus = 200,
+    paymentsStatus = 200,
+  } = opts
+
+  return vi.fn(async (url: string): Promise<Response> => {
+    if (url.includes('/auth/v1/user')) {
+      return new Response(JSON.stringify({ id: ACTOR_ID }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/users')) {
+      return new Response(JSON.stringify([{ id: ACTOR_ID, role: 'owner' }]), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/orders') && url.includes('order_comp=eq.true')) {
+      return new Response(JSON.stringify(compOrders), {
+        status: compOrdersStatus,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/orders')) {
+      return new Response(JSON.stringify(orders), {
+        status: ordersStatus,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/order_items') && url.includes('comp=eq.true')) {
+      return new Response(JSON.stringify(compItems), {
+        status: compItemsStatus,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    if (url.includes('/rest/v1/payments')) {
+      return new Response(JSON.stringify(payments), {
+        status: paymentsStatus,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response(JSON.stringify([]), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }) as FetchFn
+}
+
+describe('get_shift_report handler', () => {
+  describe('OPTIONS preflight', () => {
+    it('returns 204 with CORS headers including x-demo-staff-id', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/get_shift_report', { method: 'OPTIONS' })
+      const res = await handler(req, vi.fn() as unknown as FetchFn, TEST_ENV)
+      expect(res.status).toBe(204)
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*')
+      expect(corsHeaders['Access-Control-Allow-Headers']).toContain('x-demo-staff-id')
+    })
+  })
+
+  describe('validation', () => {
+    it('returns 400 for missing from/to', async (): Promise<void> => {
+      const res = await handler(makeRequest({}), buildMockFetch(), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toContain('from and to')
+    })
+
+    it('returns 400 for unparseable date', async (): Promise<void> => {
+      const res = await handler(makeRequest({ from: 'not-a-date', to: TO }), buildMockFetch(), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.error).toContain('valid ISO')
+    })
+
+    it('returns 400 when from >= to', async (): Promise<void> => {
+      const res = await handler(makeRequest({ from: TO, to: FROM }), buildMockFetch(), TEST_ENV)
+      expect(res.status).toBe(400)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.error).toContain('"from" must be before "to"')
+    })
+
+    it('returns 400 for malformed JSON body', async (): Promise<void> => {
+      const req = new Request('http://localhost/functions/v1/get_shift_report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-jwt' },
+        body: 'not-json',
+      })
+      const res = await handler(req, buildMockFetch(), TEST_ENV)
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 500 when env is null', async (): Promise<void> => {
+      const res = await handler(makeRequest({ from: FROM, to: TO }), buildMockFetch(), null)
+      expect(res.status).toBe(500)
+    })
+  })
+
+  describe('happy path', () => {
+    it('returns correct sales breakdown for a single non-comp order', async (): Promise<void> => {
+      const orders = [{
+        id: 'order-1',
+        final_total_cents: 100000,
+        covers: 3,
+        discount_amount_cents: 5000,
+        order_comp: false,
+        vat_cents: 13000,
+        service_charge_cents: 0,
+      }]
+      const payments = [{ order_id: 'order-1', method: 'cash', amount_cents: 100000 }]
+
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ orders, payments }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: ShiftReportData }
+      expect(json.success).toBe(true)
+
+      const d = json.data
+      expect(d.total_orders).toBe(1)
+      expect(d.total_covers).toBe(3)
+      expect(d.net_sales_cents).toBe(100000)
+      expect(d.discounts_cents).toBe(5000)
+      expect(d.complimentary_cents).toBe(0)
+      expect(d.gross_sales_cents).toBe(105000) // 100000 + 5000 + 0
+      expect(d.vat_amount_cents).toBe(13000)
+      expect(d.subtotal_excl_vat_cents).toBe(87000) // 100000 - 13000
+      expect(d.total_incl_vat_cents).toBe(100000)
+      expect(d.cash_cents).toBe(100000)
+      expect(d.card_cents).toBe(0)
+      expect(d.total_collected_cents).toBe(100000)
+    })
+
+    it('avg order value excludes comp orders', async (): Promise<void> => {
+      const orders = [
+        { id: 'order-1', final_total_cents: 80000, covers: 2, discount_amount_cents: 0, order_comp: false, vat_cents: 10000, service_charge_cents: 0 },
+        { id: 'order-2', final_total_cents: 0,     covers: 1, discount_amount_cents: 0, order_comp: true,  vat_cents: 0,     service_charge_cents: 0 },
+      ]
+      const payments = [{ order_id: 'order-1', method: 'card', amount_cents: 80000 }]
+
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ orders, payments }),
+        TEST_ENV,
+      )
+      const json = await res.json() as { success: boolean; data: ShiftReportData }
+      expect(json.data.total_orders).toBe(2)
+      // Avg over paying orders only (order-1): 80000 / 1 = 80000
+      expect(json.data.avg_order_value_cents).toBe(80000)
+    })
+
+    it('includes complimentary value from comp orders', async (): Promise<void> => {
+      const orders = [
+        { id: 'order-1', final_total_cents: 0, covers: 2, discount_amount_cents: 0, order_comp: true, vat_cents: 0, service_charge_cents: 0 },
+      ]
+      const compOrders = [
+        {
+          id: 'order-1',
+          order_items: [
+            { quantity: 2, unit_price_cents: 30000, voided: false },
+            { quantity: 1, unit_price_cents: 10000, voided: true },
+          ],
+        },
+      ]
+
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ orders, compOrders, payments: [] }),
+        TEST_ENV,
+      )
+      const json = await res.json() as { success: boolean; data: ShiftReportData }
+      // Only non-voided: 2 * 30000 = 60000
+      expect(json.data.complimentary_cents).toBe(60000)
+      expect(json.data.gross_sales_cents).toBe(60000) // 0 + 0 + 60000
+    })
+
+    it('buckets payment methods correctly', async (): Promise<void> => {
+      const orders = [
+        { id: 'order-1', final_total_cents: 150000, covers: 4, discount_amount_cents: 0, order_comp: false, vat_cents: 0, service_charge_cents: 0 },
+      ]
+      const payments = [
+        { order_id: 'order-1', method: 'cash',   amount_cents: 70000 },
+        { order_id: 'order-1', method: 'card',   amount_cents: 50000 },
+        { order_id: 'order-1', method: 'mobile', amount_cents: 30000 },
+      ]
+
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ orders, payments }),
+        TEST_ENV,
+      )
+      const json = await res.json() as { success: boolean; data: ShiftReportData }
+      expect(json.data.cash_cents).toBe(70000)
+      expect(json.data.card_cents).toBe(50000)
+      expect(json.data.mobile_cents).toBe(30000)
+      expect(json.data.total_collected_cents).toBe(150000)
+    })
+
+    it('returns empty report (all zeros) when no orders exist', async (): Promise<void> => {
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ orders: [], payments: [] }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(200)
+      const json = await res.json() as { success: boolean; data: ShiftReportData }
+      expect(json.data.total_orders).toBe(0)
+      expect(json.data.net_sales_cents).toBe(0)
+      expect(json.data.total_collected_cents).toBe(0)
+    })
+  })
+
+  describe('error propagation', () => {
+    it('returns 500 when orders query fails', async (): Promise<void> => {
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ ordersStatus: 503 }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(500)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.success).toBe(false)
+      expect(json.error).toContain('Failed to fetch orders')
+    })
+
+    it('returns 500 when comp orders query fails', async (): Promise<void> => {
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ compOrdersStatus: 500 }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(500)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.error).toContain('Failed to fetch comp orders')
+    })
+
+    it('returns 500 when comp items query fails', async (): Promise<void> => {
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ compItemsStatus: 500 }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(500)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.error).toContain('Failed to fetch comp items')
+    })
+
+    it('returns 500 when payments query fails', async (): Promise<void> => {
+      const res = await handler(
+        makeRequest({ from: FROM, to: TO }),
+        buildMockFetch({ paymentsStatus: 500 }),
+        TEST_ENV,
+      )
+      expect(res.status).toBe(500)
+      const json = await res.json() as { success: boolean; error: string }
+      expect(json.error).toContain('Failed to fetch payments')
+    })
+  })
+})

--- a/supabase/functions/get_shift_report/index.ts
+++ b/supabase/functions/get_shift_report/index.ts
@@ -1,19 +1,11 @@
-/**
- * get_shift_report — Supabase Edge Function
- *
- * Returns aggregated data for a printable shift close report.
- * Accepts an explicit ISO datetime range (from/to), enabling local-midnight
- * precision rather than the UTC-date rounding used by get_reports.
- *
- * Auth: owner role required (same as get_reports).
- */
+/** get_shift_report — aggregated data for a printable shift close report. */
 
 import { verifyAndGetCaller } from '../_shared/auth.ts'
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-demo-staff-id',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
 }
 
 export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
@@ -67,37 +59,23 @@ interface CompItemRow {
 }
 
 export interface ShiftReportData {
-  /** ISO datetime strings (UTC) for the queried range */
   from: string
   to: string
-
-  /** Orders summary */
   total_orders: number
   total_covers: number
   avg_order_value_cents: number
-
-  /** Sales breakdown (all in cents) */
   gross_sales_cents: number
   discounts_cents: number
   complimentary_cents: number
   net_sales_cents: number
-
-  /** VAT summary (all in cents) */
   subtotal_excl_vat_cents: number
   vat_amount_cents: number
   total_incl_vat_cents: number
-
-  /** Payment method breakdown (all in cents) */
   cash_cents: number
   card_cents: number
   mobile_cents: number
   other_cents: number
   total_collected_cents: number
-}
-
-interface RequestBody {
-  from: string
-  to: string
 }
 
 // ---------------------------------------------------------------------------
@@ -156,12 +134,17 @@ export async function handler(
     )
   }
 
-  // Validate that from/to are parseable as dates
   const fromDate = new Date(from)
   const toDate = new Date(to)
   if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
     return new Response(
       JSON.stringify({ success: false, error: 'from and to must be valid ISO datetime strings' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+  if (fromDate >= toDate) {
+    return new Response(
+      JSON.stringify({ success: false, error: '"from" must be before "to"' }),
       { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
     )
   }
@@ -177,7 +160,7 @@ export async function handler(
   const end = toDate.toISOString()
 
   try {
-    // 1. Fetch all paid orders in range (include vat_cents)
+    // 1. Fetch all paid orders in range
     const ordersRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders?select=id,final_total_cents,covers,discount_amount_cents,order_comp,vat_cents,service_charge_cents&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&limit=10000`,
       { headers: dbHeaders },
@@ -198,6 +181,7 @@ export async function handler(
     let totalDiscountsCents = 0
     let totalVatCents = 0
     const nonCompOrders = orders.filter(o => !o.order_comp)
+    const payingOrders = orders.filter(o => !o.order_comp && (o.final_total_cents ?? 0) > 0)
 
     for (const o of orders) {
       netSalesCents += o.final_total_cents ?? 0
@@ -209,54 +193,62 @@ export async function handler(
     }
 
     const totalOrders = orders.length
-    const avgOrderValueCents = totalOrders > 0 ? Math.round(netSalesCents / totalOrders) : 0
+    // Avg order value over paying orders only (comp orders have final_total = 0)
+    const avgOrderValueCents = payingOrders.length > 0
+      ? Math.round(netSalesCents / payingOrders.length)
+      : 0
 
-    // 3. Complimentary value — sum of comp item values across all orders in range
-    //    a) Whole-order comps: sum non-voided item values
+    // 3. Complimentary value from whole-order comps
     let complimentaryCents = 0
 
     const compOrdersRes = await fetchFn(
       `${supabaseUrl}/rest/v1/orders?select=id,order_items(quantity,unit_price_cents,voided)&order_comp=eq.true&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&limit=1000`,
       { headers: dbHeaders },
     )
-    if (compOrdersRes.ok) {
-      const compOrders = (await compOrdersRes.json()) as CompOrderRow[]
-      for (const co of compOrders) {
-        for (const oi of co.order_items) {
-          if (!oi.voided) {
-            complimentaryCents += oi.quantity * oi.unit_price_cents
-          }
+    if (!compOrdersRes.ok) {
+      const errText = await compOrdersRes.text()
+      return new Response(
+        JSON.stringify({ success: false, error: `Failed to fetch comp orders: ${errText}` }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const compOrders = (await compOrdersRes.json()) as CompOrderRow[]
+    for (const co of compOrders) {
+      for (const oi of co.order_items) {
+        if (!oi.voided) {
+          complimentaryCents += oi.quantity * oi.unit_price_cents
         }
       }
     }
 
-    //    b) Item-level comps within non-comp orders
-    if (orderIds.length > 0) {
+    // 4. Item-level comps within non-comp orders
+    if (nonCompOrders.length > 0) {
       const nonCompOrderIds = nonCompOrders.map(o => o.id)
-      if (nonCompOrderIds.length > 0) {
-        const compItemsRes = await fetchFn(
-          `${supabaseUrl}/rest/v1/order_items?select=quantity,unit_price_cents&comp=eq.true&order_id=in.(${nonCompOrderIds.join(',')})&limit=10000`,
-          { headers: dbHeaders },
+      const compItemsRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/order_items?select=quantity,unit_price_cents&comp=eq.true&order_id=in.(${nonCompOrderIds.join(',')})&limit=10000`,
+        { headers: dbHeaders },
+      )
+      if (!compItemsRes.ok) {
+        const errText = await compItemsRes.text()
+        return new Response(
+          JSON.stringify({ success: false, error: `Failed to fetch comp items: ${errText}` }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
         )
-        if (compItemsRes.ok) {
-          const compItems = (await compItemsRes.json()) as CompItemRow[]
-          for (const ci of compItems) {
-            complimentaryCents += ci.quantity * ci.unit_price_cents
-          }
-        }
+      }
+      const compItems = (await compItemsRes.json()) as CompItemRow[]
+      for (const ci of compItems) {
+        complimentaryCents += ci.quantity * ci.unit_price_cents
       }
     }
 
-    // Gross sales = net sales + discounts + complimentary
+    // Gross = net + discounts + complimentary
     const grossSalesCents = netSalesCents + totalDiscountsCents + complimentaryCents
 
-    // 4. VAT summary
-    // net_sales includes VAT (final_total_cents is post-VAT for tax-exclusive, or includes VAT for inclusive)
-    // Use stored vat_cents as the authoritative VAT figure
+    // 5. VAT summary (net includes VAT; use stored vat_cents as authoritative)
     const subtotalExclVatCents = netSalesCents - totalVatCents
     const totalInclVatCents = netSalesCents
 
-    // 5. Payment breakdown
+    // 6. Payment breakdown
     let cashCents = 0
     let cardCents = 0
     let mobileCents = 0
@@ -267,15 +259,20 @@ export async function handler(
         `${supabaseUrl}/rest/v1/payments?select=order_id,method,amount_cents&order_id=in.(${orderIds.join(',')})&limit=50000`,
         { headers: dbHeaders },
       )
-      if (paymentsRes.ok) {
-        const payments = (await paymentsRes.json()) as PaymentRow[]
-        for (const p of payments) {
-          switch (p.method) {
-            case 'cash':   cashCents   += p.amount_cents ?? 0; break
-            case 'card':   cardCents   += p.amount_cents ?? 0; break
-            case 'mobile': mobileCents += p.amount_cents ?? 0; break
-            default:       otherCents  += p.amount_cents ?? 0; break
-          }
+      if (!paymentsRes.ok) {
+        const errText = await paymentsRes.text()
+        return new Response(
+          JSON.stringify({ success: false, error: `Failed to fetch payments: ${errText}` }),
+          { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        )
+      }
+      const payments = (await paymentsRes.json()) as PaymentRow[]
+      for (const p of payments) {
+        switch (p.method) {
+          case 'cash':   cashCents   += p.amount_cents ?? 0; break
+          case 'card':   cardCents   += p.amount_cents ?? 0; break
+          case 'mobile': mobileCents += p.amount_cents ?? 0; break
+          default:       otherCents  += p.amount_cents ?? 0; break
         }
       }
     }

--- a/supabase/functions/get_shift_report/index.ts
+++ b/supabase/functions/get_shift_report/index.ts
@@ -1,0 +1,320 @@
+/**
+ * get_shift_report — Supabase Edge Function
+ *
+ * Returns aggregated data for a printable shift close report.
+ * Accepts an explicit ISO datetime range (from/to), enabling local-midnight
+ * precision rather than the UTC-date rounding used by get_reports.
+ *
+ * Auth: owner role required (same as get_reports).
+ */
+
+import { verifyAndGetCaller } from '../_shared/auth.ts'
+
+export const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+}
+
+export type FetchFn = (input: string, init?: RequestInit) => Promise<Response>
+
+export interface HandlerEnv {
+  supabaseUrl: string
+  serviceKey: string
+}
+
+function readEnv(): HandlerEnv | null {
+  const g = globalThis as { Deno?: { env: { get: (key: string) => string | undefined } } }
+  if (!g.Deno) return null
+  const supabaseUrl = g.Deno.env.get('SUPABASE_URL') ?? ''
+  const serviceKey = g.Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+  if (!supabaseUrl || !serviceKey) return null
+  return { supabaseUrl, serviceKey }
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface OrderRow {
+  id: string
+  final_total_cents: number | null
+  covers: number | null
+  discount_amount_cents: number | null
+  order_comp: boolean | null
+  vat_cents: number | null
+  service_charge_cents: number | null
+}
+
+interface PaymentRow {
+  order_id: string
+  method: string
+  amount_cents: number
+}
+
+interface CompOrderRow {
+  id: string
+  order_items: Array<{
+    quantity: number
+    unit_price_cents: number
+    voided: boolean
+  }>
+}
+
+interface CompItemRow {
+  quantity: number
+  unit_price_cents: number
+}
+
+export interface ShiftReportData {
+  /** ISO datetime strings (UTC) for the queried range */
+  from: string
+  to: string
+
+  /** Orders summary */
+  total_orders: number
+  total_covers: number
+  avg_order_value_cents: number
+
+  /** Sales breakdown (all in cents) */
+  gross_sales_cents: number
+  discounts_cents: number
+  complimentary_cents: number
+  net_sales_cents: number
+
+  /** VAT summary (all in cents) */
+  subtotal_excl_vat_cents: number
+  vat_amount_cents: number
+  total_incl_vat_cents: number
+
+  /** Payment method breakdown (all in cents) */
+  cash_cents: number
+  card_cents: number
+  mobile_cents: number
+  other_cents: number
+  total_collected_cents: number
+}
+
+interface RequestBody {
+  from: string
+  to: string
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handler(
+  req: Request,
+  fetchFn: FetchFn = fetch,
+  env: HandlerEnv | null = readEnv(),
+): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders })
+  }
+
+  if (req.method === 'GET' && new URL(req.url).pathname.endsWith('/health')) {
+    return new Response(
+      JSON.stringify({ ok: true, function: 'get_shift_report' }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  if (!env) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Server configuration error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const caller = await verifyAndGetCaller(req, env.supabaseUrl, env.serviceKey, 'owner', fetchFn)
+  if ('error' in caller) {
+    return new Response(
+      JSON.stringify({ success: false, error: caller.error }),
+      { status: caller.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return new Response(
+      JSON.stringify({ success: false, error: 'Invalid request body' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const payload = body as Record<string, unknown>
+  const from = payload['from'] as string | undefined
+  const to = payload['to'] as string | undefined
+
+  if (!from || !to) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'from and to are required ISO datetime strings' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  // Validate that from/to are parseable as dates
+  const fromDate = new Date(from)
+  const toDate = new Date(to)
+  if (isNaN(fromDate.getTime()) || isNaN(toDate.getTime())) {
+    return new Response(
+      JSON.stringify({ success: false, error: 'from and to must be valid ISO datetime strings' }),
+      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+
+  const { supabaseUrl, serviceKey } = env
+  const dbHeaders = {
+    apikey: serviceKey,
+    Authorization: `Bearer ${serviceKey}`,
+    'Content-Type': 'application/json',
+  }
+
+  const start = fromDate.toISOString()
+  const end = toDate.toISOString()
+
+  try {
+    // 1. Fetch all paid orders in range (include vat_cents)
+    const ordersRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=id,final_total_cents,covers,discount_amount_cents,order_comp,vat_cents,service_charge_cents&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&limit=10000`,
+      { headers: dbHeaders },
+    )
+    if (!ordersRes.ok) {
+      const errText = await ordersRes.text()
+      return new Response(
+        JSON.stringify({ success: false, error: `Failed to fetch orders: ${errText}` }),
+        { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      )
+    }
+    const orders = (await ordersRes.json()) as OrderRow[]
+    const orderIds = orders.map(o => o.id)
+
+    // 2. Compute orders summary
+    let netSalesCents = 0
+    let totalCovers = 0
+    let totalDiscountsCents = 0
+    let totalVatCents = 0
+    const nonCompOrders = orders.filter(o => !o.order_comp)
+
+    for (const o of orders) {
+      netSalesCents += o.final_total_cents ?? 0
+      totalCovers += o.covers ?? 0
+    }
+    for (const o of nonCompOrders) {
+      totalDiscountsCents += o.discount_amount_cents ?? 0
+      totalVatCents += o.vat_cents ?? 0
+    }
+
+    const totalOrders = orders.length
+    const avgOrderValueCents = totalOrders > 0 ? Math.round(netSalesCents / totalOrders) : 0
+
+    // 3. Complimentary value — sum of comp item values across all orders in range
+    //    a) Whole-order comps: sum non-voided item values
+    let complimentaryCents = 0
+
+    const compOrdersRes = await fetchFn(
+      `${supabaseUrl}/rest/v1/orders?select=id,order_items(quantity,unit_price_cents,voided)&order_comp=eq.true&status=eq.paid&created_at=gte.${encodeURIComponent(start)}&created_at=lte.${encodeURIComponent(end)}&limit=1000`,
+      { headers: dbHeaders },
+    )
+    if (compOrdersRes.ok) {
+      const compOrders = (await compOrdersRes.json()) as CompOrderRow[]
+      for (const co of compOrders) {
+        for (const oi of co.order_items) {
+          if (!oi.voided) {
+            complimentaryCents += oi.quantity * oi.unit_price_cents
+          }
+        }
+      }
+    }
+
+    //    b) Item-level comps within non-comp orders
+    if (orderIds.length > 0) {
+      const nonCompOrderIds = nonCompOrders.map(o => o.id)
+      if (nonCompOrderIds.length > 0) {
+        const compItemsRes = await fetchFn(
+          `${supabaseUrl}/rest/v1/order_items?select=quantity,unit_price_cents&comp=eq.true&order_id=in.(${nonCompOrderIds.join(',')})&limit=10000`,
+          { headers: dbHeaders },
+        )
+        if (compItemsRes.ok) {
+          const compItems = (await compItemsRes.json()) as CompItemRow[]
+          for (const ci of compItems) {
+            complimentaryCents += ci.quantity * ci.unit_price_cents
+          }
+        }
+      }
+    }
+
+    // Gross sales = net sales + discounts + complimentary
+    const grossSalesCents = netSalesCents + totalDiscountsCents + complimentaryCents
+
+    // 4. VAT summary
+    // net_sales includes VAT (final_total_cents is post-VAT for tax-exclusive, or includes VAT for inclusive)
+    // Use stored vat_cents as the authoritative VAT figure
+    const subtotalExclVatCents = netSalesCents - totalVatCents
+    const totalInclVatCents = netSalesCents
+
+    // 5. Payment breakdown
+    let cashCents = 0
+    let cardCents = 0
+    let mobileCents = 0
+    let otherCents = 0
+
+    if (orderIds.length > 0) {
+      const paymentsRes = await fetchFn(
+        `${supabaseUrl}/rest/v1/payments?select=order_id,method,amount_cents&order_id=in.(${orderIds.join(',')})&limit=50000`,
+        { headers: dbHeaders },
+      )
+      if (paymentsRes.ok) {
+        const payments = (await paymentsRes.json()) as PaymentRow[]
+        for (const p of payments) {
+          switch (p.method) {
+            case 'cash':   cashCents   += p.amount_cents ?? 0; break
+            case 'card':   cardCents   += p.amount_cents ?? 0; break
+            case 'mobile': mobileCents += p.amount_cents ?? 0; break
+            default:       otherCents  += p.amount_cents ?? 0; break
+          }
+        }
+      }
+    }
+
+    const totalCollectedCents = cashCents + cardCents + mobileCents + otherCents
+
+    const data: ShiftReportData = {
+      from: start,
+      to: end,
+      total_orders: totalOrders,
+      total_covers: totalCovers,
+      avg_order_value_cents: avgOrderValueCents,
+      gross_sales_cents: grossSalesCents,
+      discounts_cents: totalDiscountsCents,
+      complimentary_cents: complimentaryCents,
+      net_sales_cents: netSalesCents,
+      subtotal_excl_vat_cents: subtotalExclVatCents,
+      vat_amount_cents: totalVatCents,
+      total_incl_vat_cents: totalInclVatCents,
+      cash_cents: cashCents,
+      card_cents: cardCents,
+      mobile_cents: mobileCents,
+      other_cents: otherCents,
+      total_collected_cents: totalCollectedCents,
+    }
+
+    return new Response(
+      JSON.stringify({ success: true, data }),
+      { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ success: false, error: err instanceof Error ? err.message : 'Internal server error' }),
+      { status: 500, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    )
+  }
+}
+
+if (typeof (globalThis as { Deno?: unknown }).Deno !== 'undefined') {
+  const g = globalThis as { Deno: { serve: (h: (req: Request) => Promise<Response>) => void } }
+  g.Deno.serve((req: Request) => handler(req))
+}


### PR DESCRIPTION
## Summary

Implements issue #449 — a printable end-of-shift summary accessible from Admin → Reports.

## What's included

### New Edge Function: `get_shift_report`
- Accepts explicit ISO datetime range (`from`/`to`) for local-midnight precision (vs. UTC-date rounding in `get_reports`)
- Fetches paid orders with `vat_cents` included
- Computes:
  - Orders summary (total orders, covers, avg value)
  - Sales breakdown (gross → discounts → complimentary → net)
  - VAT summary (subtotal excl. VAT, VAT amount, total incl. VAT)
  - Payment breakdown by method (cash / card / mobile / other)
  - Complimentary value from both whole-order comps and item-level comps
- Auth: owner role required (same as `get_reports`)
- Added to `supabase/config.toml` with `verify_jwt = false`

### New Component: `ShiftReportPrintView`
80mm thermal print layout:
1. Header: restaurant name, "Shift Close Report", date range, printed by/at
2. Orders summary: total orders, covers, avg order value
3. Sales breakdown: gross → discounts → complimentary → net sales
4. VAT summary: subtotal excl. VAT, VAT amount, total incl. VAT
5. Payment methods: cash / card / mobile / other / complimentary / total collected
6. Footer: dashed separator + "End of Shift Report" centred

Uses same `hidden print:block` + `.print-area` pattern as `BillPrintView` — no new print infrastructure dependency.

### Updates to `ReportsDashboard`
- New "Print Shift Report" card at the top of the Reports page
- `datetime-local` pickers defaulting to today 00:00 → now (local time)
- "Reset to Today" button to restore defaults
- Print button: fetches data → sets `isPrintingShift` → calls `window.print()` → cleans up on `afterprint`
- Removed pre-existing unused `Building2` import

### New API helper: `shiftReportApi.ts`
- `callGetShiftReport()` with full TypeScript types
- Converts `datetime-local` inputs (local time) to UTC ISO strings before sending

### Tests
- 5 unit tests in `shiftReportApi.test.ts` — all passing

## Checklist
- [x] No `SUPABASE_SERVICE_ROLE_KEY` in new frontend code
- [x] No `SUPABASE_ANON_KEY` anywhere in changes
- [x] No `getSupabaseAdmin` in new code
- [x] Auth validated before data access in edge function
- [x] `verify_jwt = false` added to `config.toml`
- [x] Lint + typecheck pass (no new errors)
- [x] Unit tests written and passing
- [x] 80mm thermal print width via existing CSS infrastructure
- [x] Works via browser print dialog
- [x] Default range: today midnight → now (local time)

Closes #449